### PR TITLE
Move extracted files into the same folder as archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # `xtractr`
 
 Go Library for Queuing and Extracting ZIP and RAR files.
+Still under development, but working well.
 
 -   [GoDoc](https://pkg.go.dev/golift.io/xtractr)

--- a/files.go
+++ b/files.go
@@ -20,8 +20,6 @@ type XFile struct {
 	DirMode   os.FileMode // Write folders with this mode.
 }
 
-var ErrUnknownArchiveType = fmt.Errorf("unknown archive file type")
-
 // GetFileList returns all the files in a path.
 // This is non-resursive and only returns files _in_ the base path provided.
 // This is a helper method and only exposed for convenience. You do not have to call this.
@@ -31,7 +29,7 @@ func (x *Xtractr) GetFileList(path string) (files []string) {
 			files = append(files, filepath.Join(path, file.Name()))
 		}
 	} else {
-		x.log("Error: Reading path '%s': %v", path, err)
+		x.Printf("Error: Reading path '%s': %v", path, err)
 	}
 
 	return
@@ -147,7 +145,7 @@ func (x *Xtractr) MoveFiles(fromPath string, toPath string, overwrite bool) ([]s
 		exists := !os.IsNotExist(err)
 
 		if exists && !overwrite {
-			x.log("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
+			x.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
 
 			continue
 		}
@@ -155,13 +153,13 @@ func (x *Xtractr) MoveFiles(fromPath string, toPath string, overwrite bool) ([]s
 		switch err := os.Rename(file, newFile); {
 		case err != nil:
 			keepErr = err
-			x.log("Error: Renaming Temp File: %v to %v: %v", file, newFile, err)
+			x.Printf("Error: Renaming Temp File: %v to %v: %v", file, newFile, err)
 			// keep trying.
 			continue
 		case exists:
-			x.debug("Renamed Temp File: %v -> %v (overwrote existing file)", file, newFile)
+			x.Debugf("Renamed Temp File: %v -> %v (overwrote existing file)", file, newFile)
 		default:
-			x.debug("Renamed Temp File: %v -> %v", file, newFile)
+			x.Debugf("Renamed Temp File: %v -> %v", file, newFile)
 		}
 
 		files[i] = newFile
@@ -179,12 +177,12 @@ func (x *Xtractr) MoveFiles(fromPath string, toPath string, overwrite bool) ([]s
 func (x *Xtractr) DeleteFiles(files ...string) {
 	for _, file := range files {
 		if err := os.RemoveAll(file); err != nil {
-			x.log("Error: Deleting %v: %v", file, err)
+			x.Printf("Error: Deleting %v: %v", file, err)
 
 			continue
 		}
 
-		x.log("Deleted (recursively): %s", file)
+		x.Printf("Deleted (recursively): %s", file)
 	}
 }
 

--- a/queue.go
+++ b/queue.go
@@ -167,7 +167,7 @@ func (x *Xtractr) decompressFiles(re *Response) error {
 }
 
 func (x *Xtractr) cleanupProcessedArchive(re *Response, archivePath string) error {
-	tmpFile := filepath.Join(re.Output, x.Suffix+filepath.Base(archivePath)+".txt")
+	tmpFile := filepath.Join(re.Output, x.Suffix+"."+filepath.Base(archivePath)+".txt")
 	re.NewFiles = append(x.GetFileList(re.Output), tmpFile)
 
 	msg := []byte(fmt.Sprintf("# %s - this file is removed with the extracted data\n---\n"+

--- a/queue.go
+++ b/queue.go
@@ -166,13 +166,13 @@ func (x *Xtractr) decompressFiles(re *Response) error {
 	return nil
 }
 
-func (x *Xtractr) cleanupProcessedArchive(re *Response, archive string) error {
-	tmpFile := filepath.Join(re.Output, x.Suffix+archive+".txt")
+func (x *Xtractr) cleanupProcessedArchive(re *Response, archivePath string) error {
+	tmpFile := filepath.Join(re.Output, x.Suffix+filepath.Base(archivePath)+".txt")
 	re.NewFiles = append(x.GetFileList(re.Output), tmpFile)
 
 	msg := []byte(fmt.Sprintf("# %s - this file is removed with the extracted data\n---\n"+
 		"archive:%s\nextras:%v\nfrom_path:%s\ntemp_path:%s\nrelocated:%v\ntime:%v\nfiles:\n  - %v\n",
-		x.Suffix, archive, re.Extras, re.X.SearchPath, re.Output, !re.X.TempFolder, time.Now(),
+		x.Suffix, archivePath, re.Extras, re.X.SearchPath, re.Output, !re.X.TempFolder, time.Now(),
 		strings.Join(re.NewFiles, "\n  - ")))
 
 	if err := ioutil.WriteFile(tmpFile, msg, x.FileMode); err != nil {
@@ -180,12 +180,12 @@ func (x *Xtractr) cleanupProcessedArchive(re *Response, archive string) error {
 	}
 
 	if re.X.DeleteOrig {
-		x.DeleteFiles(archive) // as requested
+		x.DeleteFiles(archivePath) // as requested
 	}
 
 	var err error
 	// Only move back the files if the archive wasn't extracted from the temp path.
-	if archiveDir := filepath.Dir(archive); !re.X.TempFolder && re.Output != archiveDir {
+	if archiveDir := filepath.Dir(archivePath); !re.X.TempFolder && re.Output != archiveDir {
 		// Move the extracted files back into the same folder as the archive.
 		re.NewFiles, err = x.MoveFiles(re.Output, archiveDir, false)
 	}

--- a/rar.go
+++ b/rar.go
@@ -13,11 +13,6 @@ import (
 	"github.com/nwaples/rardecode"
 )
 
-var (
-	ErrInvalidPath = fmt.Errorf("archived file contains invalid path")
-	ErrInvalidHead = fmt.Errorf("archived file contains invalid header file")
-)
-
 // ExtractRAR extracts a rar file.. to a destination. Simple enough.
 func ExtractRAR(x *XFile) (int64, []string, error) {
 	rarReader, err := rardecode.OpenReader(x.FilePath, "")


### PR DESCRIPTION
Hopefully fixes https://github.com/davidnewhall/unpackerr/issues/64

EDIT: Seems confirmed, the originally reported bug is fixed and the app now extracts items into the correct folder.