### PR TITLE
Reorder logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+# Simple go lint and test.
+os: linux
+dist: bionic
+language: go
+go:
+  - 1.16.x
+install:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+all:
+	@echo "try: make test"
+
+test: lint
+	go test -race -covermode=atomic ./...
+	# Test 32 bit OSes.
+	GOOS=linux GOARCH=386 go build .
+	GOOS=freebsd GOARCH=386 go build .
+
+lint:
+	GOOS=linux golangci-lint run --enable-all -D nlreturn,exhaustivestruct
+	GOOS=darwin golangci-lint run --enable-all -D nlreturn,exhaustivestruct
+	GOOS=windows golangci-lint run --enable-all -D nlreturn,exhaustivestruct
+	GOOS=freebsd golangci-lint run --enable-all -D nlreturn,exhaustivestruct

--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ func main() {
 		FileMode: 0644, // ignored for tar files.
 		DirMode:  0755,
 	})
-	defer q.Stop()
+	defer q.Stop() // Stop() waits until all extractions finish.
 
 	response := make(chan *xtractr.Response)
-
 	// This sends an item into the extraction queue (buffered channel).
 	q.Extract(&xtractr.Xtract{
 		Name:       "my archive",    // name is not import to this library.

--- a/files.go
+++ b/files.go
@@ -5,7 +5,6 @@ package xtractr
 import (
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -96,7 +95,7 @@ func FindCompressedFiles(path string) []string {
 
 // getCompressedFiles checks file suffixes to fine the archives to decompress.
 // This pays special attention to the widely accepted variance of rar formats.
-func getCompressedFiles(hasrar bool, path string, fileList []fs.FileInfo) []string { //nolint:cyclop
+func getCompressedFiles(hasrar bool, path string, fileList []os.FileInfo) []string { //nolint:cyclop
 	files := []string{}
 
 	for _, file := range fileList {

--- a/files.go
+++ b/files.go
@@ -96,7 +96,7 @@ func FindCompressedFiles(path string) []string {
 
 // getCompressedFiles checks file suffixes to fine the archives to decompress.
 // This pays special attention to the widely accepted variance of rar formats.
-func getCompressedFiles(hasrar bool, path string, fileList []fs.FileInfo) []string {
+func getCompressedFiles(hasrar bool, path string, fileList []fs.FileInfo) []string { //nolint:cyclop
 	files := []string{}
 
 	for _, file := range fileList {
@@ -137,7 +137,7 @@ func (x *XFile) Extract() (int64, []string, []string, error) {
 
 // ExtractFile calls the correct procedure for the type of file being extracted.
 // Returns size of extracted data, list of extracted files, list of archives processed, and/or error.
-func ExtractFile(x *XFile) (int64, []string, []string, error) {
+func ExtractFile(x *XFile) (int64, []string, []string, error) { //nolint:cyclop
 	var (
 		size  int64
 		files []string
@@ -275,6 +275,7 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 
 	_, err = io.Copy(newFile, oldFile)
 	oldFile.Close()
+
 	if err != nil {
 		return fmt.Errorf("io.Copy(): %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module golift.io/xtractr
 
-go 1.15
+go 1.16
 
 require github.com/nwaples/rardecode v1.1.0

--- a/queue.go
+++ b/queue.go
@@ -195,6 +195,7 @@ func (x *Xtractr) processArchive(filename, tmpPath, password string) (int64, []s
 	}
 
 	x.config.Debugf("Extracting File: %v to %v", filename, tmpPath)
+
 	bytes, files, archives, err := ExtractFile(&XFile{ // extract the file.
 		FilePath:  filename,
 		OutputDir: tmpPath,
@@ -202,7 +203,6 @@ func (x *Xtractr) processArchive(filename, tmpPath, password string) (int64, []s
 		DirMode:   x.config.DirMode,
 		Password:  password,
 	})
-
 	if err != nil {
 		x.DeleteFiles(tmpPath) // clean up the mess after an error and bail.
 	}
@@ -226,6 +226,7 @@ func (x *Xtractr) cleanupProcessedArchives(re *Response) error {
 
 	if re.X.DeleteOrig {
 		x.DeleteFiles(re.Archives...) // as requested
+
 		if len(re.Extras) != 0 {
 			x.DeleteFiles(re.Extras...) // these got extracted too
 		}

--- a/queue.go
+++ b/queue.go
@@ -64,6 +64,8 @@ func (x *Xtractr) processQueue() {
 	for ex := range x.queue { // extractions come from Extract()
 		x.extract(ex)
 	}
+
+	x.done <- struct{}{}
 }
 
 // extract is where the real work begins and files get extracted.

--- a/rar.go
+++ b/rar.go
@@ -14,13 +14,20 @@ import (
 )
 
 // ExtractRAR extracts a rar file.. to a destination. Simple enough.
-func ExtractRAR(x *XFile) (int64, []string, error) {
+func ExtractRAR(x *XFile) (int64, []string, []string, error) {
 	rarReader, err := rardecode.OpenReader(x.FilePath, x.Password)
 	if err != nil {
-		return 0, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
+		return 0, nil, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 	defer rarReader.Close()
 
+	s, f, err := x.unrar(rarReader)
+	v := rarReader.Volumes()
+
+	return s, f, v, err
+}
+
+func (x *XFile) unrar(rarReader *rardecode.ReadCloser) (int64, []string, error) {
 	files := []string{}
 	size := int64(0)
 
@@ -36,7 +43,7 @@ func ExtractRAR(x *XFile) (int64, []string, error) {
 			return size, files, fmt.Errorf("%w: %s", ErrInvalidHead, x.FilePath)
 		}
 
-		wfile := filepath.Clean(filepath.Join(x.OutputDir, header.Name))
+		wfile := x.clean(header.Name)
 		if !strings.HasPrefix(wfile, x.OutputDir) {
 			// The file being written is trying to write outside of our base path. Malicious archive?
 			return size, files, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, wfile, header.Name)

--- a/rar.go
+++ b/rar.go
@@ -21,10 +21,9 @@ func ExtractRAR(x *XFile) (int64, []string, []string, error) {
 	}
 	defer rarReader.Close()
 
-	s, f, err := x.unrar(rarReader)
-	v := rarReader.Volumes()
+	size, files, err := x.unrar(rarReader)
 
-	return s, f, v, err
+	return size, files, rarReader.Volumes(), err
 }
 
 func (x *XFile) unrar(rarReader *rardecode.ReadCloser) (int64, []string, error) {

--- a/start.go
+++ b/start.go
@@ -59,9 +59,7 @@ var (
 // You must provide a Logger in the config, everything else is optional.
 func NewQueue(config *Config) *Xtractr {
 	x := parseConfig(config)
-
-	err := x.Start()
-	if err != nil {
+	if err := x.Start(); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
This re-arranges the extraction order for nested archives. Previously archives were extracted one at a time and after each extraction the output data was checked for more archives. Now all original archives are extracted and _then_ the extracted data is checked for more archives. This fixes https://github.com/davidnewhall/unpackerr/issues/85.

Also closes #4 by capturing all rar volumes that got extracted.

And unrelated to the above: I re-arranged the zip, tar and rar methods to make them more uniform.

Lastly, `Stop()` now waits until all extractions finish. Added `Start()` so a queue can be restarted.