### PR TITLE
Fix match for files with partNN in name.

### DIFF
--- a/cmd/xt/main.go
+++ b/cmd/xt/main.go
@@ -33,8 +33,12 @@ func processInput(paths []string, output string) {
 	log.Printf("==> Output Path: %s", output)
 
 	archives := getArchives(paths)
+	if len(archives) == 0 {
+		log.Println("==> No archives found in:", paths)
+	}
+
 	for i, f := range archives {
-		log.Printf("==> Extracting Archive (%d/%d): %s", i, len(archives), f)
+		log.Printf("==> Extracting Archive (%d/%d): %s", i+1, len(archives), f)
 
 		start := time.Now()
 

--- a/files.go
+++ b/files.go
@@ -112,9 +112,7 @@ func getCompressedFiles(hasrar bool, path string, fileList []os.FileInfo) []stri
 		case strings.HasSuffix(lowerName, ".rar"):
 			hasParts := regexp.MustCompile(`.*\.part[0-9]+\.rar$`)
 			partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
-			// This if statements says:
-			// If the current file does not have "part0-9" in the name, add it to our list (all .rar files).
-			// If it does have "part0-9" in the name, then make sure it's part 1.
+			// Some archives are named poorly. Only return part01 or part001, not all.
 			if !hasParts.Match([]byte(lowerName)) || partOne.Match([]byte(lowerName)) {
 				files = append(files, filepath.Join(path, file.Name()))
 			}

--- a/files.go
+++ b/files.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -109,14 +110,12 @@ func getCompressedFiles(hasrar bool, path string, fileList []os.FileInfo) []stri
 			strings.HasSuffix(lowerName, ".bz2") || strings.HasSuffix(lowerName, ".7z"):
 			files = append(files, filepath.Join(path, file.Name()))
 		case strings.HasSuffix(lowerName, ".rar"):
-			// Some archives are named poorly. Only return part01 or part001, not all.
-			m, _ := filepath.Match("*.part[0-9]*.rar", lowerName)
+			hasParts := regexp.MustCompile(`.*\.part[0-9]+\.rar$`)
+			partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
 			// This if statements says:
 			// If the current file does not have "part0-9" in the name, add it to our list (all .rar files).
 			// If it does have "part0-9" in the name, then make sure it's part 1.
-			if !m || strings.HasSuffix(lowerName, ".part01.rar") ||
-				strings.HasSuffix(lowerName, ".part001.rar") ||
-				strings.HasSuffix(lowerName, ".part1.rar") {
+			if !hasParts.Match([]byte(lowerName)) || partOne.Match([]byte(lowerName)) {
 				files = append(files, filepath.Join(path, file.Name()))
 			}
 		case !hasrar && strings.HasSuffix(lowerName, ".r00"):


### PR DESCRIPTION
Archives with `part01` or `part4` etc in the name were being ignored. This makes sure the `partNN` shows up directly before `.rar` to be considered an ignorable file.