### PR TITLE
Fix bug when RAR extension is capitalized

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -26,8 +26,9 @@ func createTestPaths(t *testing.T) string {
 		"/path0/path1/path2/file.gz",         // 8
 		"/path0/path1/path2/file.zip",        // 9
 		"/path0/path1/path2/file.txt",        // not archive
-		"/path0/path1/path2/path3/file.rar",  // 10
-		"/path0/path1/path2/path3/file2.rar", // 11
+		"/path0/path1/path2/path3/file.r00",  // 10 because no file.rar.
+		"/path0/path1/path2/path3/file2.r00", // skip because RAR v
+		"/path0/path1/path2/path3/file2.RAR", // 11
 		"/path0/path1/path2/path3/file3.iso", // 12
 		"/path0/path1/path2/path3/file.nfo",  // not archive
 	}


### PR DESCRIPTION
This fixes two bugs when scanning for archives to extract.
1. If a multi part rar archive has a capital `.RAR` extension, the app will attempt to extract the `.r00` file.
2. If two rar archives exist in the same folder, where one has a `.rar` and one starts at `.r00`, the .r00 will be skipped.

The test case was updated slightly to catch both of these if there is a code regression.

