### PR TITLE
Fix OS-specific path separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+.idea
 *.DS*
 *.zip
 *.rar

--- a/7z.go
+++ b/7z.go
@@ -68,10 +68,10 @@ func extract7z(xFile *XFile) (int64, []string, []string, error) {
 		if err != nil {
 			lastFile := xFile.FilePath
 			/* // https://github.com/bodgit/sevenzip/issues/54
-			// We can probably never get the file with the error.
-			if volumes := sevenZip.Volumes(); len(volumes) > 0 {
-				lastFile = volumes[len(volumes)-1]
-			} */
+			   // We can probably never get the file with the error.
+			   if volumes := sevenZip.Volumes(); len(volumes) > 0 {
+			   	lastFile = volumes[len(volumes)-1]
+			   } */
 			return size, files, sevenZip.Volumes(), fmt.Errorf("%s: %w", lastFile, err)
 		}
 
@@ -84,7 +84,7 @@ func extract7z(xFile *XFile) (int64, []string, []string, error) {
 
 func (x *XFile) un7zip(zipFile *sevenzip.File) (int64, error) { //nolint:dupl
 	wfile := x.clean(zipFile.Name)
-	if !strings.HasPrefix(wfile, x.OutputDir) {
+	if !strings.HasPrefix(wfile, filepath.Clean(x.OutputDir)) {
 		// The file being written is trying to write outside of our base path. Malicious archive?
 		return 0, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, wfile, zipFile.Name)
 	}

--- a/iso.go
+++ b/iso.go
@@ -69,8 +69,8 @@ func (x *XFile) uniso(isoFile *iso9660.File, parent string) (int64, []string, er
 
 func (x *XFile) unisofile(isoFile *iso9660.File, fileName string) (int64, []string, error) {
 	destFile := x.clean(fileName)
-	//nolint:gocritic // this 1-argument filepath.Join removes a ./ prefix should there be one.
-	if !strings.HasPrefix(destFile, filepath.Join(x.OutputDir)) {
+	//nolint:gocritic // this 1-argument filepath.Clean removes a ./ prefix should there be one.
+	if !strings.HasPrefix(destFile, filepath.Clean(x.OutputDir)) {
 		// The file being written is trying to write outside of our base path. Malicious ISO?
 		return 0, nil, fmt.Errorf("%s: %w: %s != %s (from: %s)",
 			x.FilePath, ErrInvalidPath, destFile, x.OutputDir, isoFile.Name())

--- a/rar.go
+++ b/rar.go
@@ -92,8 +92,8 @@ func (x *XFile) unrar(rarReader *rardecode.ReadCloser) (int64, []string, error) 
 		}
 
 		wfile := x.clean(header.Name)
-		//nolint:gocritic // this 1-argument filepath.Join removes a ./ prefix should there be one.
-		if !strings.HasPrefix(wfile, filepath.Join(x.OutputDir)) {
+		//nolint:gocritic // this 1-argument filepath.Clean removes a ./ prefix should there be one.
+		if !strings.HasPrefix(wfile, filepath.Clean(x.OutputDir)) {
 			// The file being written is trying to write outside of our base path. Malicious archive?
 			return size, files, fmt.Errorf("%s: %w: %s != %s (from: %s)",
 				x.FilePath, ErrInvalidPath, wfile, x.OutputDir, header.Name)

--- a/tar.go
+++ b/tar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	lzw "github.com/sshaman1101/dcompress"
@@ -102,7 +103,7 @@ func (x *XFile) untar(tarReader *tar.Reader) (int64, []string, error) {
 		}
 
 		wfile := x.clean(header.Name)
-		if !strings.HasPrefix(wfile, x.OutputDir) {
+		if !strings.HasPrefix(wfile, filepath.Clean(x.OutputDir)) {
 			// The file being written is trying to write outside of our base path. Malicious archive?
 			return size, files, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, wfile, header.Name)
 		}

--- a/zip.go
+++ b/zip.go
@@ -27,7 +27,7 @@ func ExtractZIP(xFile *XFile) (int64, []string, error) {
 			return size, files, fmt.Errorf("%s: %w", xFile.FilePath, err)
 		}
 
-		files = append(files, filepath.Join(xFile.OutputDir, zipFile.Name)) //nolint: gosec
+		files = append(files, filepath.Join(xFile.OutputDir, zipFile.Name)) //nolint:gosec
 		size += fSize
 	}
 
@@ -36,7 +36,7 @@ func ExtractZIP(xFile *XFile) (int64, []string, error) {
 
 func (x *XFile) unzip(zipFile *zip.File) (int64, error) { //nolint:dupl
 	wfile := x.clean(zipFile.Name)
-	if !strings.HasPrefix(wfile, x.OutputDir) {
+	if !strings.HasPrefix(wfile, filepath.Clean(x.OutputDir)) {
 		// The file being written is trying to write outside of our base path. Malicious archive?
 		return 0, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, wfile, zipFile.Name)
 	}


### PR DESCRIPTION
Fix OS-specific path separator when i run on Windows

```go
wfile = "downloads\TEST\Autofills"
x.OutputDir = "downloads/TEST"
```