### PR TITLE
Preserve mod time and access time from archived files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
       - (*os.File).Close
       - os.RemoveAll
       - os.Remove
+      - os.Chtimes
       - (io.Closer).Close
       - (*compress/gzip.Reader).Close
       - (*archive/zip.ReadCloser).Close

--- a/7z.go
+++ b/7z.go
@@ -93,7 +93,7 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (int64, string, error) {
 	file := &file{
 		Path:     x.clean(zipFile.Name),
 		Data:     zFile,
-		FileMode: zipFile.Mode(),
+		FileMode: x.safeFileMode(zipFile.Mode()),
 		DirMode:  x.DirMode,
 		Mtime:    zipFile.Modified,
 		Atime:    zipFile.Accessed,

--- a/7z.go
+++ b/7z.go
@@ -84,35 +84,44 @@ func extract7z(xFile *XFile) (int64, []string, []string, error) {
 }
 
 func (x *XFile) un7zip(zipFile *sevenzip.File) (int64, string, error) {
-	wfile := x.clean(zipFile.Name)
-	if !strings.HasPrefix(wfile, x.OutputDir) {
-		// The file being written is trying to write outside of our base path. Malicious archive?
-		return 0, wfile, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, wfile, zipFile.Name)
-	}
-
-	if zipFile.FileInfo().IsDir() {
-		x.Debugf("Writing archived directory: %s", wfile)
-
-		if err := os.MkdirAll(wfile, x.DirMode); err != nil {
-			return 0, wfile, fmt.Errorf("making zipFile dir: %w", err)
-		}
-
-		return 0, wfile, nil
-	}
-
-	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)",
-		wfile, zipFile.FileInfo().Size(), zipFile.UncompressedSize)
-
 	zFile, err := zipFile.Open()
 	if err != nil {
-		return 0, wfile, fmt.Errorf("zipFile.Open: %w", err)
+		return 0, zipFile.Name, fmt.Errorf("zipFile.Open: %w", err)
 	}
 	defer zFile.Close()
 
-	s, err := writeFile(wfile, zFile, x.FileMode, x.DirMode)
-	if err != nil {
-		return s, wfile, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, wfile, zipFile.Name)
+	file := &file{
+		Path:     x.clean(zipFile.Name),
+		Data:     zFile,
+		FileMode: zipFile.Mode(),
+		DirMode:  x.DirMode,
+		Mtime:    zipFile.Modified,
+		Atime:    zipFile.Accessed,
 	}
 
-	return s, wfile, nil
+	if !strings.HasPrefix(file.Path, x.OutputDir) {
+		// The file being written is trying to write outside of our base path. Malicious archive?
+		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
+		return 0, file.Path, err
+	}
+
+	if zipFile.FileInfo().IsDir() {
+		x.Debugf("Writing archived directory: %s", file.Path)
+
+		if err := os.MkdirAll(file.Path, zipFile.Mode()); err != nil {
+			return 0, file.Path, fmt.Errorf("making zipFile dir: %w", err)
+		}
+
+		return 0, file.Path, nil
+	}
+
+	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)",
+		file.Path, zipFile.FileInfo().Size(), zipFile.UncompressedSize)
+
+	s, err := file.Write()
+	if err != nil {
+		return s, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, zipFile.Name)
+	}
+
+	return s, file.Path, nil
 }

--- a/ar.go
+++ b/ar.go
@@ -41,7 +41,7 @@ func (x *XFile) unAr(reader io.Reader) (int64, []string, error) {
 		file := &file{
 			Path:     x.clean(header.Name),
 			Data:     arReader,
-			FileMode: os.FileMode(header.Mode), //nolint:gosec // what else ya gonna do with this?
+			FileMode: x.safeFileMode(os.FileMode(header.Mode)), //nolint:gosec // what else ya gonna do with this?
 			DirMode:  x.DirMode,
 			Mtime:    header.ModTime,
 		}

--- a/ar.go
+++ b/ar.go
@@ -41,7 +41,7 @@ func (x *XFile) unAr(reader io.Reader) (int64, []string, error) {
 		file := &file{
 			Path:     x.clean(header.Name),
 			Data:     arReader,
-			FileMode: x.safeFileMode(os.FileMode(header.Mode)), //nolint:gosec // what else ya gonna do with this?
+			FileMode: os.FileMode(header.Mode), //nolint:gosec // what else ya gonna do with this?
 			DirMode:  x.DirMode,
 			Mtime:    header.ModTime,
 		}
@@ -53,7 +53,7 @@ func (x *XFile) unAr(reader io.Reader) (int64, []string, error) {
 
 		// ar format does not store directory paths. Flat list of files.
 
-		fSize, err := file.Write()
+		fSize, err := x.write(file)
 		if err != nil {
 			return size, files, err
 		}

--- a/cpio.go
+++ b/cpio.go
@@ -67,7 +67,7 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (int6
 	file := &file{
 		Path:     x.clean(cpioFile.Name),
 		Data:     cpioReader,
-		FileMode: cpioFile.FileInfo().Mode(),
+		FileMode: x.safeFileMode(cpioFile.FileInfo().Mode()),
 		DirMode:  x.DirMode,
 		Mtime:    cpioFile.ModTime,
 	}
@@ -78,7 +78,7 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (int6
 	}
 
 	if cpioFile.Mode.IsDir() || cpioFile.FileInfo().IsDir() {
-		if err := os.MkdirAll(file.Path, cpioFile.FileInfo().Mode()); err != nil {
+		if err := os.MkdirAll(file.Path, x.safeDirMode(cpioFile.FileInfo().Mode())); err != nil {
 			return 0, fmt.Errorf("making cpio dir: %w", err)
 		}
 

--- a/cpio.go
+++ b/cpio.go
@@ -64,14 +64,21 @@ func (x *XFile) uncpio(reader io.Reader) (int64, []string, error) {
 }
 
 func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (int64, error) {
-	wfile := x.clean(cpioFile.Name)
-	if !strings.HasPrefix(wfile, x.OutputDir) {
+	file := &file{
+		Path:     x.clean(cpioFile.Name),
+		Data:     cpioReader,
+		FileMode: cpioFile.FileInfo().Mode(),
+		DirMode:  x.DirMode,
+		Mtime:    cpioFile.ModTime,
+	}
+
+	if !strings.HasPrefix(file.Path, x.OutputDir) {
 		// The file being written is trying to write outside of the base path. Malicious archive?
-		return 0, fmt.Errorf("%s: %w: %s (from: %s)", cpioFile.FileInfo().Name(), ErrInvalidPath, wfile, cpioFile.Name)
+		return 0, fmt.Errorf("%s: %w: %s (from: %s)", cpioFile.FileInfo().Name(), ErrInvalidPath, file.Path, cpioFile.Name)
 	}
 
 	if cpioFile.Mode.IsDir() || cpioFile.FileInfo().IsDir() {
-		if err := os.MkdirAll(wfile, x.DirMode); err != nil {
+		if err := os.MkdirAll(file.Path, cpioFile.FileInfo().Mode()); err != nil {
 			return 0, fmt.Errorf("making cpio dir: %w", err)
 		}
 
@@ -80,9 +87,9 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (int6
 
 	// This turns hard links into symlinks.
 	if cpioFile.Linkname != "" {
-		err := os.Symlink(cpioFile.Linkname, wfile)
+		err := os.Symlink(cpioFile.Linkname, file.Path)
 		if err != nil {
-			return 0, fmt.Errorf("%s symlink: %w: %s (from: %s)", cpioFile.FileInfo().Name(), err, wfile, cpioFile.Name)
+			return 0, fmt.Errorf("%s symlink: %w: %s (from: %s)", cpioFile.FileInfo().Name(), err, file.Path, cpioFile.Name)
 		}
 
 		return 0, nil
@@ -90,9 +97,9 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (int6
 
 	// This should turn non-regular files into empty files.
 	// ie. sockets, block, character and fifo devices.
-	s, err := writeFile(wfile, cpioReader, x.FileMode, x.DirMode)
+	s, err := file.Write()
 	if err != nil {
-		return s, fmt.Errorf("%s: %w: %s (from: %s)", cpioFile.FileInfo().Name(), err, wfile, cpioFile.Name)
+		return s, fmt.Errorf("%s: %w: %s (from: %s)", cpioFile.FileInfo().Name(), err, file.Path, cpioFile.Name)
 	}
 
 	return s, nil

--- a/decompress.go
+++ b/decompress.go
@@ -31,14 +31,19 @@ func ExtractXZ(xFile *XFile) (size int64, filesList []string, err error) {
 	}
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".xz")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".xz"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractZlib extracts a zlib-compressed file. A single file.
@@ -56,14 +61,19 @@ func ExtractZlib(xFile *XFile) (size int64, filesList []string, err error) {
 	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".zz", ".zlib")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".zz", ".zlib"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractLZMA extracts an lzma-compressed file. A single file.
@@ -80,14 +90,19 @@ func ExtractLZMA(xFile *XFile) (size int64, filesList []string, err error) {
 	}
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".lzma", ".lz", ".lzip")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".lzma", ".lz", ".lzip"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractLZMA2 extracts an lzma2-compressed file. A single file.
@@ -104,14 +119,19 @@ func ExtractLZMA2(xFile *XFile) (size int64, filesList []string, err error) {
 	}
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".lzma", ".lzma2")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".lzma", ".lzma2"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractZstandard extracts a Zstandard-compressed file. A single file.
@@ -129,14 +149,19 @@ func ExtractZstandard(xFile *XFile) (size int64, filesList []string, err error) 
 	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".zstd", ".zst")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".zstd", ".zst"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractLZW extracts an LZW-compressed file. A single file.
@@ -153,14 +178,19 @@ func ExtractLZW(xFile *XFile) (size int64, filesList []string, err error) {
 	}
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".Z")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".Z"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractLZ4 extracts an LZ4-compressed file. A single file.
@@ -172,14 +202,19 @@ func ExtractLZ4(xFile *XFile) (size int64, filesList []string, err error) {
 	defer compressedFile.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".lz4")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".lz4"),
+		Data:     lz4.NewReader(compressedFile),
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, lz4.NewReader(compressedFile), xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractSnappy extracts a snappy-compressed file. A single file.
@@ -191,14 +226,19 @@ func ExtractSnappy(xFile *XFile) (size int64, filesList []string, err error) {
 	defer compressedFile.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".snappy", ".sz")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".snappy", ".sz"),
+		Data:     snappy.NewReader(compressedFile),
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, snappy.NewReader(compressedFile), xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractS2 extracts a Snappy2-compressed file. A single file.
@@ -210,14 +250,19 @@ func ExtractS2(xFile *XFile) (size int64, filesList []string, err error) {
 	defer compressedFile.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".s2")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".s2"),
+		Data:     s2.NewReader(compressedFile),
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, s2.NewReader(compressedFile), xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractBrotli extracts a Brotli-compressed file. A single file.
@@ -229,14 +274,19 @@ func ExtractBrotli(xFile *XFile) (size int64, filesList []string, err error) {
 	defer compressedFile.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".brotli", ".br")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".brotli", ".br"),
+		Data:     brotli.NewReader(compressedFile),
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, brotli.NewReader(compressedFile), xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractBzip extracts a bzip2-compressed file. That is, a single file.
@@ -248,14 +298,19 @@ func ExtractBzip(xFile *XFile) (size int64, filesList []string, err error) {
 	defer compressedFile.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".bz", ".bz2")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".bz", ".bz2"),
+		Data:     bzip2.NewReader(compressedFile),
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+	}
 
-	size, err = writeFile(wfile, bzip2.NewReader(compressedFile), xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }
 
 // ExtractGzip extracts a gzip-compressed file. That is, a single file.
@@ -273,12 +328,18 @@ func ExtractGzip(xFile *XFile) (size int64, filesList []string, err error) {
 	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.
-	wfile := xFile.clean(xFile.FilePath, ".gz")
+	file := &file{
+		Path:     xFile.clean(xFile.FilePath, ".gz"),
+		Data:     zipReader,
+		FileMode: xFile.FileMode,
+		DirMode:  xFile.DirMode,
+		Mtime:    zipReader.ModTime,
+	}
 
-	size, err = writeFile(wfile, zipReader, xFile.FileMode, xFile.DirMode)
+	size, err = file.Write()
 	if err != nil {
 		return size, nil, err
 	}
 
-	return size, []string{wfile}, nil
+	return size, []string{file.Path}, nil
 }

--- a/decompress.go
+++ b/decompress.go
@@ -38,7 +38,7 @@ func ExtractXZ(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -68,7 +68,7 @@ func ExtractZlib(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -97,7 +97,7 @@ func ExtractLZMA(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -126,7 +126,7 @@ func ExtractLZMA2(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -156,7 +156,7 @@ func ExtractZstandard(xFile *XFile) (size int64, filesList []string, err error) 
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -185,7 +185,7 @@ func ExtractLZW(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -209,7 +209,7 @@ func ExtractLZ4(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -233,7 +233,7 @@ func ExtractSnappy(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -257,7 +257,7 @@ func ExtractS2(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -281,7 +281,7 @@ func ExtractBrotli(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -305,7 +305,7 @@ func ExtractBzip(xFile *XFile) (size int64, filesList []string, err error) {
 		DirMode:  xFile.DirMode,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}
@@ -336,7 +336,7 @@ func ExtractGzip(xFile *XFile) (size int64, filesList []string, err error) {
 		Mtime:    zipReader.ModTime,
 	}
 
-	size, err = file.Write()
+	size, err = xFile.write(file)
 	if err != nil {
 		return size, nil, err
 	}

--- a/files.go
+++ b/files.go
@@ -534,3 +534,19 @@ func (a ArchiveList) List() []string {
 func (x *XFile) SetLogger(logger Logger) {
 	x.log = logger
 }
+
+func (x *XFile) safeDirMode(current os.FileMode) os.FileMode {
+	if current.Perm() == 0 {
+		return x.DirMode
+	}
+
+	return current | 0700 // ensure owner has read/write/exec on folders.
+}
+
+func (x *XFile) safeFileMode(current os.FileMode) os.FileMode {
+	if current.Perm() == 0 {
+		return x.FileMode
+	}
+
+	return current | 0400 // ensure owner has read access to the file.
+}

--- a/iso.go
+++ b/iso.go
@@ -46,8 +46,8 @@ func (x *XFile) uniso(isoFile *iso9660.File, parent string) (int64, []string, er
 		return x.unisofile(isoFile, itemName)
 	}
 
-	if err := os.MkdirAll(filepath.Join(x.OutputDir, itemName), x.safeDirMode(isoFile.Mode())); err != nil {
-		return 0, nil, fmt.Errorf("making 1directory %s: %w", isoFile.Name(), err)
+	if err := x.mkDir(filepath.Join(x.OutputDir, itemName), isoFile.Mode(), isoFile.ModTime()); err != nil {
+		return 0, nil, fmt.Errorf("making iso directory %s: %w", isoFile.Name(), err)
 	}
 
 	children, err := isoFile.GetChildren()
@@ -76,7 +76,7 @@ func (x *XFile) unisofile(isoFile *iso9660.File, wfile string) (int64, []string,
 	file := &file{
 		Path:     x.clean(wfile),
 		Data:     isoFile.Reader(),
-		FileMode: x.safeFileMode(isoFile.Mode()),
+		FileMode: isoFile.Mode(),
 		DirMode:  x.DirMode,
 		Mtime:    isoFile.ModTime(),
 	}
@@ -90,7 +90,7 @@ func (x *XFile) unisofile(isoFile *iso9660.File, wfile string) (int64, []string,
 
 	x.Debugf("Writing archived file: %s (bytes: %d)", file.Path, isoFile.Size())
 
-	size, err := file.Write()
+	size, err := x.write(file)
 
 	return size, []string{file.Path}, err
 }

--- a/iso.go
+++ b/iso.go
@@ -37,6 +37,7 @@ func ExtractISO(xFile *XFile) (size int64, filesList []string, err error) {
 
 func (x *XFile) uniso(isoFile *iso9660.File, parent string) (int64, []string, error) {
 	itemName := filepath.Join(parent, isoFile.Name())
+
 	if isoFile.Name() == string([]byte{0}) { // rename root folder.
 		itemName = strings.TrimSuffix(strings.TrimSuffix(filepath.Base(x.FilePath), ".iso"), ".ISO")
 	}
@@ -45,8 +46,8 @@ func (x *XFile) uniso(isoFile *iso9660.File, parent string) (int64, []string, er
 		return x.unisofile(isoFile, itemName)
 	}
 
-	if err := os.MkdirAll(isoFile.Name(), isoFile.Mode()); err != nil {
-		return 0, nil, fmt.Errorf("making directory %s: %w", isoFile.Name(), err)
+	if err := os.MkdirAll(filepath.Join(x.OutputDir, itemName), x.safeDirMode(isoFile.Mode())); err != nil {
+		return 0, nil, fmt.Errorf("making 1directory %s: %w", isoFile.Name(), err)
 	}
 
 	children, err := isoFile.GetChildren()
@@ -75,7 +76,7 @@ func (x *XFile) unisofile(isoFile *iso9660.File, wfile string) (int64, []string,
 	file := &file{
 		Path:     x.clean(wfile),
 		Data:     isoFile.Reader(),
-		FileMode: isoFile.Mode(),
+		FileMode: x.safeFileMode(isoFile.Mode()),
 		DirMode:  x.DirMode,
 		Mtime:    isoFile.ModTime(),
 	}

--- a/queue.go
+++ b/queue.go
@@ -315,7 +315,7 @@ func (x *Xtractr) decompressArchives(resp *Response) error {
 // Returns list of archive files extracted, size of data written and files written.
 func (x *Xtractr) processArchive(filename string, resp *Response) (int64, []string, []string, error) {
 	if err := os.MkdirAll(resp.Output, x.config.DirMode); err != nil {
-		return 0, nil, nil, fmt.Errorf("os.MkdirAll: %w", err)
+		return 0, nil, nil, fmt.Errorf("making output dir: %w", err)
 	}
 
 	x.config.Debugf("Extracting File: %v to %v", filename, resp.Output)

--- a/rar.go
+++ b/rar.go
@@ -95,7 +95,7 @@ func (x *XFile) unrar(rarReader *rardecode.ReadCloser) (int64, []string, error) 
 		file := &file{
 			Path:     x.clean(header.Name),
 			Data:     rarReader,
-			FileMode: header.Mode(),
+			FileMode: x.safeFileMode(header.Mode()),
 			DirMode:  x.DirMode,
 			Mtime:    header.ModificationTime,
 			Atime:    header.AccessTime,
@@ -110,7 +110,7 @@ func (x *XFile) unrar(rarReader *rardecode.ReadCloser) (int64, []string, error) 
 		if header.IsDir {
 			x.Debugf("Writing archived directory: %s", file.Path)
 
-			if err = os.MkdirAll(file.Path, header.Mode().Perm()); err != nil {
+			if err = os.MkdirAll(file.Path, x.safeDirMode(header.Mode())); err != nil {
 				return size, files, fmt.Errorf("os.MkdirAll: %w", err)
 			}
 

--- a/tar.go
+++ b/tar.go
@@ -135,7 +135,7 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (int64, err
 	file := &file{
 		Path:     x.clean(header.Name),
 		Data:     tarReader,
-		FileMode: header.FileInfo().Mode(),
+		FileMode: x.safeFileMode(header.FileInfo().Mode()),
 		DirMode:  x.DirMode,
 		Mtime:    header.ChangeTime,
 		Atime:    header.AccessTime,
@@ -154,7 +154,7 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (int64, err
 	if header.Typeflag == tar.TypeDir {
 		x.Debugf("Writing archived directory: %s", file.Path)
 
-		if err := os.MkdirAll(file.Path, header.FileInfo().Mode()); err != nil {
+		if err := os.MkdirAll(file.Path, x.safeDirMode(header.FileInfo().Mode())); err != nil {
 			return 0, fmt.Errorf("os.MkdirAll: %w", err)
 		}
 

--- a/tar.go
+++ b/tar.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	lzw "github.com/sshaman1101/dcompress"
 	"github.com/therootcompany/xz"
@@ -119,31 +120,48 @@ func (x *XFile) untar(reader io.Reader) (int64, []string, error) {
 			return size, files, fmt.Errorf("%w: %s", ErrInvalidHead, x.FilePath)
 		}
 
-		wfile := x.clean(header.Name)
-		if !strings.HasPrefix(wfile, x.OutputDir) {
-			// The file being written is trying to write outside of our base path. Malicious archive?
-			return size, files, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, wfile, header.Name)
-		}
-
-		if header.Typeflag == tar.TypeDir {
-			x.Debugf("Writing archived directory: %s", wfile)
-
-			if err = os.MkdirAll(wfile, header.FileInfo().Mode()); err != nil {
-				return size, files, fmt.Errorf("os.MkdirAll: %w", err)
-			}
-
-			continue
-		}
-
-		x.Debugf("Writing archived file: %s (bytes: %d)", wfile, header.FileInfo().Size())
-
-		fSize, err := writeFile(wfile, tarReader, header.FileInfo().Mode(), x.DirMode)
+		fSize, err := x.untarFile(header, tarReader)
 		if err != nil {
 			return size, files, err
 		}
 
-		files = append(files, wfile)
+		files = append(files, header.Name)
 		size += fSize
-		x.Debugf("Wrote archived file: %s (%d bytes), total: %d files and %d bytes", wfile, fSize, len(files), size)
+		x.Debugf("Wrote archived file: %s (%d bytes), total: %d files and %d bytes", header.Name, fSize, len(files), size)
 	}
+}
+
+func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (int64, error) {
+	file := &file{
+		Path:     x.clean(header.Name),
+		Data:     tarReader,
+		FileMode: header.FileInfo().Mode(),
+		DirMode:  x.DirMode,
+		Mtime:    header.ChangeTime,
+		Atime:    header.AccessTime,
+	}
+
+	if header.Format != tar.FormatGNU && header.Format != tar.FormatPAX {
+		file.Mtime = header.ModTime
+		file.Atime = time.Now()
+	}
+
+	if !strings.HasPrefix(file.Path, x.OutputDir) {
+		// The file being written is trying to write outside of our base path. Malicious archive?
+		return 0, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, file.Path, header.Name)
+	}
+
+	if header.Typeflag == tar.TypeDir {
+		x.Debugf("Writing archived directory: %s", file.Path)
+
+		if err := os.MkdirAll(file.Path, header.FileInfo().Mode()); err != nil {
+			return 0, fmt.Errorf("os.MkdirAll: %w", err)
+		}
+
+		return 0, nil
+	}
+
+	x.Debugf("Writing archived file: %s (bytes: %d)", file.Path, header.FileInfo().Size())
+
+	return file.Write()
 }

--- a/zip.go
+++ b/zip.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 /* How to extract a ZIP file. */
@@ -37,35 +38,44 @@ func ExtractZIP(xFile *XFile) (size int64, filesList []string, err error) {
 }
 
 func (x *XFile) unzip(zipFile *zip.File) (int64, string, error) {
-	wfile := x.clean(zipFile.Name)
-	if !strings.HasPrefix(wfile, x.OutputDir) {
-		// The file being written is trying to write outside of our base path. Malicious archive?
-		return 0, wfile, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, wfile, zipFile.Name)
-	}
-
-	if zipFile.FileInfo().IsDir() {
-		x.Debugf("Writing archived directory: %s", wfile)
-
-		if err := os.MkdirAll(wfile, x.DirMode); err != nil {
-			return 0, wfile, fmt.Errorf("making zipFile dir: %w", err)
-		}
-
-		return 0, wfile, nil
-	}
-
-	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)", wfile,
-		zipFile.CompressedSize64, zipFile.UncompressedSize64)
-
 	zFile, err := zipFile.Open()
 	if err != nil {
-		return 0, wfile, fmt.Errorf("zipFile.Open: %w", err)
+		return 0, zipFile.Name, fmt.Errorf("zipFile.Open: %w", err)
 	}
 	defer zFile.Close()
 
-	s, err := writeFile(wfile, zFile, x.FileMode, x.DirMode)
-	if err != nil {
-		return s, wfile, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, wfile, zipFile.Name)
+	file := &file{
+		Path:     x.clean(zipFile.Name),
+		Data:     zFile,
+		FileMode: zipFile.FileInfo().Mode(),
+		DirMode:  x.DirMode,
+		Mtime:    zipFile.Modified,
+		Atime:    time.Now(),
 	}
 
-	return s, wfile, nil
+	if !strings.HasPrefix(file.Path, x.OutputDir) {
+		// The file being written is trying to write outside of our base path. Malicious archive?
+		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
+		return 0, file.Path, err
+	}
+
+	if zipFile.FileInfo().IsDir() {
+		x.Debugf("Writing archived directory: %s", file.Path)
+
+		if err := os.MkdirAll(file.Path, zipFile.FileInfo().Mode()); err != nil {
+			return 0, file.Path, fmt.Errorf("making zipFile dir: %w", err)
+		}
+
+		return 0, file.Path, nil
+	}
+
+	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)", file.Path,
+		zipFile.CompressedSize64, zipFile.UncompressedSize64)
+
+	s, err := file.Write()
+	if err != nil {
+		return s, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, zipFile.Name)
+	}
+
+	return s, file.Path, nil
 }

--- a/zip.go
+++ b/zip.go
@@ -3,6 +3,7 @@ package xtractr
 import (
 	"archive/zip"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +48,7 @@ func (x *XFile) unzip(zipFile *zip.File) (int64, string, error) {
 	file := &file{
 		Path:     x.clean(zipFile.Name),
 		Data:     zFile,
-		FileMode: zipFile.FileInfo().Mode(),
+		FileMode: x.safeFileMode(zipFile.Mode()),
 		DirMode:  x.DirMode,
 		Mtime:    zipFile.Modified,
 		Atime:    time.Now(),
@@ -61,8 +62,8 @@ func (x *XFile) unzip(zipFile *zip.File) (int64, string, error) {
 
 	if zipFile.FileInfo().IsDir() {
 		x.Debugf("Writing archived directory: %s", file.Path)
-
-		if err := os.MkdirAll(file.Path, zipFile.FileInfo().Mode()); err != nil {
+		log.Println("MOOOODE", zipFile.Mode())
+		if err := os.MkdirAll(file.Path, x.safeDirMode(zipFile.Mode())); err != nil {
 			return 0, file.Path, fmt.Errorf("making zipFile dir: %w", err)
 		}
 


### PR DESCRIPTION
This contribution changes how the library writes archived files by adding an `os.Chtimes` call to set the mtime and atime values on written files and folders. 

It also honors the archived file posix modes now. Not all archives have modes, so it still falls back, but if the archived file has a mode it is used. 

I also fixed a few bugs along the way.

- Closes https://github.com/Unpackerr/unpackerr/issues/517
- ~~Needs testing.~~ Tested zip and tar.