### PR TITLE
Squash root archive folder

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -80,7 +80,9 @@ func extract7z(xFile *XFile) (int64, []string, []string, error) {
 		xFile.Debugf("Wrote archived file: %s (%d bytes), total: %d files and %d bytes", wfile, fSize, len(files), size)
 	}
 
-	return size, files, sevenZip.Volumes(), nil
+	files, err = xFile.cleanup(files)
+
+	return size, files, sevenZip.Volumes(), err
 }
 
 func (x *XFile) un7zip(zipFile *sevenzip.File) (int64, string, error) {

--- a/ar.go
+++ b/ar.go
@@ -28,14 +28,12 @@ func (x *XFile) unAr(reader io.Reader) (int64, []string, error) {
 
 	for {
 		header, err := arReader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 
-		switch {
-		case errors.Is(err, io.EOF):
-			return size, files, nil
-		case err != nil:
 			return size, files, fmt.Errorf("%s: arReader.Next: %w", x.FilePath, err)
-		case header == nil:
-			return size, files, fmt.Errorf("%w: %s", ErrInvalidHead, x.FilePath)
 		}
 
 		wfile := x.clean(header.Name)
@@ -54,4 +52,8 @@ func (x *XFile) unAr(reader io.Reader) (int64, []string, error) {
 		files = append(files, wfile)
 		size += fSize
 	}
+
+	files, err := x.cleanup(files)
+
+	return size, files, err
 }

--- a/files.go
+++ b/files.go
@@ -544,7 +544,7 @@ func (x *XFile) squashRoot(files []string) ([]string, error) {
 	}
 
 	roots := map[string]bool{}
-
+	//nolint:mnd
 	for _, path := range files {
 		roots[strings.SplitN(strings.TrimPrefix(path, x.OutputDir), string(filepath.Separator), 2)[0]] = true
 	}

--- a/iso.go
+++ b/iso.go
@@ -64,7 +64,9 @@ func (x *XFile) uniso(isoFile *iso9660.File, parent string) (int64, []string, er
 		files = append(files, childFiles...)
 	}
 
-	return size, files, nil
+	files, err = x.cleanup(files)
+
+	return size, files, err
 }
 
 func (x *XFile) unisofile(isoFile *iso9660.File, wfile string) (int64, []string, error) {

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,7 @@
 package xtractr
 
 // NoLogger gives you an empty Logger for cases when you don't want any output.
-func NoLogger() Logger { return &antiLogger{} }
+func NoLogger() Logger { return &antiLogger{} } //nolint:ireturn // It's on purpose.
 
 type antiLogger struct{}
 

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,9 @@
+package xtractr
+
+// NoLogger gives you an empty Logger for cases when you don't want any output.
+func NoLogger() Logger { return &antiLogger{} }
+
+type antiLogger struct{}
+
+func (*antiLogger) Printf(_ string, _ ...any) {}
+func (*antiLogger) Debugf(_ string, _ ...any) {}

--- a/start.go
+++ b/start.go
@@ -122,6 +122,10 @@ func parseConfig(config *Config) *Xtractr {
 		config.Suffix = DefaultSuffix
 	}
 
+	if config.Logger == nil {
+		config.Logger = NoLogger()
+	}
+
 	return &Xtractr{
 		config: config,
 		done:   make(chan struct{}),

--- a/tar.go
+++ b/tar.go
@@ -109,14 +109,12 @@ func (x *XFile) untar(reader io.Reader) (int64, []string, error) {
 
 	for {
 		header, err := tarReader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 
-		switch {
-		case errors.Is(err, io.EOF):
-			return size, files, nil
-		case err != nil:
 			return size, files, fmt.Errorf("%s: tarReader.Next: %w", x.FilePath, err)
-		case header == nil:
-			return size, files, fmt.Errorf("%w: %s", ErrInvalidHead, x.FilePath)
 		}
 
 		wfile := x.clean(header.Name)
@@ -146,4 +144,8 @@ func (x *XFile) untar(reader io.Reader) (int64, []string, error) {
 		size += fSize
 		x.Debugf("Wrote archived file: %s (%d bytes), total: %d files and %d bytes", wfile, fSize, len(files), size)
 	}
+
+	files, err := x.cleanup(files)
+
+	return size, files, err
 }

--- a/zip.go
+++ b/zip.go
@@ -33,7 +33,9 @@ func ExtractZIP(xFile *XFile) (size int64, filesList []string, err error) {
 		xFile.Debugf("Wrote archived file: %s (%d bytes), total: %d files and %d bytes", wfile, fSize, len(files), size)
 	}
 
-	return size, files, nil
+	files, err = xFile.cleanup(files)
+
+	return size, files, err
 }
 
 func (x *XFile) unzip(zipFile *zip.File) (int64, string, error) {


### PR DESCRIPTION
- Closes #70
- Adds a default logger with no output. Because it looked like there might be places it would panic if left nil.

Tested by adding a new flag to [xt](https://github.com/unpackerr/xt) and extracting some archives. Logger works too.