### PR TITLE
Consolidate errors in errors.go, truncate long archived file names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
           - goconst
           - wsl
           - errcheck
+          - err113
         path: .+_test.go
       - linters:
           - cyclop

--- a/cue.go
+++ b/cue.go
@@ -16,14 +16,6 @@ import (
 	"github.com/mewkiz/flac/meta"
 )
 
-// CUE sheet parsing errors.
-var (
-	ErrNoCueFile        = errors.New("cue sheet does not reference a FILE")
-	ErrNoTracks         = errors.New("cue sheet contains no tracks")
-	ErrAudioNotFound    = errors.New("audio file referenced by cue sheet not found")
-	ErrUnsupportedAudio = errors.New("cue sheet references unsupported audio format (only FLAC is supported)")
-)
-
 // CueSheet represents a parsed CUE sheet.
 type CueSheet struct {
 	// Performer is the album-level performer.

--- a/files.go
+++ b/files.go
@@ -556,9 +556,7 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 	}
 	defer oldFile.Close()
 
-	tryPath := newpath
-
-	newFile, err := os.OpenFile(tryPath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, x.config.FileMode)
+	newFile, err := os.OpenFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, x.config.FileMode)
 	if err != nil {
 		if IsErrNameTooLong(err) {
 			tryPath, tryErr := TruncatePathForFS(newpath)

--- a/files.go
+++ b/files.go
@@ -737,9 +737,7 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		return 0, fmt.Errorf("writing archived file '%s' parent folder: %w", filepath.Base(file.Path), err)
 	}
 
-	writePath := file.Path
-
-	fout, err := os.OpenFile(writePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
+	fout, err := os.OpenFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
 	if err != nil {
 		if IsErrNameTooLong(err) {
 			shortPath, truncErr := TruncatePathForFS(file.Path)
@@ -747,9 +745,8 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 				return 0, fmt.Errorf("opening archived file (name too long, truncation failed): %w", truncErr)
 			}
 
-			writePath = shortPath
 			file.Path = shortPath
-			fout, err = os.OpenFile(writePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
+			fout, err = os.OpenFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
 		}
 
 		if err != nil {
@@ -769,7 +766,7 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 	}
 
 	// If this sucks, make it a defer and ignore the error, like xFile.mkDir().
-	err = os.Chtimes(writePath, file.Atime, file.Mtime)
+	err = os.Chtimes(file.Path, file.Atime, file.Mtime)
 	if err != nil {
 		return uint64(size), fmt.Errorf("changing archived file times: %w", err)
 	}

--- a/files.go
+++ b/files.go
@@ -544,7 +544,7 @@ func openFile(path string, flags int, mode os.FileMode) (*os.File, string, error
 	}
 
 	if !IsErrNameTooLong(err) {
-		return nil, "", err
+		return nil, "", fmt.Errorf("os.OpenFile(): %w", err)
 	}
 
 	shortPath, truncErr := TruncatePathForFS(path)
@@ -554,7 +554,7 @@ func openFile(path string, flags int, mode os.FileMode) (*os.File, string, error
 
 	openFile, err = os.OpenFile(shortPath, flags, mode)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("os.OpenFile(): %w", err)
 	}
 
 	return openFile, shortPath, nil
@@ -592,7 +592,7 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 
 	newFile, _, err := openFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, oldFileStat.Mode())
 	if err != nil {
-		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.OpenFile(): %w", err)}}
+		return &ExtractError{Errs: []error{origErr, err}}
 	}
 	defer newFile.Close()
 
@@ -601,7 +601,7 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("io.Copy(): %w", err)}}
 	}
 
-	_ = os.Chtimes(newpath, oldFileStat.ModTime(), oldFileStat.ModTime()) //nolint:errcheck
+	_ = os.Chtimes(newpath, oldFileStat.ModTime(), oldFileStat.ModTime())
 	// The copy was successful, so now delete the original file
 	_ = oldFile.Close() // Needs to be closed before delete.
 	_ = os.Remove(oldpath)
@@ -763,7 +763,7 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 
 	fout, pathUsed, err := openFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
 	if err != nil {
-		return 0, fmt.Errorf("opening archived file for writing: %w", err)
+		return 0, err
 	}
 	defer fout.Close()
 

--- a/files.go
+++ b/files.go
@@ -532,6 +532,34 @@ func truncateToBytes(str string, maxBytes int) string {
 	return string(bytes)
 }
 
+// openFile opens path with the given flags and mode. If the path exceeds
+// filesystem name limits, the path is truncated via TruncatePathForFS and
+// retried. It returns the opened file and the path that was actually used
+// (the original or the truncated path), so the caller can update file.Path
+// for later use (e.g. os.Chtimes).
+func openFile(path string, flags int, mode os.FileMode) (*os.File, string, error) {
+	openFile, err := os.OpenFile(path, flags, mode)
+	if err == nil {
+		return openFile, path, nil
+	}
+
+	if !IsErrNameTooLong(err) {
+		return nil, "", err
+	}
+
+	shortPath, truncErr := TruncatePathForFS(path)
+	if truncErr != nil {
+		return nil, "", truncErr
+	}
+
+	openFile, err = os.OpenFile(shortPath, flags, mode)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return openFile, shortPath, nil
+}
+
 type file struct {
 	Path     string
 	Data     io.Reader
@@ -543,41 +571,37 @@ type file struct {
 
 // Rename is an attempt to deal with "invalid cross link device" on weird file systems.
 func (x *Xtractr) Rename(oldpath, newpath string) error {
-	err := os.Rename(oldpath, newpath)
-	if err == nil {
+	origErr := os.Rename(oldpath, newpath)
+	if origErr == nil {
 		return nil
 	}
 
+	origErr = fmt.Errorf("os.Rename(): %w", origErr)
+
 	/* Rename failed, try copy. */
+
+	oldFileStat, err := os.Stat(oldpath)
+	if err != nil {
+		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.Stat(): %w", err)}}
+	}
 
 	oldFile, err := os.Open(oldpath) // do not forget to close this!
 	if err != nil {
-		return fmt.Errorf("os.Open(): %w", err)
+		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.Open(): %w", err)}}
 	}
-	defer oldFile.Close()
 
-	newFile, err := os.OpenFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, x.config.FileMode)
+	newFile, _, err := openFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, oldFileStat.Mode())
 	if err != nil {
-		if IsErrNameTooLong(err) {
-			tryPath, tryErr := TruncatePathForFS(newpath)
-			if tryErr != nil {
-				return fmt.Errorf("os.OpenFile() and path truncation: %w", tryErr)
-			}
-
-			newFile, err = os.OpenFile(tryPath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, x.config.FileMode)
-		}
-
-		if err != nil {
-			return fmt.Errorf("os.OpenFile(): %w", err)
-		}
+		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.OpenFile(): %w", err)}}
 	}
 	defer newFile.Close()
 
 	_, err = io.Copy(newFile, oldFile)
 	if err != nil {
-		return fmt.Errorf("io.Copy(): %w", err)
+		return &ExtractError{Errs: []error{origErr, fmt.Errorf("io.Copy(): %w", err)}}
 	}
 
+	_ = os.Chtimes(newpath, oldFileStat.ModTime(), oldFileStat.ModTime()) //nolint:errcheck
 	// The copy was successful, so now delete the original file
 	_ = oldFile.Close() // Needs to be closed before delete.
 	_ = os.Remove(oldpath)
@@ -737,23 +761,13 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		return 0, fmt.Errorf("writing archived file '%s' parent folder: %w", filepath.Base(file.Path), err)
 	}
 
-	fout, err := os.OpenFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
+	fout, pathUsed, err := openFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
 	if err != nil {
-		if IsErrNameTooLong(err) {
-			shortPath, truncErr := TruncatePathForFS(file.Path)
-			if truncErr != nil {
-				return 0, fmt.Errorf("opening archived file (name too long, truncation failed): %w", truncErr)
-			}
-
-			file.Path = shortPath
-			fout, err = os.OpenFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
-		}
-
-		if err != nil {
-			return 0, fmt.Errorf("opening archived file for writing: %w", err)
-		}
+		return 0, fmt.Errorf("opening archived file for writing: %w", err)
 	}
 	defer fout.Close()
+
+	file.Path = pathUsed
 
 	progWriter := x.prog.writer(fout)
 	if parallel {

--- a/queue.go
+++ b/queue.go
@@ -355,6 +355,7 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		Updates:     resp.X.Updates,
 		Progress:    resp.X.Progress,
 	}
+
 	bytes, files, archives, err := ExtractFile(xFile)
 	if err != nil {
 		x.DeleteFiles(resp.Output) // clean up the mess after an error and bail.

--- a/rpm.go
+++ b/rpm.go
@@ -3,7 +3,6 @@ package xtractr
 import (
 	"compress/bzip2"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 
@@ -11,12 +10,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/therootcompany/xz"
 	"github.com/ulikunitz/xz/lzma"
-)
-
-// Errors returned when decompressing RAR archives.
-var (
-	ErrUnsupportedRPMCompression = errors.New("unsupported rpm compression")
-	ErrUnsupportedRPMArchiveFmt  = errors.New("unsupported rpm archive format")
 )
 
 // ExtractRPM extract a file as a RedHat Package Manager file.

--- a/start.go
+++ b/start.go
@@ -1,7 +1,6 @@
 package xtractr
 
 import (
-	"errors"
 	"os"
 )
 
@@ -57,18 +56,6 @@ type Xtractr struct {
 	queue  chan *Xtract
 	done   chan struct{}
 }
-
-// Custom errors returned by this module.
-var (
-	ErrQueueStopped       = errors.New("extractor queue stopped, cannot extract")
-	ErrNoCompressedFiles  = errors.New("no compressed files found")
-	ErrUnknownArchiveType = errors.New("unknown archive file type")
-	ErrInvalidPath        = errors.New("archived file contains invalid path")
-	ErrInvalidHead        = errors.New("archived file contains invalid header file")
-	ErrQueueRunning       = errors.New("extractor queue running, cannot start")
-	ErrNoConfig           = errors.New("call NewQueue() to initialize a queue")
-	ErrNoLogger           = errors.New("xtractr.Config.Logger must be non-nil")
-)
 
 // NewQueue returns a new Xtractr Queue you can send Xtract jobs into.
 // This is where to start if you're creating an extractor queue.

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -1,0 +1,62 @@
+package xtractr //nolint:testpackage // necessary for testing truncateToBytes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTruncateToBytes verifies truncateToBytes (used by TruncatePathForFS)
+// and would have caught the negative maxBytes bug (infinite loop/panic).
+func TestTruncateToBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("negative_maxBytes_returns_empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, truncateToBytes("hello", -1))
+		assert.Empty(t, truncateToBytes("any string", -100))
+	})
+
+	t.Run("zero_maxBytes_returns_empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, truncateToBytes("hello", 0))
+	})
+
+	t.Run("positive_within_limit_returns_unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		str := "hello"
+		assert.Equal(t, str, truncateToBytes(str, 5))
+		assert.Equal(t, str, truncateToBytes(str, 10))
+	})
+
+	t.Run("truncates_at_byte_boundary", func(t *testing.T) {
+		t.Parallel()
+
+		str := "hello"
+		assert.Equal(t, "hell", truncateToBytes(str, 4))
+		assert.Equal(t, "he", truncateToBytes(str, 2))
+	})
+
+	t.Run("utf8_rune_boundary", func(t *testing.T) {
+		t.Parallel()
+		// "é" is 2 bytes in UTF-8; must not cut mid-rune
+		str := "café"
+		assert.Equal(t, "café", truncateToBytes(str, 5))
+		// Truncate to 4 bytes: cannot keep full "é" (2 bytes), so drop it → "caf" (3 bytes)
+		out4 := truncateToBytes(str, 4)
+		assert.Equal(t, "caf", out4)
+		assert.Len(t, out4, 3)
+		assert.Equal(t, "caf", truncateToBytes(str, 3))
+	})
+
+	t.Run("long_string", func(t *testing.T) {
+		t.Parallel()
+
+		str := strings.Repeat("a", 300)
+		out := truncateToBytes(str, 255)
+		assert.Len(t, out, 255)
+		assert.Equal(t, strings.Repeat("a", 255), out)
+	})
+}


### PR DESCRIPTION
- Closes #42
- Fixes https://github.com/golift/xtractr/issues/74 

Long file names in archives are simply truncated to fit into the file system. If there's a name conflict a suffix is appended. Makes the Rename() fallback copy procedure more robust and accurate.