### PR TITLE
Detect file encoding per file

### DIFF
--- a/chardet.go
+++ b/chardet.go
@@ -14,6 +14,12 @@ import (
 	"golang.org/x/text/encoding/traditionalchinese"
 )
 
+// zipNameDecoders stores per-entry filename encodings with an archive-level fallback.
+type zipNameDecoders struct {
+	defaultEncoding encoding.Encoding
+	nameEncodings   map[string]encoding.Encoding
+}
+
 // Encoding preference scores for tiebreaking. Higher = more commonly seen in non-UTF8 zips.
 // GBK/GB-18030 is most common because Chinese Windows is the largest source
 // of non-UTF8 zip files. Shift-JIS is next (Japanese Windows). These are
@@ -48,7 +54,7 @@ type encodingCandidate struct {
 // attempts to detect their character encoding. It uses chardet for initial
 // candidates, then validates and scores each one. Returns nil if no non-UTF8
 // filenames are found or no suitable decoder can be determined.
-func detectZipEncoding(xFile *XFile, entries []*zip.File) *encoding.Decoder {
+func detectZipEncoding(xFile *XFile, entries []*zip.File) *zipNameDecoders {
 	var rawNames []string
 
 	for _, f := range entries {
@@ -61,30 +67,63 @@ func detectZipEncoding(xFile *XFile, entries []*zip.File) *encoding.Decoder {
 		return nil
 	}
 
-	// Concatenate all non-UTF8 names for charset detection.
+	// Concatenate all non-UTF8 names for an archive-level fallback.
 	var allBytes []byte
 	for _, name := range rawNames {
 		allBytes = append(allBytes, []byte(name)...)
 	}
 
-	detector := chardet.NewTextDetector()
+	// Get a map of filename->encoding.
+	detector, decoders := detectEachFileEncoding(rawNames)
 
 	results, err := detector.DetectAll(allBytes)
 	if err != nil {
 		xFile.Debugf("Charset detection failed for zip filenames: %v", err)
-		return nil
+
+		if len(decoders.nameEncodings) == 0 {
+			return nil
+		}
+
+		return decoders
 	}
 
 	best := pickBestEncoding(results, rawNames)
-	if best == nil {
+	if best != nil {
+		decoders.defaultEncoding = best.enc
+		xFile.Debugf("Detected zip fallback filename encoding: %s (confidence: %d, score: %d)",
+			best.charset, best.confidence, best.score)
+	}
+
+	if len(decoders.nameEncodings) == 0 && decoders.defaultEncoding == nil {
 		xFile.Debugf("No suitable encoding found for %d non-UTF8 zip filenames", len(rawNames))
 		return nil
 	}
 
-	xFile.Debugf("Detected zip filename encoding: %s (confidence: %d, score: %d)",
-		best.charset, best.confidence, best.score)
+	xFile.Debugf("Detected per-entry zip filename encodings for %d/%d entries",
+		len(decoders.nameEncodings), len(rawNames))
 
-	return best.enc.NewDecoder()
+	return decoders
+}
+
+func detectEachFileEncoding(rawNames []string) (*chardet.Detector, *zipNameDecoders) {
+	detector := chardet.NewTextDetector()
+	decoders := &zipNameDecoders{nameEncodings: make(map[string]encoding.Encoding, len(rawNames))}
+	// Detect the encoding of the filenames, per filename.
+	for _, name := range rawNames {
+		results, err := detector.DetectAll([]byte(name))
+		if err != nil {
+			continue
+		}
+
+		best := pickBestEncoding(results, []string{name})
+		if best == nil {
+			continue
+		}
+
+		decoders.nameEncodings[name] = best.enc
+	}
+
+	return detector, decoders
 }
 
 // pickBestEncoding evaluates chardet results against the raw filenames and
@@ -134,8 +173,8 @@ func pickBestEncoding(results []chardet.Result, rawNames []string) *encodingCand
 }
 
 // decodeZipFilename decodes a zip entry filename if it's non-UTF8 and a decoder is available.
-func decodeZipFilename(name string, nonUTF8 bool, decoder *encoding.Decoder) string {
-	if decoder == nil {
+func decodeZipFilename(name string, nonUTF8 bool, decoders *zipNameDecoders) string {
+	if decoders == nil {
 		return name
 	}
 
@@ -143,7 +182,16 @@ func decodeZipFilename(name string, nonUTF8 bool, decoder *encoding.Decoder) str
 		return name
 	}
 
-	decoded, err := decoder.String(name)
+	enc := decoders.defaultEncoding
+	if specific, ok := decoders.nameEncodings[name]; ok {
+		enc = specific
+	}
+
+	if enc == nil {
+		return name
+	}
+
+	decoded, err := enc.NewDecoder().String(name)
 	if err != nil {
 		return name // fall back to original on error
 	}

--- a/chardet.go
+++ b/chardet.go
@@ -255,10 +255,12 @@ func decodeZipFilename(name string, extra []byte, nonUTF8 bool, decoders *zipNam
 }
 
 func decodeUnicodePathExtra(rawName string, extra []byte) (string, bool) {
-	for idx := 0; idx+4 <= len(extra); {
+	const extraFieldBytes = 4
+	for idx := 0; idx+extraFieldBytes <= len(extra); {
 		fieldID := binary.LittleEndian.Uint16(extra[idx : idx+2])
-		fieldSize := int(binary.LittleEndian.Uint16(extra[idx+2 : idx+4]))
-		start := idx + 4
+		fieldSize := int(binary.LittleEndian.Uint16(extra[idx+2 : idx+extraFieldBytes]))
+		start := idx + extraFieldBytes
+
 		end := start + fieldSize
 		if end > len(extra) {
 			return "", false
@@ -266,6 +268,7 @@ func decodeUnicodePathExtra(rawName string, extra []byte) (string, bool) {
 
 		if fieldID == zipExtraUnicodePathID && fieldSize >= 5 {
 			fieldData := extra[start:end]
+
 			nameCRC := binary.LittleEndian.Uint32(fieldData[1:5])
 			if nameCRC != crc32.ChecksumIEEE([]byte(rawName)) {
 				idx = end

--- a/chardet.go
+++ b/chardet.go
@@ -2,6 +2,8 @@ package xtractr
 
 import (
 	"archive/zip"
+	"encoding/binary"
+	"hash/crc32"
 	"strings"
 	"unicode/utf8"
 
@@ -42,6 +44,8 @@ const (
 	scorePercentDivisor = 100 // used to compute percentage-based scores
 	maxASCII            = 0x80
 )
+
+const zipExtraUnicodePathID = 0x7075 // Info-ZIP Unicode Path extra field.
 
 // encodingCandidate holds a charset detection result with its validation score.
 type encodingCandidate struct {
@@ -201,7 +205,13 @@ func pickBestEncoding(results []chardet.Result, rawNames []string) *encodingCand
 }
 
 // decodeZipFilename decodes a zip entry filename if it's non-UTF8 and a decoder is available.
-func decodeZipFilename(name string, nonUTF8 bool, decoders *zipNameDecoders) string {
+func decodeZipFilename(name string, extra []byte, nonUTF8 bool, decoders *zipNameDecoders) string {
+	// Prefer ZIP's Unicode Path extra field when present. This is explicit metadata
+	// and avoids heuristic guessing for mixed-language filenames.
+	if unicodeName, ok := decodeUnicodePathExtra(name, extra); ok {
+		return unicodeName
+	}
+
 	if decoders == nil {
 		return name
 	}
@@ -242,6 +252,36 @@ func decodeZipFilename(name string, nonUTF8 bool, decoders *zipNameDecoders) str
 	}
 
 	return strings.Join(decoded, "/")
+}
+
+func decodeUnicodePathExtra(rawName string, extra []byte) (string, bool) {
+	for idx := 0; idx+4 <= len(extra); {
+		fieldID := binary.LittleEndian.Uint16(extra[idx : idx+2])
+		fieldSize := int(binary.LittleEndian.Uint16(extra[idx+2 : idx+4]))
+		start := idx + 4
+		end := start + fieldSize
+		if end > len(extra) {
+			return "", false
+		}
+
+		if fieldID == zipExtraUnicodePathID && fieldSize >= 5 {
+			fieldData := extra[start:end]
+			nameCRC := binary.LittleEndian.Uint32(fieldData[1:5])
+			if nameCRC != crc32.ChecksumIEEE([]byte(rawName)) {
+				idx = end
+				continue
+			}
+
+			unicodeName := string(fieldData[5:])
+			if unicodeName != "" && utf8.ValidString(unicodeName) {
+				return unicodeName, true
+			}
+		}
+
+		idx = end
+	}
+
+	return "", false
 }
 
 func encodingPreference(charset string) int {

--- a/chardet.go
+++ b/chardet.go
@@ -18,6 +18,7 @@ import (
 type zipNameDecoders struct {
 	defaultEncoding encoding.Encoding
 	nameEncodings   map[string]encoding.Encoding
+	partNames       map[string]string
 }
 
 // Encoding preference scores for tiebreaking. Higher = more commonly seen in non-UTF8 zips.
@@ -99,15 +100,18 @@ func detectZipEncoding(xFile *XFile, entries []*zip.File) *zipNameDecoders {
 		return nil
 	}
 
-	xFile.Debugf("Detected per-entry zip filename encodings for %d/%d entries",
-		len(decoders.nameEncodings), len(rawNames))
+	xFile.Debugf("Detected zip filename encodings for %d/%d entries and %d path parts",
+		len(decoders.nameEncodings), len(rawNames), len(decoders.partNames))
 
 	return decoders
 }
 
 func detectEachFileEncoding(rawNames []string) (*chardet.Detector, *zipNameDecoders) {
 	detector := chardet.NewTextDetector()
-	decoders := &zipNameDecoders{nameEncodings: make(map[string]encoding.Encoding, len(rawNames))}
+	decoders := &zipNameDecoders{
+		nameEncodings: make(map[string]encoding.Encoding, len(rawNames)),
+		partNames:     map[string]string{},
+	}
 	// Detect the encoding of the filenames, per filename.
 	for _, name := range rawNames {
 		results, err := detector.DetectAll([]byte(name))
@@ -121,6 +125,30 @@ func detectEachFileEncoding(rawNames []string) (*chardet.Detector, *zipNameDecod
 		}
 
 		decoders.nameEncodings[name] = best.enc
+
+		decodedName, err := best.enc.NewDecoder().String(name)
+		if err != nil {
+			continue
+		}
+
+		rawParts := strings.Split(name, "/")
+
+		decodedParts := strings.Split(decodedName, "/")
+		if len(rawParts) != len(decodedParts) {
+			continue
+		}
+
+		for idx, part := range rawParts {
+			if part == "" {
+				continue
+			}
+
+			if _, ok := decoders.partNames[part]; ok {
+				continue
+			}
+
+			decoders.partNames[part] = decodedParts[idx]
+		}
 	}
 
 	return detector, decoders
@@ -182,21 +210,38 @@ func decodeZipFilename(name string, nonUTF8 bool, decoders *zipNameDecoders) str
 		return name
 	}
 
-	enc := decoders.defaultEncoding
-	if specific, ok := decoders.nameEncodings[name]; ok {
-		enc = specific
+	parts := strings.Split(name, "/")
+	decoded := make([]string, len(parts))
+
+	for idx, part := range parts {
+		if part == "" {
+			decoded[idx] = part
+			continue
+		}
+
+		enc := decoders.defaultEncoding
+		if value, ok := decoders.partNames[part]; ok {
+			decoded[idx] = value
+			continue
+		} else if specific, ok := decoders.nameEncodings[name]; ok {
+			enc = specific
+		}
+
+		if enc == nil {
+			decoded[idx] = part
+			continue
+		}
+
+		value, err := enc.NewDecoder().String(part)
+		if err != nil {
+			decoded[idx] = part // fall back to original on error
+			continue
+		}
+
+		decoded[idx] = value
 	}
 
-	if enc == nil {
-		return name
-	}
-
-	decoded, err := enc.NewDecoder().String(name)
-	if err != nil {
-		return name // fall back to original on error
-	}
-
-	return decoded
+	return strings.Join(decoded, "/")
 }
 
 func encodingPreference(charset string) int {

--- a/chardet.go
+++ b/chardet.go
@@ -295,6 +295,12 @@ func scriptConsistencyScore(decoded []string) int {
 	// Kana characters are unambiguous markers for Japanese text.
 	// When decoded text contains kana, that encoding is almost certainly correct.
 	if kana > 0 {
+		// Some mojibake patterns produce a small amount of kana mixed into mostly
+		// CJK text. That's usually not Japanese; avoid a large kana bonus there.
+		if counts.cjk > 0 && kana*4 < counts.cjk {
+			return counts.cjk * scorePercentDivisor / total
+		}
+
 		return scoreKanaBonus + kana*scorePercentDivisor/total
 	}
 

--- a/chardet_internal_test.go
+++ b/chardet_internal_test.go
@@ -47,6 +47,6 @@ func TestDecodeZipFilename_PrefersPartEncodingForSharedFolders(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, rootUTF+"/"+japaneseLeafUTF, decodeZipFilename(japanesePathRaw, true, decoders))
-	assert.Equal(t, rootUTF+"/"+chineseLeafUTF, decodeZipFilename(chinesePathRaw, true, decoders))
+	assert.Equal(t, rootUTF+"/"+japaneseLeafUTF, decodeZipFilename(japanesePathRaw, nil, true, decoders))
+	assert.Equal(t, rootUTF+"/"+chineseLeafUTF, decodeZipFilename(chinesePathRaw, nil, true, decoders))
 }

--- a/chardet_internal_test.go
+++ b/chardet_internal_test.go
@@ -1,0 +1,52 @@
+package xtractr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+//nolint:gosmopolitan
+func TestDecodeZipFilename_PrefersPartEncodingForSharedFolders(t *testing.T) {
+	t.Parallel()
+
+	gbkEncoder := simplifiedchinese.GBK.NewEncoder()
+	shiftJISEncoder := japanese.ShiftJIS.NewEncoder()
+
+	rootUTF := "感谢你的帮助"
+	japaneseLeafUTF := "テスト.txt"
+	chineseLeafUTF := "报告.txt"
+
+	rootRaw, err := gbkEncoder.String(rootUTF)
+	require.NoError(t, err)
+
+	japaneseLeafRaw, err := shiftJISEncoder.String(japaneseLeafUTF)
+	require.NoError(t, err)
+
+	chineseLeafRaw, err := gbkEncoder.String(chineseLeafUTF)
+	require.NoError(t, err)
+
+	// Simulate mixed archive detection where one full path leans Shift-JIS.
+	japanesePathRaw := rootRaw + "/" + japaneseLeafRaw
+	chinesePathRaw := rootRaw + "/" + chineseLeafRaw
+
+	decoders := &zipNameDecoders{
+		defaultEncoding: simplifiedchinese.GBK,
+		nameEncodings: map[string]encoding.Encoding{
+			japanesePathRaw: japanese.ShiftJIS, // would garble root without part-level override
+			chinesePathRaw:  simplifiedchinese.GBK,
+		},
+		partNames: map[string]string{
+			rootRaw:         rootUTF,
+			japaneseLeafRaw: japaneseLeafUTF,
+			chineseLeafRaw:  chineseLeafUTF,
+		},
+	}
+
+	assert.Equal(t, rootUTF+"/"+japaneseLeafUTF, decodeZipFilename(japanesePathRaw, true, decoders))
+	assert.Equal(t, rootUTF+"/"+chineseLeafUTF, decodeZipFilename(chinesePathRaw, true, decoders))
+}

--- a/zip.go
+++ b/zip.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/text/encoding"
 )
 
 /* How to extract a ZIP file. */
@@ -71,7 +69,7 @@ type zipFileEntry struct {
 // Pass 2 (parallel): dispatch file writes to workers.
 func (x *XFile) extractZIPParallel(
 	zipReader *zip.ReadCloser,
-	decoder *encoding.Decoder,
+	decoder *zipNameDecoders,
 ) (uint64, []string, error) {
 	fileEntries, files, err := x.zipPrepareEntries(zipReader, decoder)
 	if err != nil {
@@ -92,7 +90,7 @@ func (x *XFile) extractZIPParallel(
 // and returns the list of file entries to extract in parallel.
 func (x *XFile) zipPrepareEntries(
 	zipReader *zip.ReadCloser,
-	decoder *encoding.Decoder,
+	decoder *zipNameDecoders,
 ) ([]zipFileEntry, []string, error) {
 	entries := make([]zipFileEntry, 0, len(zipReader.File))
 	files := make([]string, 0, len(zipReader.File))

--- a/zip.go
+++ b/zip.go
@@ -31,7 +31,7 @@ func ExtractZIP(xFile *XFile) (size uint64, filesList []string, err error) {
 	files := []string{}
 
 	for _, zipFile := range zipReader.File {
-		decodedName := decodeZipFilename(zipFile.Name, zipFile.NonUTF8, decoder)
+		decodedName := decodeZipFilename(zipFile.Name, zipFile.Extra, zipFile.NonUTF8, decoder)
 
 		fSize, wfile, err := xFile.unzipWithName(zipFile, decodedName)
 		if err != nil {
@@ -96,7 +96,7 @@ func (x *XFile) zipPrepareEntries(
 	files := make([]string, 0, len(zipReader.File))
 
 	for _, zipFile := range zipReader.File {
-		decodedName := decodeZipFilename(zipFile.Name, zipFile.NonUTF8, decoder)
+		decodedName := decodeZipFilename(zipFile.Name, zipFile.Extra, zipFile.NonUTF8, decoder)
 		cleanPath := x.clean(decodedName)
 
 		if !strings.HasPrefix(cleanPath, x.OutputDir) {

--- a/zip_test.go
+++ b/zip_test.go
@@ -132,11 +132,14 @@ func unicodePathExtra(rawName []byte, unicodeName string) []byte {
 	return extra
 }
 
-func createNonUTF8ZipFileWithUnicodeExtra(t *testing.T, dir string, rawName []byte, unicodeName string, content []byte) string {
+func createNonUTF8ZipFileWithUnicodeExtra(
+	t *testing.T, dir string, rawName []byte, unicodeName string, content []byte,
+) string {
 	t.Helper()
 
 	zipPath := filepath.Join(dir, "non_utf8_unicode_extra.zip")
 	outFile, err := os.Create(zipPath)
+
 	require.NoError(t, err)
 	defer safeCloser(t, outFile)
 

--- a/zip_test.go
+++ b/zip_test.go
@@ -215,6 +215,7 @@ func TestZipNonUTF8_MixedEncodings(t *testing.T) {
 		"テスト.txt",
 		"感谢你的帮助.jpg",
 		"数据目录/报告.txt",
+		"游戏启动说明.txt",
 	}
 
 	encodedNames := make([][]byte, 0, len(expectedNames))
@@ -233,6 +234,11 @@ func TestZipNonUTF8_MixedEncodings(t *testing.T) {
 	require.NoError(t, err)
 
 	encodedNames = append(encodedNames, encodedChinese2)
+
+	encodedChinese3, err := gbkEncoder.Bytes([]byte(expectedNames[3]))
+	require.NoError(t, err)
+
+	encodedNames = append(encodedNames, encodedChinese3)
 
 	tmpDir := t.TempDir()
 	content := []byte("hello")

--- a/zip_test.go
+++ b/zip_test.go
@@ -206,6 +206,62 @@ func TestZipNonUTF8_ShiftJIS(t *testing.T) {
 }
 
 //nolint:gosmopolitan
+func TestZipNonUTF8_MixedEncodings(t *testing.T) {
+	t.Parallel()
+
+	shiftJISEncoder := japanese.ShiftJIS.NewEncoder()
+	gbkEncoder := simplifiedchinese.GBK.NewEncoder()
+	expectedNames := []string{
+		"テスト.txt",
+		"感谢你的帮助.jpg",
+		"数据目录/报告.txt",
+	}
+
+	encodedNames := make([][]byte, 0, len(expectedNames))
+
+	encodedJapanese, err := shiftJISEncoder.Bytes([]byte(expectedNames[0]))
+	require.NoError(t, err)
+
+	encodedNames = append(encodedNames, encodedJapanese)
+
+	encodedChinese1, err := gbkEncoder.Bytes([]byte(expectedNames[1]))
+	require.NoError(t, err)
+
+	encodedNames = append(encodedNames, encodedChinese1)
+
+	encodedChinese2, err := gbkEncoder.Bytes([]byte(expectedNames[2]))
+	require.NoError(t, err)
+
+	encodedNames = append(encodedNames, encodedChinese2)
+
+	tmpDir := t.TempDir()
+	content := []byte("hello")
+	zipPath := createNonUTF8ZipFile(t, tmpDir, encodedNames, content)
+
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o700))
+
+	size, files, err := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  zipPath,
+		OutputDir: outDir,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(len(content)*len(expectedNames)), size)
+	assert.Len(t, files, len(expectedNames))
+
+	for idx, file := range files {
+		assert.Equal(t, filepath.Base(expectedNames[idx]), filepath.Base(file))
+	}
+
+	for _, name := range expectedNames {
+		_, err := os.Stat(filepath.Join(outDir, name))
+		assert.NoError(t, err, "decoded file should exist on disk: %s", name)
+	}
+}
+
+//nolint:gosmopolitan
 func TestZipUTF8FilenamesUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/zip_test.go
+++ b/zip_test.go
@@ -3,6 +3,8 @@ package xtractr_test
 import (
 	"archive/zip"
 	_ "embed"
+	"encoding/binary"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +15,8 @@ import (
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golift.io/xtractr"
 )
+
+const zipExtraUnicodePathID = 0x7075
 
 func TestZip(t *testing.T) {
 	t.Parallel()
@@ -109,6 +113,48 @@ func createNonUTF8ZipFile(t *testing.T, dir string, encodedNames [][]byte, conte
 		_, err = writer.Write(content)
 		require.NoError(t, err)
 	}
+
+	return zipPath
+}
+
+func unicodePathExtra(rawName []byte, unicodeName string) []byte {
+	nameBytes := []byte(unicodeName)
+	fieldData := make([]byte, 1+4+len(nameBytes))
+	fieldData[0] = 1 // version
+	binary.LittleEndian.PutUint32(fieldData[1:5], crc32.ChecksumIEEE(rawName))
+	copy(fieldData[5:], nameBytes)
+
+	extra := make([]byte, 4+len(fieldData))
+	binary.LittleEndian.PutUint16(extra[0:2], zipExtraUnicodePathID)
+	binary.LittleEndian.PutUint16(extra[2:4], uint16(len(fieldData)))
+	copy(extra[4:], fieldData)
+
+	return extra
+}
+
+func createNonUTF8ZipFileWithUnicodeExtra(t *testing.T, dir string, rawName []byte, unicodeName string, content []byte) string {
+	t.Helper()
+
+	zipPath := filepath.Join(dir, "non_utf8_unicode_extra.zip")
+	outFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer safeCloser(t, outFile)
+
+	zipWriter := zip.NewWriter(outFile)
+	defer safeCloser(t, zipWriter)
+
+	header := &zip.FileHeader{
+		Name:    string(rawName),
+		Method:  zip.Deflate,
+		NonUTF8: true,
+		Extra:   unicodePathExtra(rawName, unicodeName),
+	}
+
+	writer, err := zipWriter.CreateHeader(header)
+	require.NoError(t, err)
+
+	_, err = writer.Write(content)
+	require.NoError(t, err)
 
 	return zipPath
 }
@@ -265,6 +311,39 @@ func TestZipNonUTF8_MixedEncodings(t *testing.T) {
 		_, err := os.Stat(filepath.Join(outDir, name))
 		assert.NoError(t, err, "decoded file should exist on disk: %s", name)
 	}
+}
+
+//nolint:gosmopolitan
+func TestZipNonUTF8_UnicodePathExtraMixedLanguage(t *testing.T) {
+	t.Parallel()
+
+	// Raw filename bytes are Shift-JIS (legacy), but Unicode Path extra field
+	// carries the canonical UTF-8 mixed-language name.
+	shiftJISEncoder := japanese.ShiftJIS.NewEncoder()
+	rawName, err := shiftJISEncoder.Bytes([]byte("テスト.txt"))
+	require.NoError(t, err)
+
+	unicodeName := "游戏テスト启动说明.txt"
+	tmpDir := t.TempDir()
+	content := []byte("hello")
+	zipPath := createNonUTF8ZipFileWithUnicodeExtra(t, tmpDir, rawName, unicodeName, content)
+
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o700))
+
+	size, files, err := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  zipPath,
+		OutputDir: outDir,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(len(content)), size)
+	assert.Len(t, files, 1)
+	assert.Equal(t, unicodeName, filepath.Base(files[0]))
+
+	_, err = os.Stat(filepath.Join(outDir, unicodeName))
+	assert.NoError(t, err, "decoded file should exist on disk: %s", unicodeName)
 }
 
 //nolint:gosmopolitan


### PR DESCRIPTION
- Fixes #124

Instead of assuming every file in an archive shares an encoding, detect it per file.  Adds support for zip unicode path extra field, making encoding detection more deterministic in many cases.