### PR TITLE
Use variable-blocksize encoding consistently in split FLAC tracks

### DIFF
--- a/cue.go
+++ b/cue.go
@@ -452,11 +452,15 @@ func writeTrackFLAC( //nolint:funlen
 	trackSamples := endSample - startSample
 
 	// Create a new StreamInfo for this track.
+	// BlockSizeMin/Max will be rewritten by the encoder on Close().
+	// FrameSizeMin/Max are set to 0 (unknown) because the mewkiz encoder does
+	// not track frame sizes and will not update them on Close(); copying the
+	// source values would be wrong after splitting frames at track boundaries.
 	trackInfo := &meta.StreamInfo{
 		BlockSizeMin:  srcInfo.BlockSizeMin,
 		BlockSizeMax:  srcInfo.BlockSizeMax,
-		FrameSizeMin:  srcInfo.FrameSizeMin,
-		FrameSizeMax:  srcInfo.FrameSizeMax,
+		FrameSizeMin:  0,
+		FrameSizeMax:  0,
 		SampleRate:    srcInfo.SampleRate,
 		NChannels:     srcInfo.NChannels,
 		BitsPerSample: srcInfo.BitsPerSample,
@@ -513,13 +517,14 @@ func writeTrackFLAC( //nolint:funlen
 }
 
 // buildOutputFrame creates a new frame with a subset of samples from the source frame.
+// All output frames are created with HasFixedBlockSize=false (variable block size mode)
+// regardless of the source stream's block size mode. This ensures a consistent encoding
+// throughout the output file: mixing fixed-blocksize frames (which encode a frame number
+// in the header) with variable-blocksize frames (which encode a sample position) produces
+// an invalid FLAC stream that many decoders — including GStreamer's flacparse — will reject.
 func buildOutputFrame(src *frame.Frame, offset, count, origSamples int) *frame.Frame {
-	// If the frame is entirely within the track, just return it as-is.
-	if offset == 0 && count == origSamples {
-		return src
-	}
-
-	// We need to slice the samples. First correlate to get proper L/R samples.
+	// Always correlate to get proper L/R samples before slicing.
+	// Correlate is a no-op when the frame is already in correlated form.
 	src.Correlate()
 
 	outFrame := &frame.Frame{

--- a/cue.go
+++ b/cue.go
@@ -484,7 +484,6 @@ func writeTrackFLAC( //nolint:funlen
 		clipStart := max(srcFrame.sampleStart, startSample)
 		clipEnd := min(srcFrame.sampleEnd, endSample)
 
-		origSamples := int(srcFrame.sampleEnd - srcFrame.sampleStart)
 		offsetInFrame := int(clipStart - srcFrame.sampleStart)
 		samplesToTake := int(clipEnd - clipStart)
 
@@ -492,7 +491,7 @@ func writeTrackFLAC( //nolint:funlen
 			continue
 		}
 
-		outFrame := buildOutputFrame(srcFrame.frame, offsetInFrame, samplesToTake, origSamples)
+		outFrame := buildOutputFrame(srcFrame.frame, offsetInFrame, samplesToTake)
 
 		err = enc.WriteFrame(outFrame)
 		if err != nil {
@@ -522,7 +521,7 @@ func writeTrackFLAC( //nolint:funlen
 // throughout the output file: mixing fixed-blocksize frames (which encode a frame number
 // in the header) with variable-blocksize frames (which encode a sample position) produces
 // an invalid FLAC stream that many decoders — including GStreamer's flacparse — will reject.
-func buildOutputFrame(src *frame.Frame, offset, count, origSamples int) *frame.Frame {
+func buildOutputFrame(src *frame.Frame, offset, count int) *frame.Frame {
 	// Always correlate to get proper L/R samples before slicing.
 	// Correlate is a no-op when the frame is already in correlated form.
 	src.Correlate()

--- a/cue_test.go
+++ b/cue_test.go
@@ -1,6 +1,8 @@
 package xtractr_test
 
 import (
+	"errors"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -396,6 +398,75 @@ func TestCueREMComments(t *testing.T) {
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err)
 	assert.Len(t, files, 1)
+}
+
+// TestCueVariableBlockSizeConsistency verifies that all frames in every split
+// track file use variable-block-size encoding (HasFixedBlockSize=false).
+// Mixing fixed- and variable-blocksize frames in one file is invalid FLAC:
+// the two modes encode different values in the "frame/sample number" field of
+// the frame header, causing decoders such as GStreamer's flacparse to reject
+// the file with a stream error.
+func TestCueVariableBlockSizeConsistency(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	// Use a block size that will not align perfectly with track boundaries so
+	// that the first frame of track 2 is a boundary-split (partial) frame.
+	// 44100 samples/s * 1 minute = 2646000 samples; block size 4096 means
+	// the track boundary at sample 2646000 falls mid-frame.
+	totalSamples := uint64(2 * 60 * testSampleRate) // 2 minutes
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track Two"`,
+		`    INDEX 01 01:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	_, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	for _, trackPath := range files {
+		f, err := os.Open(trackPath)
+		require.NoError(t, err, "opening track: %s", trackPath)
+
+		stream, err := flac.New(f)
+		require.NoError(t, err, "parsing track: %s", trackPath)
+
+		for {
+			frm, err := stream.ParseNext()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err, "reading frame from: %s", trackPath)
+			assert.False(t, frm.HasFixedBlockSize,
+				"frame in %s uses fixed-blocksize encoding; "+
+					"all frames must use variable-blocksize (HasFixedBlockSize=false) "+
+					"or decoders like GStreamer's flacparse will reject the file",
+				filepath.Base(trackPath))
+		}
+
+		require.NoError(t, f.Close())
+	}
 }
 
 func TestCueSupportedExtensions(t *testing.T) {

--- a/cue_test.go
+++ b/cue_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -467,6 +468,133 @@ func TestCueVariableBlockSizeConsistency(t *testing.T) {
 
 		require.NoError(t, f.Close())
 	}
+}
+
+// TestCueSplitRealFLAC is an integration test that uses ffmpeg to produce a
+// fixed-blocksize FLAC file (the default for all mainstream encoders) and then
+// splits it with ExtractCUE.  This is the exact scenario that caused GStreamer's
+// flacparse to abort with "streaming stopped, reason error (-5)":
+//
+//   - ffmpeg-encoded FLACs use HasFixedBlockSize=true in every frame header.
+//   - The old buildOutputFrame fast-path returned interior frames as-is
+//     (HasFixedBlockSize=true) while boundary-split frames were newly built
+//     with HasFixedBlockSize=false.
+//   - The mix is invalid FLAC; fixed-blocksize frames encode a frame number
+//     while variable-blocksize frames encode a sample position in the same
+//     header field, so a decoder reading a mixed file gets garbage positions.
+//
+// The test is skipped automatically when ffmpeg is not in PATH so it does not
+// break CI environments that lack the tool.
+func TestCueSplitRealFLAC(t *testing.T) {
+	t.Parallel()
+
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not found in PATH; skipping real-FLAC integration test")
+	}
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+	flacPath := filepath.Join(tmpDir, "album.flac")
+
+	// Build a 90-second fixed-blocksize FLAC by concatenating three 30-second
+	// sine-tone segments at different frequencies (440, 523, 659 Hz).
+	// ffmpeg's FLAC encoder always writes fixed-blocksize streams, which is
+	// what triggers the bug in the un-patched code.
+	cmd := exec.Command(ffmpeg, //nolint:gosec
+		"-y",
+		"-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100:duration=30",
+		"-f", "lavfi", "-i", "sine=frequency=523:sample_rate=44100:duration=30",
+		"-f", "lavfi", "-i", "sine=frequency=659:sample_rate=44100:duration=30",
+		"-filter_complex", "[0][1][2]concat=n=3:v=0:a=1",
+		"-c:a", "flac",
+		flacPath,
+	)
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg failed: %s", out)
+
+	// Verify the source FLAC uses fixed-blocksize encoding — if it doesn't, the
+	// test is not exercising the right code path and should be updated.
+	requireFixedBlocksizeFLAC(t, flacPath)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Test Artist"`,
+		`TITLE "Test Album"`,
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "A4 Tone"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "C5 Tone"`,
+		`    INDEX 01 00:30:00`,
+		`  TRACK 03 AUDIO`,
+		`    TITLE "E5 Tone"`,
+		`    INDEX 01 01:00:00`,
+	}, "\n") + "\n"
+
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE failed on ffmpeg-encoded FLAC")
+	require.Len(t, files, 3, "expected 3 split track files")
+	assert.Positive(t, size)
+	assert.Len(t, archiveList, 2)
+
+	for _, trackPath := range files {
+		f, err := os.Open(trackPath)
+		require.NoError(t, err)
+
+		stream, err := flac.New(f)
+		require.NoError(t, err, "flac.New failed for %s", filepath.Base(trackPath))
+
+		// Every frame in the output must use variable-blocksize encoding.
+		// Mixing fixed- and variable-blocksize frames produces an invalid file.
+		frameIdx := 0
+		for {
+			frm, err := stream.ParseNext()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+			assert.False(t, frm.HasFixedBlockSize,
+				"frame %d in %s uses fixed-blocksize encoding; "+
+					"decoders like GStreamer's flacparse will reject the file",
+				frameIdx, filepath.Base(trackPath))
+			frameIdx++
+		}
+
+		require.NoError(t, f.Close())
+	}
+}
+
+// requireFixedBlocksizeFLAC fails the test if the FLAC at path does not use
+// fixed-blocksize encoding.  It is used to assert that our ffmpeg-generated
+// source file is actually triggering the code path we want to test.
+func requireFixedBlocksizeFLAC(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	stream, err := flac.New(f)
+	require.NoError(t, err)
+
+	frm, err := stream.ParseNext()
+	require.NoError(t, err, "could not read first frame of source FLAC")
+	require.True(t, frm.HasFixedBlockSize,
+		"source FLAC %s does not use fixed-blocksize encoding; "+
+			"the test is not exercising the right code path",
+		filepath.Base(path))
 }
 
 func TestCueSupportedExtensions(t *testing.T) {

--- a/cue_test.go
+++ b/cue_test.go
@@ -447,10 +447,10 @@ func TestCueVariableBlockSizeConsistency(t *testing.T) {
 	require.Len(t, files, 2)
 
 	for _, trackPath := range files {
-		f, err := os.Open(trackPath)
+		trackFile, err := os.Open(trackPath)
 		require.NoError(t, err, "opening track: %s", trackPath)
 
-		stream, err := flac.New(f)
+		stream, err := flac.New(trackFile)
 		require.NoError(t, err, "parsing track: %s", trackPath)
 
 		for {
@@ -458,6 +458,7 @@ func TestCueVariableBlockSizeConsistency(t *testing.T) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
+
 			require.NoError(t, err, "reading frame from: %s", trackPath)
 			assert.False(t, frm.HasFixedBlockSize,
 				"frame in %s uses fixed-blocksize encoding; "+
@@ -466,7 +467,7 @@ func TestCueVariableBlockSizeConsistency(t *testing.T) {
 				filepath.Base(trackPath))
 		}
 
-		require.NoError(t, f.Close())
+		require.NoError(t, trackFile.Close())
 	}
 }
 
@@ -501,7 +502,7 @@ func TestCueSplitRealFLAC(t *testing.T) {
 	// sine-tone segments at different frequencies (440, 523, 659 Hz).
 	// ffmpeg's FLAC encoder always writes fixed-blocksize streams, which is
 	// what triggers the bug in the un-patched code.
-	cmd := exec.Command(ffmpeg, //nolint:gosec
+	cmd := exec.CommandContext(t.Context(), ffmpeg, //nolint:gosec
 		"-y",
 		"-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100:duration=30",
 		"-f", "lavfi", "-i", "sine=frequency=523:sample_rate=44100:duration=30",
@@ -550,20 +551,22 @@ func TestCueSplitRealFLAC(t *testing.T) {
 	assert.Len(t, archiveList, 2)
 
 	for _, trackPath := range files {
-		f, err := os.Open(trackPath)
+		trackFile, err := os.Open(trackPath)
 		require.NoError(t, err)
 
-		stream, err := flac.New(f)
+		stream, err := flac.New(trackFile)
 		require.NoError(t, err, "flac.New failed for %s", filepath.Base(trackPath))
 
 		// Every frame in the output must use variable-blocksize encoding.
 		// Mixing fixed- and variable-blocksize frames produces an invalid file.
 		frameIdx := 0
+
 		for {
 			frm, err := stream.ParseNext()
 			if errors.Is(err, io.EOF) {
 				break
 			}
+
 			require.NoError(t, err)
 			assert.False(t, frm.HasFixedBlockSize,
 				"frame %d in %s uses fixed-blocksize encoding; "+
@@ -572,7 +575,7 @@ func TestCueSplitRealFLAC(t *testing.T) {
 			frameIdx++
 		}
 
-		require.NoError(t, f.Close())
+		require.NoError(t, trackFile.Close())
 	}
 }
 
@@ -582,11 +585,12 @@ func TestCueSplitRealFLAC(t *testing.T) {
 func requireFixedBlocksizeFLAC(t *testing.T, path string) {
 	t.Helper()
 
-	f, err := os.Open(path)
+	srcFile, err := os.Open(path)
 	require.NoError(t, err)
-	defer f.Close()
 
-	stream, err := flac.New(f)
+	defer srcFile.Close()
+
+	stream, err := flac.New(srcFile)
 	require.NoError(t, err)
 
 	frm, err := stream.ParseNext()


### PR DESCRIPTION
When a FLAC+CUE file is split into individual tracks, frames that fall entirely within a track were returned from buildOutputFrame as-is from the source stream. For the common case of a fixed-blocksize source (BlockSizeMin == BlockSizeMax), those frames carry HasFixedBlockSize=true in their headers. Boundary-split frames (those that span a track edge) were correctly created with HasFixedBlockSize=false (variable-blocksize).

The mix is invalid FLAC: fixed-blocksize frames encode a frame number in the header, while variable-blocksize frames encode a sample position. Decoders such as GStreamer's flacparse detect this inconsistency and abort with streaming stopped, reason error (-5). VLC appears to tolerate it but shows a broken progress bar because the sample positions it reads are meaningless frame-count values treated as sample offsets.

Fix: remove the early-return fast path in buildOutputFrame so that every frame written to an output track is freshly constructed with HasFixedBlockSize=false. The mewkiz encoder auto-sets the Num field to the running sample position so no additional tracking is needed.

Also zero-out FrameSizeMin/FrameSizeMax in the initial StreamInfo passed to the encoder. The mewkiz encoder has a TODO and never updates those fields on Close(), so copying the source values would embed stale wrong byte-size metadata into every split track.

Adds TestCueVariableBlockSizeConsistency to catch regressions.

- Fixes: https://github.com/Unpackerr/unpackerr/issues/141