### PR TITLE
FLAC/CUE: add track tags, covers/images

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.11
   # Runs golangci-lint on linux against linux and windows.
   golangci-linux:
     strategy:
@@ -54,4 +54,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.11

--- a/cue.go
+++ b/cue.go
@@ -73,17 +73,16 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 	}
 
 	// Resolve the audio file path relative to the CUE file.
+	// Some CUE sheets say FILE "album.wav" WAVE but the file on disk is album.flac; try .flac when .wav is missing.
 	cueDir := filepath.Dir(xFile.FilePath)
-	audioPath := filepath.Join(cueDir, cue.File)
 
-	// Check that the audio file exists.
-	_, err = os.Stat(audioPath)
+	audioPath, err := resolveCueAudioPath(cueDir, cue.File)
 	if err != nil {
-		return 0, nil, nil, fmt.Errorf("%w: %s", ErrAudioNotFound, audioPath)
+		return 0, nil, nil, err
 	}
 
 	// Only FLAC is supported for now.
-	ext := strings.ToLower(filepath.Ext(cue.File))
+	ext := strings.ToLower(filepath.Ext(audioPath))
 	if ext != ".flac" {
 		return 0, nil, nil, fmt.Errorf("%w: %s", ErrUnsupportedAudio, ext)
 	}
@@ -207,6 +206,29 @@ func parseCueSheet(reader io.Reader) (*CueSheet, []cueTimestamp, error) { //noli
 	}
 
 	return cue, timestamps, nil
+}
+
+// resolveCueAudioPath returns the path to the audio file referenced by the CUE.
+// If the CUE says FILE "album.wav" but the file on disk is album.flac, the .flac path is returned.
+func resolveCueAudioPath(cueDir, cueFile string) (string, error) {
+	path := filepath.Join(cueDir, cueFile)
+
+	_, err := os.Stat(path)
+	if err == nil {
+		return path, nil
+	}
+
+	ext := strings.ToLower(filepath.Ext(cueFile))
+	if ext == ".wav" {
+		flacPath := path[:len(path)-len(ext)] + ".flac"
+
+		_, err = os.Stat(flacPath)
+		if err == nil {
+			return flacPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrAudioNotFound, path)
 }
 
 // splitCueLine splits a CUE line into its command and arguments.

--- a/cue.go
+++ b/cue.go
@@ -324,10 +324,10 @@ func parseCueTime(s string) cueTimestamp {
 
 // splitFLAC splits a FLAC file into individual tracks based on CUE sheet data.
 func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTimestamp) (uint64, []string, error) {
-	// Open, parse, and read all frames from the FLAC file.
+	// Open, parse, and read all frames and metadata (e.g. front cover) from the FLAC file.
 	// We close the stream immediately after reading to release the file handle,
 	// which is important on Windows where open handles block TempDir cleanup.
-	streamInfo, allFrames, err := readFLACFile(audioPath)
+	streamInfo, allFrames, coverPicture, err := readFLACFile(audioPath)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -357,9 +357,32 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 		return 0, nil, fmt.Errorf("creating output directory: %w", err)
 	}
 
+	var (
+		coverPath string
+		writeErr  error
+	)
+
+	if coverPicture != nil {
+		coverPath, writeErr = writeCoverToFile(xFile.OutputDir, coverPicture, xFile.FileMode)
+		if writeErr != nil {
+			xFile.Debugf("Error writing album cover: %s", writeErr)
+		}
+
+		xFile.Debugf("Wrote album cover: %s (%d bytes)", coverPath, len(coverPicture.Data))
+	}
+
 	defer xFile.newProgress(0, 0, len(cue.Tracks)).done()
 
-	return writeTracksFLAC(xFile, cue, allFrames, trackStarts, streamInfo, trackEnds)
+	totalSize, files, err := writeTracksFLAC(xFile, cue, allFrames, trackStarts, streamInfo, trackEnds, coverPicture)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if coverPath != "" {
+		return totalSize + uint64(len(coverPicture.Data)), append(files, coverPath), nil
+	}
+
+	return totalSize, files, nil
 }
 
 func writeTracksFLAC(
@@ -369,6 +392,7 @@ func writeTracksFLAC(
 	trackStarts []uint64,
 	streamInfo *meta.StreamInfo,
 	trackEnds []uint64,
+	coverPicture *meta.Picture,
 ) (uint64, []string, error) {
 	var (
 		totalSize uint64
@@ -377,21 +401,17 @@ func writeTracksFLAC(
 
 	// Split frames into tracks.
 	for trackIdx := range cue.Tracks {
-		track := &cue.Tracks[trackIdx]
 		startSample := trackStarts[trackIdx]
-		endSample := trackEnds[trackIdx]
 
+		endSample := trackEnds[trackIdx]
 		if endSample <= startSample {
 			continue
 		}
 
+		track := &cue.Tracks[trackIdx]
 		outputName := formatTrackFilename(track)
 		outputPath := filepath.Join(xFile.OutputDir, outputName)
-
-		var blocks []*meta.Block
-		if cue != nil && track != nil {
-			blocks = []*meta.Block{buildVorbisCommentBlock(cue, track)}
-		}
+		blocks := buildTrackMetadataBlocks(cue, track, coverPicture)
 
 		size, err := writeTrackFLAC(outputPath, streamInfo, allFrames, startSample, endSample, xFile.FileMode, blocks)
 		if err != nil {
@@ -414,34 +434,49 @@ type flacFrame struct {
 	sampleEnd   uint64
 }
 
-// readFLACFile opens a FLAC file, reads all frames, and closes the file.
-// We open and close the os.File ourselves because flac.Open wraps the reader
-// in bufio.NewReader, which loses the io.Closer interface and prevents
-// flac.Stream.Close from actually closing the underlying file handle.
-// This matters on Windows where open handles block file deletion.
-func readFLACFile(audioPath string) (*meta.StreamInfo, []flacFrame, error) {
+// frontCoverPictureType is the FLAC/ID3v2 APIC picture type for "Cover (front)".
+const frontCoverPictureType = 3
+
+// readFLACFile opens a FLAC file, parses metadata and all frames, and closes the file.
+// It returns the stream info, frames, and the first front-cover picture block if present.
+// We use flac.Parse (not flac.New) so metadata blocks (e.g. Picture) are available.
+// We open and close the os.File ourselves so the underlying file handle is released
+// (important on Windows where open handles block TempDir cleanup).
+func readFLACFile(audioPath string) (*meta.StreamInfo, []flacFrame, *meta.Picture, error) {
 	file, err := os.Open(audioPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("opening flac file: %w", err)
+		return nil, nil, nil, fmt.Errorf("opening flac file: %w", err)
 	}
+	defer file.Close()
 
-	stream, err := flac.New(file)
+	stream, err := flac.Parse(file)
 	if err != nil {
-		_ = file.Close()
-		return nil, nil, fmt.Errorf("parsing flac file: %w", err)
+		return nil, nil, nil, fmt.Errorf("parsing flac file: %w", err)
 	}
 
-	info := stream.Info
 	frames, err := readAllFrames(stream)
-
-	// Always close the file handle, regardless of readAllFrames result.
-	_ = file.Close()
-
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return info, frames, nil
+	var cover *meta.Picture
+
+	for _, blk := range stream.Blocks {
+		if blk.Type != meta.TypePicture {
+			continue
+		}
+
+		pic, ok := blk.Body.(*meta.Picture)
+		if !ok || pic.Type != frontCoverPictureType {
+			continue
+		}
+
+		cover = pic
+
+		break
+	}
+
+	return stream.Info, frames, cover, nil
 }
 
 // buildVorbisCommentBlock returns a FLAC metadata block with ALBUM, ARTIST, TITLE, and TRACKNUMBER
@@ -476,9 +511,57 @@ func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack) *meta.Block {
 	}
 
 	return &meta.Block{
-		Header: meta.Header{Type: meta.TypeVorbisComment, Length: 1, IsLast: false},
+		Header: meta.Header{Type: meta.TypeVorbisComment, Length: 1},
 		Body:   comment,
 	}
+}
+
+// buildTrackMetadataBlocks returns metadata blocks for a split track: VorbisComment
+// (when cue/track are set) and optionally the front-cover Picture. The last block
+// has IsLast set so the FLAC encoder writes the metadata block chain correctly.
+func buildTrackMetadataBlocks(cue *CueSheet, track *CueTrack, coverPicture *meta.Picture) []*meta.Block {
+	var blocks []*meta.Block
+
+	if cue != nil && track != nil {
+		blocks = append(blocks, buildVorbisCommentBlock(cue, track))
+	}
+
+	if coverPicture != nil {
+		blocks = append(blocks, &meta.Block{
+			Header: meta.Header{Type: meta.TypePicture, Length: 1, IsLast: false},
+			Body:   coverPicture,
+		})
+	}
+
+	if len(blocks) > 0 {
+		blocks[len(blocks)-1].IsLast = true
+	}
+
+	return blocks
+}
+
+// writeCoverToFile writes the front-cover picture data to a file in outputDir.
+// The filename is chosen from the picture's MIME type: cover.png for image/png,
+// cover.jpg for image/jpeg, otherwise cover.bin.
+func writeCoverToFile(outputDir string, pic *meta.Picture, fileMode os.FileMode) (string, error) {
+	ext := "bin"
+
+	switch {
+	case strings.EqualFold(pic.MIME, "image/png"):
+		ext = "png"
+	case strings.EqualFold(pic.MIME, "image/jpeg"), strings.EqualFold(pic.MIME, "image/jpg"):
+		ext = "jpg"
+	}
+
+	name := "cover." + ext
+	path := filepath.Join(outputDir, name)
+
+	err := os.WriteFile(path, pic.Data, fileMode)
+	if err != nil {
+		return "", fmt.Errorf("writing cover to file: %w", err)
+	}
+
+	return path, nil
 }
 
 // readAllFrames reads all audio frames from a FLAC stream.

--- a/cue.go
+++ b/cue.go
@@ -2,6 +2,8 @@ package xtractr
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -10,11 +12,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/mewkiz/flac"
 	"github.com/mewkiz/flac/frame"
 	"github.com/mewkiz/flac/meta"
 )
+
+// ErrUTF16LengthInvalid is returned when the length of a UTF-16 encoded byte slice is not even.
+var ErrUTF16LengthInvalid = errors.New("invalid UTF-16 length")
 
 // CueSheet represents a parsed CUE sheet.
 type CueSheet struct {
@@ -74,9 +81,10 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 
 	// Resolve the audio file path relative to the CUE file.
 	// Some CUE sheets say FILE "album.wav" WAVE but the file on disk is album.flac; try .flac when .wav is missing.
+	// If the FILE line still does not match (e.g. O vs Ö), try the FLAC with the same base name as the CUE file.
 	cueDir := filepath.Dir(xFile.FilePath)
 
-	audioPath, err := resolveCueAudioPath(cueDir, cue.File)
+	audioPath, err := resolveCueAudioPath(cueDir, cue.File, xFile.FilePath)
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -113,14 +121,80 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 }
 
 // parseCueSheetFile parses a CUE sheet from a file path and returns the sheet plus raw timestamps.
+// It supports UTF-8, UTF-8 with BOM, and UTF-16 (LE/BE with BOM) encoded CUE files.
+// TL;dr Some CUE sheets really suck.
+//
+//nolint:cyclop // tell me about it.
 func parseCueSheetFile(path string) (*CueSheet, []cueTimestamp, error) {
-	file, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening cue sheet: %w", err)
 	}
-	defer file.Close()
 
-	return parseCueSheet(file)
+	// Detect BOM and decode to UTF-8 so the scanner sees valid text.
+	// UTF-16 LE file has BOM bytes FF FE -> LittleEndian 0xFEFF.
+	// UTF-16 BE file has BOM bytes FE FF -> LittleEndian 0xFFFE.
+	const (
+		utf16LEBOM = 0xFEFF
+		utf16BEBOM = 0xFFFE
+	)
+
+	var reader io.Reader
+
+	if len(data) > 1 {
+		switch bom := binary.LittleEndian.Uint16(data[:2]); bom {
+		case utf16LEBOM:
+			// UTF-16 little-endian; decode data[2:] as LE.
+			decoded, errDec := decodeUTF16(data[2:], binary.LittleEndian)
+			if errDec != nil {
+				return nil, nil, fmt.Errorf("decoding UTF-16 LE cue sheet: %w", errDec)
+			}
+
+			reader = bytes.NewReader(decoded)
+		case utf16BEBOM:
+			// UTF-16 big-endian; decode data[2:] as BE.
+			decoded, errDec := decodeUTF16(data[2:], binary.BigEndian)
+			if errDec != nil {
+				return nil, nil, fmt.Errorf("decoding UTF-16 BE cue sheet: %w", errDec)
+			}
+
+			reader = bytes.NewReader(decoded)
+		}
+	}
+
+	if reader == nil {
+		// No UTF-16 BOM; strip UTF-8 BOM if present.
+		if len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF {
+			data = data[3:]
+		}
+
+		reader = bytes.NewReader(data)
+	}
+
+	return parseCueSheet(reader)
+}
+
+// decodeUTF16 decodes a UTF-16 encoded byte slice to UTF-8.
+//
+//nolint:mnd
+func decodeUTF16(data []byte, order binary.ByteOrder) ([]byte, error) {
+	if len(data)%2 != 0 {
+		return nil, fmt.Errorf("%w: %d", ErrUTF16LengthInvalid, len(data))
+	}
+
+	u16 := make([]uint16, len(data)/2)
+	for i := range u16 {
+		u16[i] = order.Uint16(data[2*i:])
+	}
+
+	runes := utf16.Decode(u16)
+	// Encode runes to UTF-8.
+	buf := make([]byte, 0, len(runes)*utf8.UTFMax)
+	for _, r := range runes {
+		buf = utf8.AppendRune(buf, r)
+	}
+
+	return buf, nil
 }
 
 // parseCueSheet parses a CUE sheet from an io.Reader.
@@ -224,7 +298,9 @@ func parseCueSheet(reader io.Reader) (*CueSheet, []cueTimestamp, error) { //noli
 
 // resolveCueAudioPath returns the path to the audio file referenced by the CUE.
 // If the CUE says FILE "album.wav" but the file on disk is album.flac, the .flac path is returned.
-func resolveCueAudioPath(cueDir, cueFile string) (string, error) {
+// If the FILE line does not match any file (e.g. encoding or O vs Ö), it tries the FLAC with the same
+// base name as the CUE file (e.g. Artist - Album.cue -> Artist - Album.flac).
+func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 	path := filepath.Join(cueDir, cueFile)
 
 	_, err := os.Stat(path)
@@ -240,6 +316,15 @@ func resolveCueAudioPath(cueDir, cueFile string) (string, error) {
 		if err == nil {
 			return flacPath, nil
 		}
+	}
+
+	// Fallback: try the FLAC with the same base name as the CUE file (handles O vs Ö, encoding mismatches).
+	baseNoExt := strings.TrimSuffix(filepath.Base(cueFilePath), filepath.Ext(cueFilePath))
+	fallbackPath := filepath.Join(cueDir, baseNoExt+".flac")
+
+	_, err = os.Stat(fallbackPath)
+	if err == nil {
+		return fallbackPath, nil
 	}
 
 	return "", fmt.Errorf("%w: %s", ErrAudioNotFound, path)
@@ -859,7 +944,14 @@ func formatTrackFilename(track *CueTrack) string {
 }
 
 // sanitizeFilename removes or replaces characters that are problematic in filenames.
+// It normalizes smart/curly quotes to ASCII so tools like Lidarr can find files reliably.
 func sanitizeFilename(name string) string {
+	// Normalize smart quotes and curly quotes to ASCII (fixes Lidarr "could not find file" when CUE has U+2019 etc).
+	name = strings.ReplaceAll(name, "\u2018", "'")  // LEFT SINGLE QUOTATION MARK
+	name = strings.ReplaceAll(name, "\u2019", "'")  // RIGHT SINGLE QUOTATION MARK
+	name = strings.ReplaceAll(name, "\u201C", "\"") // LEFT DOUBLE QUOTATION MARK
+	name = strings.ReplaceAll(name, "\u201D", "\"") // RIGHT DOUBLE QUOTATION MARK
+	// Remove other characters that are problematic in filenames or for downstream tools.
 	replacer := strings.NewReplacer(
 		"/", "-",
 		"\\", "-",
@@ -871,6 +963,19 @@ func sanitizeFilename(name string) string {
 		">", "",
 		"|", "",
 	)
+	name = replacer.Replace(name)
 
-	return replacer.Replace(name)
+	// Strip control characters and Unicode replacement character.
+	var data strings.Builder
+	data.Grow(len(name))
+
+	for _, r := range name {
+		if r == '\uFFFD' || r < 32 || r == 127 {
+			continue
+		}
+
+		data.WriteRune(r)
+	}
+
+	return data.String()
 }

--- a/cue.go
+++ b/cue.go
@@ -337,6 +337,17 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 
 	defer xFile.newProgress(0, 0, len(cue.Tracks)).done()
 
+	return writeTracksFLAC(xFile, cue, allFrames, trackStarts, streamInfo, trackEnds)
+}
+
+func writeTracksFLAC(
+	xFile *XFile,
+	cue *CueSheet,
+	allFrames []flacFrame,
+	trackStarts []uint64,
+	streamInfo *meta.StreamInfo,
+	trackEnds []uint64,
+) (uint64, []string, error) {
 	var (
 		totalSize uint64
 		files     = make([]string, 0, len(cue.Tracks))
@@ -355,7 +366,12 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 		outputName := formatTrackFilename(track)
 		outputPath := filepath.Join(xFile.OutputDir, outputName)
 
-		size, err := writeTrackFLAC(outputPath, streamInfo, allFrames, startSample, endSample, xFile.FileMode)
+		var blocks []*meta.Block
+		if cue != nil && track != nil {
+			blocks = []*meta.Block{buildVorbisCommentBlock(cue, track)}
+		}
+
+		size, err := writeTrackFLAC(outputPath, streamInfo, allFrames, startSample, endSample, xFile.FileMode, blocks)
 		if err != nil {
 			return totalSize, files, fmt.Errorf("writing track %d: %w", track.Number, err)
 		}
@@ -406,6 +422,43 @@ func readFLACFile(audioPath string) (*meta.StreamInfo, []flacFrame, error) {
 	return info, frames, nil
 }
 
+// buildVorbisCommentBlock returns a FLAC metadata block with ALBUM, ARTIST, TITLE, and TRACKNUMBER
+// from the CUE sheet and track so that split files can be identified by Lidarr and other importers.
+func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack) *meta.Block {
+	artist := track.Performer
+	if artist == "" {
+		artist = cue.Performer
+	}
+
+	title := track.Title
+	if title == "" {
+		title = fmt.Sprintf("Track %d", track.Number)
+	}
+
+	tags := [][2]string{
+		{"TITLE", title},
+		{"TRACKNUMBER", strconv.Itoa(track.Number)},
+	}
+
+	if cue.Title != "" {
+		tags = append(tags, [2]string{"ALBUM", cue.Title})
+	}
+
+	if artist != "" {
+		tags = append(tags, [2]string{"ARTIST", artist})
+	}
+
+	comment := &meta.VorbisComment{
+		Vendor: "golift.io/xtractr",
+		Tags:   tags,
+	}
+
+	return &meta.Block{
+		Header: meta.Header{Type: meta.TypeVorbisComment, Length: 1, IsLast: false},
+		Body:   comment,
+	}
+}
+
 // readAllFrames reads all audio frames from a FLAC stream.
 func readAllFrames(stream *flac.Stream) ([]flacFrame, error) {
 	var (
@@ -437,12 +490,16 @@ func readAllFrames(stream *flac.Stream) ([]flacFrame, error) {
 
 // writeTrackFLAC writes a subset of FLAC frames to a new FLAC file for a single track.
 // Frames are split at sample boundaries when they span track boundaries.
+// If cue and track are non-nil, a VorbisComment metadata block is written with ALBUM (from cue Title),
+// ARTIST (from track Performer or cue Performer), TITLE (track title),
+// and TRACKNUMBER so Lidarr and others can identify the file.
 func writeTrackFLAC( //nolint:funlen
 	outputPath string,
 	srcInfo *meta.StreamInfo,
 	allFrames []flacFrame,
 	startSample, endSample uint64,
 	fileMode os.FileMode,
+	blocks []*meta.Block,
 ) (uint64, error) {
 	outFile, err := os.OpenFile(outputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileMode)
 	if err != nil {
@@ -467,7 +524,7 @@ func writeTrackFLAC( //nolint:funlen
 		NSamples:      trackSamples,
 	}
 
-	enc, err := flac.NewEncoder(outFile, trackInfo)
+	enc, err := flac.NewEncoder(outFile, trackInfo, blocks...)
 	if err != nil {
 		_ = outFile.Close()
 		return 0, fmt.Errorf("creating flac encoder: %w", err)

--- a/cue.go
+++ b/cue.go
@@ -102,6 +102,8 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 		xFile.Debugf("Copying CUE sheet to output: %s", writeErr)
 	} else {
 		files = append(files, cueDest)
+		// Mark so recursion does not try to extract this copied CUE again.
+		xFile.SkipOnRecursion = append(xFile.SkipOnRecursion, cueDest)
 	}
 
 	// The archive list includes both the CUE file and the FLAC file.
@@ -685,7 +687,7 @@ func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
 		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	err = os.WriteFile(destPath, data, fileMode)
+	err = os.WriteFile(destPath, data, fileMode) //nolint:gosec // ffs.
 	if err != nil {
 		return fmt.Errorf("writing cue sheet: %w", err)
 	}

--- a/cue.go
+++ b/cue.go
@@ -92,6 +92,18 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 		return 0, nil, nil, err
 	}
 
+	// Write the CUE sheet into the output directory so the folder is self-contained
+	// (tracks, art, and the exact split definition for archival and re-rip verification).
+	cueBase := filepath.Base(xFile.FilePath)
+	cueDest := filepath.Join(xFile.OutputDir, cueBase)
+
+	writeErr := copyCueToOutput(xFile.FilePath, cueDest, xFile.FileMode)
+	if writeErr != nil {
+		xFile.Debugf("Copying CUE sheet to output: %s", writeErr)
+	} else {
+		files = append(files, cueDest)
+	}
+
 	// The archive list includes both the CUE file and the FLAC file.
 	archives = []string{xFile.FilePath, audioPath}
 
@@ -323,15 +335,20 @@ func parseCueTime(s string) cueTimestamp {
 }
 
 // splitFLAC splits a FLAC file into individual tracks based on CUE sheet data.
+//
+//nolint:cyclop
 func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTimestamp) (uint64, []string, error) {
-	// Open, parse, and read all frames and metadata (e.g. front cover) from the FLAC file.
+	// Open, parse, and read all frames and metadata from the FLAC file.
 	// We close the stream immediately after reading to release the file handle,
 	// which is important on Windows where open handles block TempDir cleanup.
-	streamInfo, allFrames, coverPicture, err := readFLACFile(audioPath)
+	flacMeta, err := readFLACFile(audioPath)
 	if err != nil {
 		return 0, nil, err
 	}
 
+	streamInfo := flacMeta.Info
+	allFrames := flacMeta.Frames
+	pictures := flacMeta.Pictures
 	sampleRate := streamInfo.SampleRate
 	totalSamples := streamInfo.NSamples
 
@@ -358,28 +375,30 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 	}
 
 	var (
-		coverPath string
-		writeErr  error
+		picturePaths []string
+		pictureBytes uint64
 	)
 
-	if coverPicture != nil {
-		coverPath, writeErr = writeCoverToFile(xFile.OutputDir, coverPicture, xFile.FileMode)
-		if writeErr != nil {
-			xFile.Debugf("Error writing album cover: %s", writeErr)
+	if len(pictures) > 0 {
+		picturePaths, pictureBytes, err = writePicturesToFiles(xFile.OutputDir, pictures, xFile.FileMode)
+		if err != nil {
+			xFile.Debugf("Error writing album art files: %s", err)
 		}
 
-		xFile.Debugf("Wrote album cover: %s (%d bytes)", coverPath, len(coverPicture.Data))
+		for _, p := range picturePaths {
+			xFile.Debugf("Wrote album art: %s", p)
+		}
 	}
 
 	defer xFile.newProgress(0, 0, len(cue.Tracks)).done()
 
-	totalSize, files, err := writeTracksFLAC(xFile, cue, allFrames, trackStarts, streamInfo, trackEnds, coverPicture)
+	totalSize, files, err := writeTracksFLAC(xFile, cue, allFrames, trackStarts, streamInfo, trackEnds, flacMeta)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	if coverPath != "" {
-		return totalSize + uint64(len(coverPicture.Data)), append(files, coverPath), nil
+	if len(picturePaths) > 0 {
+		return totalSize + pictureBytes, append(files, picturePaths...), nil
 	}
 
 	return totalSize, files, nil
@@ -392,7 +411,7 @@ func writeTracksFLAC(
 	trackStarts []uint64,
 	streamInfo *meta.StreamInfo,
 	trackEnds []uint64,
-	coverPicture *meta.Picture,
+	flacMeta *flacMetadata,
 ) (uint64, []string, error) {
 	var (
 		totalSize uint64
@@ -411,7 +430,7 @@ func writeTracksFLAC(
 		track := &cue.Tracks[trackIdx]
 		outputName := formatTrackFilename(track)
 		outputPath := filepath.Join(xFile.OutputDir, outputName)
-		blocks := buildTrackMetadataBlocks(cue, track, coverPicture)
+		blocks := buildTrackMetadataBlocks(cue, track, flacMeta)
 
 		size, err := writeTrackFLAC(outputPath, streamInfo, allFrames, startSample, endSample, xFile.FileMode, blocks)
 		if err != nil {
@@ -434,54 +453,88 @@ type flacFrame struct {
 	sampleEnd   uint64
 }
 
-// frontCoverPictureType is the FLAC/ID3v2 APIC picture type for "Cover (front)".
-const frontCoverPictureType = 3
+// flacMetadata holds metadata read from a FLAC file for use when splitting by CUE.
+type flacMetadata struct {
+	Info          *meta.StreamInfo
+	Frames        []flacFrame
+	Pictures      []*meta.Picture
+	VorbisComment *meta.VorbisComment // source tags to merge into each track (GENRE, DATE, etc.)
+	OtherBlocks   []*meta.Block       // Application, CueSheet — copied into each track
+}
 
 // readFLACFile opens a FLAC file, parses metadata and all frames, and closes the file.
-// It returns the stream info, frames, and the first front-cover picture block if present.
-// We use flac.Parse (not flac.New) so metadata blocks (e.g. Picture) are available.
+// It returns stream info, frames, all pictures, the source VorbisComment (for tag merging),
+// and Application/CueSheet blocks to copy into each split track.
+// We use flac.Parse (not flac.New) so metadata blocks are available.
 // We open and close the os.File ourselves so the underlying file handle is released
 // (important on Windows where open handles block TempDir cleanup).
-func readFLACFile(audioPath string) (*meta.StreamInfo, []flacFrame, *meta.Picture, error) {
+func readFLACFile(audioPath string) (*flacMetadata, error) { //nolint:cyclop // it could be worse.
 	file, err := os.Open(audioPath)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("opening flac file: %w", err)
+		return nil, fmt.Errorf("opening flac file: %w", err)
 	}
 	defer file.Close()
 
 	stream, err := flac.Parse(file)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("parsing flac file: %w", err)
+		return nil, fmt.Errorf("parsing flac file: %w", err)
 	}
 
 	frames, err := readAllFrames(stream)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	var cover *meta.Picture
+	flacMeta := &flacMetadata{
+		Info:   stream.Info,
+		Frames: frames,
+	}
 
 	for _, blk := range stream.Blocks {
-		if blk.Type != meta.TypePicture {
-			continue
+		switch blk.Type { //nolint:exhaustive // we do not need them all here.
+		case meta.TypePicture:
+			if pic, ok := blk.Body.(*meta.Picture); ok {
+				flacMeta.Pictures = append(flacMeta.Pictures, pic)
+			}
+		case meta.TypeVorbisComment:
+			if flacMeta.VorbisComment == nil && blk.Body != nil {
+				if vc, ok := blk.Body.(*meta.VorbisComment); ok {
+					flacMeta.VorbisComment = vc
+				}
+			}
+		case meta.TypeApplication, meta.TypeCueSheet:
+			// Copy Application (e.g. reference libFLAC) and CueSheet (CD TOC) into each track.
+			flacMeta.OtherBlocks = append(flacMeta.OtherBlocks, blk)
 		}
-
-		pic, ok := blk.Body.(*meta.Picture)
-		if !ok || pic.Type != frontCoverPictureType {
-			continue
-		}
-
-		cover = pic
-
-		break
 	}
 
-	return stream.Info, frames, cover, nil
+	return flacMeta, nil
 }
 
-// buildVorbisCommentBlock returns a FLAC metadata block with ALBUM, ARTIST, TITLE, and TRACKNUMBER
-// from the CUE sheet and track so that split files can be identified by Lidarr and other importers.
-func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack) *meta.Block {
+// vorbisTagsFromCUE are tag keys we set from the CUE sheet; we do not overwrite these from source.
+func vorbisTagsFromCUE() map[string]bool {
+	return map[string]bool{
+		"ALBUM": true, "ARTIST": true, "TITLE": true, "TRACKNUMBER": true,
+	}
+}
+
+// vorbisTagsToMergeFromSource are tag keys we copy from the source FLAC when present
+// (genre, date, album artist, etc.) so split tracks retain full metadata.
+func vorbisTagsToMergeFromSource() map[string]bool {
+	return map[string]bool{
+		"ALBUMARTIST": true, "GENRE": true, "DATE": true, "COMMENT": true,
+		"COMPOSER": true, "DISCNUMBER": true, "DISCTOTAL": true, "BPM": true,
+		"LABEL": true, "CATALOG": true, "ISRC": true, "PUBLISHER": true,
+		"COPYRIGHT": true, "DESCRIPTION": true, "ENCODED-BY": true,
+	}
+}
+
+// buildVorbisCommentBlock returns a FLAC metadata block with ALBUM, ARTIST, TITLE, TRACKNUMBER
+// from the CUE sheet and track, and merges in source FLAC tags (GENRE, DATE, ALBUMARTIST, etc.)
+// when present so split tracks retain full metadata for players and libraries.
+//
+//nolint:cyclop
+func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack, sourceVorbis *meta.VorbisComment) *meta.Block {
 	artist := track.Performer
 	if artist == "" {
 		artist = cue.Performer
@@ -496,13 +549,32 @@ func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack) *meta.Block {
 		{"TITLE", title},
 		{"TRACKNUMBER", strconv.Itoa(track.Number)},
 	}
-
 	if cue.Title != "" {
 		tags = append(tags, [2]string{"ALBUM", cue.Title})
 	}
 
 	if artist != "" {
 		tags = append(tags, [2]string{"ARTIST", artist})
+	}
+
+	haveKey := map[string]bool{}
+	for _, pair := range tags {
+		haveKey[strings.ToUpper(pair[0])] = true
+	}
+
+	// Copy source VorbisComment tags that are not in the CUE sheet.
+	if sourceVorbis != nil {
+		for _, pair := range sourceVorbis.Tags {
+			tagKey := strings.ToUpper(pair[0])
+			if vorbisTagsFromCUE()[tagKey] || haveKey[tagKey] {
+				continue
+			}
+
+			if vorbisTagsToMergeFromSource()[tagKey] {
+				tags = append(tags, [2]string{pair[0], pair[1]})
+				haveKey[tagKey] = true
+			}
+		}
 	}
 
 	comment := &meta.VorbisComment{
@@ -516,20 +588,28 @@ func buildVorbisCommentBlock(cue *CueSheet, track *CueTrack) *meta.Block {
 	}
 }
 
-// buildTrackMetadataBlocks returns metadata blocks for a split track: VorbisComment
-// (when cue/track are set) and optionally the front-cover Picture. The last block
-// has IsLast set so the FLAC encoder writes the metadata block chain correctly.
-func buildTrackMetadataBlocks(cue *CueSheet, track *CueTrack, coverPicture *meta.Picture) []*meta.Block {
-	var blocks []*meta.Block
+// buildTrackMetadataBlocks returns metadata blocks for a split track: merged VorbisComment,
+// copied Application/CueSheet blocks (if any), and all Picture blocks. The last block has
+// IsLast set so the FLAC encoder writes the metadata block chain correctly.
+func buildTrackMetadataBlocks(cue *CueSheet, track *CueTrack, flacMeta *flacMetadata) []*meta.Block {
+	blocks := make([]*meta.Block, 0, len(flacMeta.OtherBlocks)+len(flacMeta.Pictures)+1)
 
 	if cue != nil && track != nil {
-		blocks = append(blocks, buildVorbisCommentBlock(cue, track))
+		blocks = append(blocks, buildVorbisCommentBlock(cue, track, flacMeta.VorbisComment))
 	}
 
-	if coverPicture != nil {
+	for _, blk := range flacMeta.OtherBlocks {
+		// Copy block with IsLast false; encoder will see more blocks after.
+		blocks = append(blocks, &meta.Block{
+			Header: meta.Header{Type: blk.Type, Length: blk.Length, IsLast: false},
+			Body:   blk.Body,
+		})
+	}
+
+	for _, pic := range flacMeta.Pictures {
 		blocks = append(blocks, &meta.Block{
 			Header: meta.Header{Type: meta.TypePicture, Length: 1, IsLast: false},
-			Body:   coverPicture,
+			Body:   pic,
 		})
 	}
 
@@ -540,28 +620,77 @@ func buildTrackMetadataBlocks(cue *CueSheet, track *CueTrack, coverPicture *meta
 	return blocks
 }
 
-// writeCoverToFile writes the front-cover picture data to a file in outputDir.
-// The filename is chosen from the picture's MIME type: cover.png for image/png,
-// cover.jpg for image/jpeg, otherwise cover.bin.
-func writeCoverToFile(outputDir string, pic *meta.Picture, fileMode os.FileMode) (string, error) {
-	ext := "bin"
+// pictureTypeNames maps FLAC/ID3v2 APIC picture types to short basenames for files.
+// Type 3 (front cover) uses "cover" so the main art file stays cover.png/jpg.
+func pictureTypeNames() map[uint32]string {
+	return map[uint32]string{
+		0: "other", 1: "file_icon", 2: "file_icon_other", 3: "cover", 4: "cover_back",
+		5: "leaflet", 6: "media", 7: "lead_artist", 8: "artist", 9: "conductor",
+		10: "band", 11: "composer", 12: "lyricist", 13: "recording_location",
+		14: "during_recording", 15: "during_performance", 16: "movie", 17: "fish",
+		18: "illustration", 19: "band_logo", 20: "publisher_logo",
+	}
+}
 
-	switch {
-	case strings.EqualFold(pic.MIME, "image/png"):
-		ext = "png"
-	case strings.EqualFold(pic.MIME, "image/jpeg"), strings.EqualFold(pic.MIME, "image/jpg"):
-		ext = "jpg"
+// writePicturesToFiles writes all picture blocks to files in outputDir. Front cover
+// (type 3) is named cover.<ext>; others use the picture type (e.g. cover_back.png).
+// Returns written paths, total bytes written, and any error from the first failed write.
+func writePicturesToFiles(outputDir string, pictures []*meta.Picture, fileMode os.FileMode) ([]string, uint64, error) {
+	typeCount := make(map[string]int)
+	paths := make([]string, 0, len(pictures))
+	totalBytes := uint64(0)
+
+	for _, pic := range pictures {
+		ext := "bin"
+
+		switch {
+		case strings.EqualFold(pic.MIME, "image/png"):
+			ext = "png"
+		case strings.EqualFold(pic.MIME, "image/jpeg"), strings.EqualFold(pic.MIME, "image/jpg"):
+			ext = "jpg"
+		}
+
+		base := pictureTypeNames()[pic.Type]
+		if base == "" {
+			base = "image_" + strconv.FormatUint(uint64(pic.Type), 10)
+		}
+
+		typeCount[base]++
+		name := base
+
+		if typeCount[base] > 1 {
+			name = base + "_" + strconv.Itoa(typeCount[base])
+		}
+
+		name += "." + ext
+		path := filepath.Join(outputDir, name)
+
+		err := os.WriteFile(path, pic.Data, fileMode)
+		if err != nil {
+			return paths, totalBytes, fmt.Errorf("writing %s: %w", name, err)
+		}
+
+		paths = append(paths, path)
+		totalBytes += uint64(len(pic.Data))
 	}
 
-	name := "cover." + ext
-	path := filepath.Join(outputDir, name)
+	return paths, totalBytes, nil
+}
 
-	err := os.WriteFile(path, pic.Data, fileMode)
+// copyCueToOutput copies the CUE sheet file into the output directory so the
+// extracted folder contains tracks, album art, and the CUE for verification/archival.
+func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
+	data, err := os.ReadFile(srcPath)
 	if err != nil {
-		return "", fmt.Errorf("writing cover to file: %w", err)
+		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	return path, nil
+	err = os.WriteFile(destPath, data, fileMode)
+	if err != nil {
+		return fmt.Errorf("writing cue sheet: %w", err)
+	}
+
+	return nil
 }
 
 // readAllFrames reads all audio frames from a FLAC stream.
@@ -611,8 +740,6 @@ func writeTrackFLAC( //nolint:funlen
 		return 0, fmt.Errorf("creating output flac file: %w", err)
 	}
 
-	trackSamples := endSample - startSample
-
 	// Create a new StreamInfo for this track.
 	// BlockSizeMin/Max will be rewritten by the encoder on Close().
 	// FrameSizeMin/Max are set to 0 (unknown) because the mewkiz encoder does
@@ -626,7 +753,7 @@ func writeTrackFLAC( //nolint:funlen
 		SampleRate:    srcInfo.SampleRate,
 		NChannels:     srcInfo.NChannels,
 		BitsPerSample: srcInfo.BitsPerSample,
-		NSamples:      trackSamples,
+		NSamples:      endSample - startSample,
 	}
 
 	enc, err := flac.NewEncoder(outFile, trackInfo, blocks...)

--- a/cue_test.go
+++ b/cue_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/mewkiz/flac"
 	"github.com/mewkiz/flac/frame"
@@ -478,6 +479,85 @@ func TestCueWavReferenceFlacFile(t *testing.T) {
 	assert.Contains(t, archiveList, flacPath)
 }
 
+// TestCueFallbackSameBasename verifies that when the FILE line does not match any file
+// (e.g. O vs Ö or encoding mismatch), we use the FLAC with the same base name as the CUE file.
+func TestCueFallbackSameBasename(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(60 * testSampleRate)
+	// FLAC on disk has same base name as CUE, but CUE FILE line references a different name.
+	flacPath := filepath.Join(tmpDir, "Album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "Other Name.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track Two"`,
+		`    INDEX 01 00:30:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "Album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE should find Album.flac via same-basename fallback")
+	assert.Len(t, files, 3)
+	assert.Len(t, archiveList, 2)
+	assert.Positive(t, size)
+	assert.Contains(t, archiveList, flacPath)
+}
+
+// TestCueUTF16LE verifies that a CUE file encoded as UTF-16 LE with BOM is parsed correctly.
+func TestCueUTF16LE(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+	//nolint:lll // it's ok.
+	cueContent := "PERFORMER \"Artist\"\r\nTITLE \"Album\"\r\nFILE \"album.flac\" WAVE\r\n  TRACK 01 AUDIO\r\n    TITLE \"Track One\"\r\n    INDEX 01 00:00:00\r\n"
+	// Encode as UTF-16 LE with BOM (common for CUE sheets from Windows).
+	u16 := utf16.Encode([]rune(cueContent))
+	buf := make([]byte, 0, 2+len(u16)*2)
+
+	buf = append(buf, 0xFF, 0xFE)
+	for _, v := range u16 {
+		buf = append(buf, byte(v), byte(v>>8))
+	}
+
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, buf, 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "UTF-16 LE CUE should parse and extract")
+	assert.Positive(t, size)
+	assert.Len(t, files, 2, "expected 1 track + CUE sheet")
+}
+
 func TestCueTimestampConversion(t *testing.T) {
 	t.Parallel()
 
@@ -569,6 +649,43 @@ func TestCueSpecialCharacters(t *testing.T) {
 
 	assert.Equal(t, "01 - Song With - Slash.flac", filepath.Base(files[0]))
 	assert.Equal(t, "02 - Song- With Special Chars.flac", filepath.Base(files[1]))
+}
+
+// TestCueSmartQuoteInTitle verifies that track titles with Unicode smart quote (U+2019)
+// are sanitized to ASCII apostrophe in output filenames so tools like Lidarr can find files.
+func TestCueSmartQuoteInTitle(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	// U+2019 is RIGHT SINGLE QUOTATION MARK (curly apostrophe), often from CUE sheets.
+	cueContent := strings.Join([]string{
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "It's Hard to Find a Way"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	// Replace straight apostrophe with U+2019 in the CUE content.
+	cueContent = strings.ReplaceAll(cueContent, "It's", "It\u2019s")
+	cuePath := filepath.Join(tmpDir, "test.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	_, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err)
+	// Output filename must use ASCII apostrophe so Lidarr can find the file.
+	assert.Equal(t, "01 - It's Hard to Find a Way.flac", filepath.Base(files[0]))
 }
 
 func TestCueREMComments(t *testing.T) {

--- a/cue_test.go
+++ b/cue_test.go
@@ -295,6 +295,48 @@ func TestCueUnsupportedFormat(t *testing.T) {
 	assert.ErrorIs(t, err, xtractr.ErrUnsupportedAudio)
 }
 
+// TestCueWavReferenceFlacFile verifies that when the CUE says FILE "album.wav" WAVE
+// but only album.flac exists on disk, we use the .flac file (common mislabeling).
+func TestCueWavReferenceFlacFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+	// CUE references .wav but we only have .flac
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "album.wav" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track Two"`,
+		`    INDEX 01 00:30:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE with CUE referencing .wav but .flac on disk")
+	assert.Len(t, files, 2)
+	assert.Len(t, archiveList, 2)
+	assert.Positive(t, size)
+	// Archive list should include the actual flac path we used, not the .wav path
+	assert.Contains(t, archiveList, flacPath)
+}
+
 func TestCueTimestampConversion(t *testing.T) {
 	t.Parallel()
 

--- a/cue_test.go
+++ b/cue_test.go
@@ -26,27 +26,12 @@ const (
 	testBlockSize     = 4096
 )
 
-// generateTestFLAC creates a FLAC file with a sine wave tone at the given path.
-func generateTestFLAC(t *testing.T, path string, totalSamples uint64) {
+// writeTestFLACAudioFrames writes sine-wave audio frames to a FLAC encoder.
+// Callers must call enc.Close() after this returns.
+func writeTestFLACAudioFrames(t *testing.T, enc *flac.Encoder, totalSamples uint64) {
 	t.Helper()
 
-	outFile, err := os.Create(path)
-	require.NoError(t, err, "creating test FLAC file")
-
-	info := &meta.StreamInfo{
-		BlockSizeMin:  testBlockSize,
-		BlockSizeMax:  testBlockSize,
-		SampleRate:    testSampleRate,
-		NChannels:     testNChannels,
-		BitsPerSample: testBitsPerSample,
-		NSamples:      totalSamples,
-	}
-
-	enc, err := flac.NewEncoder(outFile, info)
-	require.NoError(t, err, "creating FLAC encoder")
-
 	samplesWritten := uint64(0)
-
 	for samplesWritten < totalSamples {
 		blockSize := uint64(testBlockSize)
 		if samplesWritten+blockSize > totalSamples {
@@ -95,8 +80,84 @@ func generateTestFLAC(t *testing.T, path string, totalSamples uint64) {
 
 		samplesWritten += blockSize
 	}
+}
+
+// generateTestFLAC creates a FLAC file with a sine wave tone at the given path.
+func generateTestFLAC(t *testing.T, path string, totalSamples uint64) {
+	t.Helper()
+
+	outFile, err := os.Create(path)
+	require.NoError(t, err, "creating test FLAC file")
+
+	info := &meta.StreamInfo{
+		BlockSizeMin:  testBlockSize,
+		BlockSizeMax:  testBlockSize,
+		SampleRate:    testSampleRate,
+		NChannels:     testNChannels,
+		BitsPerSample: testBitsPerSample,
+		NSamples:      totalSamples,
+	}
+
+	enc, err := flac.NewEncoder(outFile, info)
+	require.NoError(t, err, "creating FLAC encoder")
+
+	writeTestFLACAudioFrames(t, enc, totalSamples)
 
 	// enc.Close() also closes the underlying outFile via io.Closer.
+	require.NoError(t, enc.Close(), "closing FLAC encoder")
+}
+
+// minimalPNG is a valid 1x1 black pixel PNG (67 bytes) for embedding as front cover in tests.
+func minimalPNG(t *testing.T) []byte {
+	t.Helper()
+
+	return []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x37, 0x6E, 0xF9,
+		0x24, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x01, 0x63, 0x60, 0x00, 0x00, 0x00,
+		0x02, 0x00, 0x01, 0x73, 0x75, 0x01, 0x18, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+		0x42, 0x60, 0x82,
+	}
+}
+
+// generateTestFLACWithCover creates a FLAC file with an embedded front-cover picture
+// and the same sine-wave audio as generateTestFLAC. Used to test that CUE split
+// copies the cover into each track.
+func generateTestFLACWithCover(t *testing.T, path string, totalSamples uint64) {
+	t.Helper()
+
+	outFile, err := os.Create(path)
+	require.NoError(t, err, "creating test FLAC file with cover")
+
+	info := &meta.StreamInfo{
+		BlockSizeMin:  testBlockSize,
+		BlockSizeMax:  testBlockSize,
+		SampleRate:    testSampleRate,
+		NChannels:     testNChannels,
+		BitsPerSample: testBitsPerSample,
+		NSamples:      totalSamples,
+	}
+
+	coverBlock := &meta.Block{
+		Header: meta.Header{Type: meta.TypePicture, Length: 1, IsLast: true},
+		Body: &meta.Picture{
+			Type:  3, // Cover (front)
+			MIME:  "image/png",
+			Desc:  "cover",
+			Width: 1, Height: 1, Depth: 8, NPalColors: 0,
+			Data: minimalPNG(t),
+		},
+	}
+
+	enc, err := flac.NewEncoder(outFile, info, coverBlock)
+	require.NoError(t, err, "creating FLAC encoder with cover")
+
+	writeTestFLACAudioFrames(t, enc, totalSamples)
+
 	require.NoError(t, enc.Close(), "closing FLAC encoder")
 }
 
@@ -198,6 +259,86 @@ func TestCueExtractCUE(t *testing.T) {
 		assert.Equal(t, "Test Artist", tagMap["ARTIST"], "ARTIST tag from CUE PERFORMER")
 		assert.Equal(t, expectedTitles[idx], tagMap["TITLE"], "TITLE tag from track")
 		assert.Equal(t, strconv.Itoa(idx+1), tagMap["TRACKNUMBER"], "TRACKNUMBER")
+		require.NoError(t, trackFile.Close())
+	}
+}
+
+func TestCueExtractCUE_SplitFLAC_EmbeddedCover(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(2 * 60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLACWithCover(t, flacPath, totalSamples)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Cover Artist"`,
+		`TITLE "Cover Album"`,
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track A"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track B"`,
+		`    INDEX 01 01:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	_, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "extracting CUE+FLAC with cover")
+
+	require.Len(t, files, 3, "expected 2 track files + cover.png")
+	assert.Contains(t, files, filepath.Join(outputDir, "cover.png"), "cover.png should be in extracted file list")
+
+	// Album cover should be written to cover.png in the output directory.
+	coverPath := filepath.Join(outputDir, "cover.png")
+	coverData, err := os.ReadFile(coverPath)
+	require.NoError(t, err, "reading cover.png")
+	assert.Equal(t, minimalPNG(t), coverData, "cover.png should match embedded image")
+
+	for _, trackPath := range files {
+		if filepath.Ext(trackPath) != ".flac" {
+			continue
+		}
+
+		trackFile, err := os.Open(trackPath)
+		require.NoError(t, err, "opening track: %s", trackPath)
+		stream, err := flac.Parse(trackFile)
+		require.NoError(t, err, "parsing track: %s", trackPath)
+
+		var frontCover *meta.Picture
+
+		for _, blk := range stream.Blocks {
+			if blk.Type != meta.TypePicture {
+				continue
+			}
+
+			pic, ok := blk.Body.(*meta.Picture)
+			if !ok {
+				continue
+			}
+
+			if pic.Type == 3 {
+				frontCover = pic
+				break
+			}
+		}
+
+		require.NotNil(t, frontCover, "track %s should have front-cover Picture block", trackPath)
+		assert.Equal(t, "image/png", frontCover.MIME, "cover MIME")
+		assert.Equal(t, uint32(1), frontCover.Width, "cover width")
+		assert.Equal(t, uint32(1), frontCover.Height, "cover height")
+		assert.Equal(t, minimalPNG(t), frontCover.Data, "cover image data should match source")
 		require.NoError(t, trackFile.Close())
 	}
 }

--- a/cue_test.go
+++ b/cue_test.go
@@ -216,7 +216,7 @@ func TestCueExtractCUE(t *testing.T) {
 	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err, "extracting CUE+FLAC")
 
-	assert.Len(t, files, 3, "expected 3 extracted track files")
+	assert.Len(t, files, 4, "expected 3 track files + CUE sheet")
 	assert.Positive(t, size, "total size should be > 0")
 	assert.Len(t, archiveList, 2, "archive list should contain cue and flac files")
 	assert.Contains(t, archiveList, cuePath)
@@ -297,7 +297,7 @@ func TestCueExtractCUE_SplitFLAC_EmbeddedCover(t *testing.T) {
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err, "extracting CUE+FLAC with cover")
 
-	require.Len(t, files, 3, "expected 2 track files + cover.png")
+	require.Len(t, files, 4, "expected 2 track files + cover.png + CUE sheet")
 	assert.Contains(t, files, filepath.Join(outputDir, "cover.png"), "cover.png should be in extracted file list")
 
 	// Album cover should be written to cover.png in the output directory.
@@ -376,7 +376,7 @@ func TestCueExtractViaExtractFile(t *testing.T) {
 
 	size, files, archiveList, err := xtractr.ExtractFile(xFile)
 	require.NoError(t, err, "ExtractFile with .cue")
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
 	assert.Len(t, archiveList, 2)
 	assert.Positive(t, size)
 }
@@ -471,7 +471,7 @@ func TestCueWavReferenceFlacFile(t *testing.T) {
 
 	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err, "ExtractCUE with CUE referencing .wav but .flac on disk")
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
 	assert.Len(t, archiveList, 2)
 	assert.Positive(t, size)
 	// Archive list should include the actual flac path we used, not the .wav path
@@ -509,7 +509,7 @@ func TestCueTimestampConversion(t *testing.T) {
 
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
 
 	file1, err := os.Open(files[0])
 	require.NoError(t, err)
@@ -565,7 +565,7 @@ func TestCueSpecialCharacters(t *testing.T) {
 
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
 
 	assert.Equal(t, "01 - Song With - Slash.flac", filepath.Base(files[0]))
 	assert.Equal(t, "02 - Song- With Special Chars.flac", filepath.Base(files[1]))
@@ -604,7 +604,7 @@ func TestCueREMComments(t *testing.T) {
 
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err)
-	assert.Len(t, files, 1)
+	assert.Len(t, files, 2, "expected 1 track file + CUE sheet")
 }
 
 // TestCueVariableBlockSizeConsistency verifies that all frames in every split
@@ -650,9 +650,13 @@ func TestCueVariableBlockSizeConsistency(t *testing.T) {
 
 	_, files, _, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err)
-	require.Len(t, files, 2)
+	require.Len(t, files, 3, "expected 2 track files + CUE sheet")
 
 	for _, trackPath := range files {
+		if filepath.Ext(trackPath) != ".flac" {
+			continue
+		}
+
 		trackFile, err := os.Open(trackPath)
 		require.NoError(t, err, "opening track: %s", trackPath)
 
@@ -752,11 +756,15 @@ func TestCueSplitRealFLAC(t *testing.T) {
 
 	size, files, archiveList, err := xtractr.ExtractCUE(xFile)
 	require.NoError(t, err, "ExtractCUE failed on ffmpeg-encoded FLAC")
-	require.Len(t, files, 3, "expected 3 split track files")
+	require.Len(t, files, 4, "expected 3 split track files + CUE sheet")
 	assert.Positive(t, size)
 	assert.Len(t, archiveList, 2)
 
 	for _, trackPath := range files {
+		if filepath.Ext(trackPath) != ".flac" {
+			continue
+		}
+
 		trackFile, err := os.Open(trackPath)
 		require.NoError(t, err)
 

--- a/cue_test.go
+++ b/cue_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -165,16 +166,38 @@ func TestCueExtractCUE(t *testing.T) {
 		"02 - Second Song.flac",
 		"03 - Third Song.flac",
 	}
+	expectedTitles := []string{"First Song", "Second Song", "Third Song"}
 
 	for idx, expectedName := range expectedNames {
 		assert.Equal(t, filepath.Join(outputDir, expectedName), files[idx])
 		trackFile, err := os.Open(files[idx])
 		require.NoError(t, err, "opening track FLAC file: %s", files[idx])
-		trackStream, err := flac.New(trackFile)
+		trackStream, err := flac.Parse(trackFile)
 		require.NoError(t, err, "parsing track FLAC file: %s", files[idx])
 		assert.Equal(t, uint32(testSampleRate), trackStream.Info.SampleRate)
 		assert.Equal(t, uint8(testNChannels), trackStream.Info.NChannels)
 		assert.Positive(t, trackStream.Info.NSamples, "track should have samples")
+		// Split tracks should include VorbisComment with ALBUM, ARTIST, TITLE, TRACKNUMBER for Lidarr/import.
+		var vorbis *meta.VorbisComment
+
+		for _, blk := range trackStream.Blocks {
+			if vc, ok := blk.Body.(*meta.VorbisComment); ok {
+				vorbis = vc
+				break
+			}
+		}
+
+		require.NotNil(t, vorbis, "track %s should have VorbisComment metadata", files[idx])
+
+		tagMap := make(map[string]string)
+		for _, pair := range vorbis.Tags {
+			tagMap[pair[0]] = pair[1]
+		}
+
+		assert.Equal(t, "Test Album", tagMap["ALBUM"], "ALBUM tag from CUE TITLE")
+		assert.Equal(t, "Test Artist", tagMap["ARTIST"], "ARTIST tag from CUE PERFORMER")
+		assert.Equal(t, expectedTitles[idx], tagMap["TITLE"], "TITLE tag from track")
+		assert.Equal(t, strconv.Itoa(idx+1), tagMap["TRACKNUMBER"], "TRACKNUMBER")
 		require.NoError(t, trackFile.Close())
 	}
 }

--- a/files.go
+++ b/files.go
@@ -134,6 +134,9 @@ type XFile struct {
 	// this true will cause the extracted content to be moved into the
 	// output folder, and the root folder in the archive to be removed.
 	SquashRoot bool
+	// SkipOnRecursion, if set by an extractor, lists paths that were copied into
+	// the output (e.g. a CUE sheet) and must not be re-extracted when recursing.
+	SkipOnRecursion []string
 	// Logger allows printing debug messages.
 	log       Logger
 	moveFiles func(fromPath, toPath string, overwrite bool) ([]string, error)

--- a/iso_test.go
+++ b/iso_test.go
@@ -1,6 +1,7 @@
 package xtractr_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,14 +26,19 @@ func TestIso(t *testing.T) {
 	}()
 
 	size := uint64(0)
-	walkErr := filepath.Walk(testFilesInfo.srcFilesDir, func(path string, info os.FileInfo, err error) error {
+	walkFS := os.DirFS(testFilesInfo.srcFilesDir)
+	walkErr := fs.WalkDir(walkFS, ".", func(path string, entry fs.DirEntry, err error) error {
 		require.NoError(t, err, "unexpected")
 
-		if info.IsDir() {
+		if entry.IsDir() {
 			return nil
 		}
 
-		fileToAdd, err := os.Open(path)
+		if path == "." {
+			return nil
+		}
+
+		fileToAdd, err := walkFS.Open(path)
 
 		require.NoError(t, err, "failed to open file")
 		defer safeCloser(t, fileToAdd)
@@ -42,7 +48,8 @@ func TestIso(t *testing.T) {
 
 		size += uint64(fStat.Size())
 
-		err = writer.AddFile(fileToAdd, strings.TrimPrefix(fileToAdd.Name(), testFilesInfo.srcFilesDir))
+		isoName := strings.TrimPrefix(filepath.ToSlash(path), "/")
+		err = writer.AddFile(fileToAdd, isoName)
 		require.NoError(t, err, "failed to add file")
 
 		return nil

--- a/queue.go
+++ b/queue.go
@@ -77,6 +77,9 @@ type Response struct {
 	Archives ArchiveList
 	// Files written to final path.
 	NewFiles []string
+	// SkipOnRecursion lists paths that extractors copied into output (e.g. CUE sheet)
+	// and must not be re-extracted when recursing. Other files (e.g. CUE from a RAR) are still extracted.
+	SkipOnRecursion []string
 	// Error encountered, only when done=true.
 	Error error
 	// Copied from input data.
@@ -259,6 +262,37 @@ func weExtractedAnISO(resp *Response) bool {
 	return false
 }
 
+// excludePathsFromArchiveList returns a copy of list with any archive path that
+// appears in exclude (e.g. resp.SkipOnRecursion) removed.
+func excludePathsFromArchiveList(list ArchiveList, exclude []string) ArchiveList {
+	if len(exclude) == 0 {
+		return list
+	}
+
+	skip := make(map[string]bool, len(exclude))
+	out := make(ArchiveList, len(list))
+
+	for _, p := range exclude {
+		skip[filepath.Clean(p)] = true
+	}
+
+	for dir, archives := range list {
+		keep := make([]string, 0, len(archives))
+
+		for _, p := range archives {
+			if !skip[filepath.Clean(p)] {
+				keep = append(keep, p)
+			}
+		}
+
+		if len(keep) > 0 {
+			out[dir] = keep
+		}
+	}
+
+	return out
+}
+
 // decompressFiles runs after we find and verify archives exist.
 // This extracts everything in the search path then (optionally)
 // checks the output path for more archives that were just decompressed.
@@ -277,6 +311,10 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
 	})
+	// Do not try to extract files that an extractor copied into output (e.g. CUE sheet);
+	// re-extracting the copied CUE would fail and delete the output directory.
+	// Other archives in the output (e.g. CUE+FLAC from a RAR) are still extracted.
+	resp.Extras = excludePathsFromArchiveList(resp.Extras, resp.SkipOnRecursion)
 	nre := &Response{
 		X: &Xtract{
 			Password:  resp.X.Password,
@@ -360,6 +398,10 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	if err != nil {
 		x.DeleteFiles(resp.Output) // clean up the mess after an error and bail.
 		return bytes, files, archives, WrapExtractError(err, xFile, bytes, "")
+	}
+
+	if len(xFile.SkipOnRecursion) > 0 {
+		resp.SkipOnRecursion = append(resp.SkipOnRecursion, xFile.SkipOnRecursion...)
 	}
 
 	return bytes, files, archives, nil

--- a/tar_test.go
+++ b/tar_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,29 +76,38 @@ func TestTar(t *testing.T) {
 
 func writeTar(sourceDir string, destWriter io.Writer) error {
 	tarWriter := tar.NewWriter(destWriter)
+	walkFS := os.DirFS(sourceDir)
 
-	outErr := filepath.Walk(sourceDir, func(path string, info os.FileInfo, _ error) error {
-		if info.Mode().IsDir() {
+	err := fs.WalkDir(walkFS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if entry.IsDir() {
 			return nil
 		}
 
-		relativePath := path[len(sourceDir):]
-		if relativePath == "" {
+		if path == "." {
 			return nil
 		}
 
-		fileReader, err := os.Open(path)
+		fileReader, err := walkFS.Open(path)
 		if err != nil {
 			return fmt.Errorf("failed to open file: %w", err)
 		}
 		defer fileReader.Close()
 
-		header, err := tar.FileInfoHeader(info, relativePath)
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("failed to get file info: %w", err)
+		}
+
+		header, err := tar.FileInfoHeader(info, path)
 		if err != nil {
 			return fmt.Errorf("failed to create tar header: %w", err)
 		}
 
-		header.Name = relativePath
+		header.Name = filepath.ToSlash(path)
 
 		err = tarWriter.WriteHeader(header)
 		if err != nil {
@@ -106,16 +116,16 @@ func writeTar(sourceDir string, destWriter io.Writer) error {
 
 		_, err = io.Copy(tarWriter, fileReader)
 		if err != nil {
-			return fmt.Errorf("failed to copy file (%s) into tar header: %w", fileReader.Name(), err)
+			return fmt.Errorf("failed to copy file (%s) into tar: %w", path, err)
 		}
 
 		return nil
 	})
-	if outErr == nil {
-		return nil
+	if err != nil {
+		return fmt.Errorf("failed to walk source directory: %w", err)
 	}
 
-	return fmt.Errorf("failed to walk source directory: %w", outErr)
+	return nil
 }
 
 func (c *tarCompressor) Compress(t *testing.T, sourceDir, destBase string) error {


### PR DESCRIPTION
FLAC/CUE split kinda works, but @kontel has reported a number of different issues with various cue files. We went back and forth until they were all worked out. This is the culmination of that work.

- Fixes https://github.com/Unpackerr/unpackerr/issues/141
- Adds common tags to tracks.
- Looks for .flac file if cue'd .wav file is missing.
- Copies CUE file to output folder.  Adds code to avoid recursively trying to extract it again.
- Copies ToC and Tags from source flac to destination flac files.
- Copies Application and Image blocks from source to destination files.
- Writes extracted image (photo) files to disk.
- Converts UTF16 CUE sheets to UTF8.
- Removes escape characters and other specials from written file names (cue/flac split only, but could be implemented elsewhere if needed).
- Improves ability to locate FLAC file when CUE has the wrong name.