### PR TITLE
Add APE+CUE splitting via ffmpeg convert-then-split

### DIFF
--- a/cue.go
+++ b/cue.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -71,7 +72,8 @@ func (t cueTimestamp) toSamples(sampleRate uint32) uint64 {
 	return samples
 }
 
-// ExtractCUE extracts individual tracks from a FLAC file referenced by a CUE sheet.
+// ExtractCUE extracts individual tracks from an audio file referenced by a CUE sheet.
+// FLAC files are split directly; APE files are converted to FLAC via ffmpeg first.
 // The xFile.FilePath should point to the .cue file.
 func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error) {
 	cue, timestamps, err := parseCueSheetFile(xFile.FilePath)
@@ -89,13 +91,16 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 		return 0, nil, nil, err
 	}
 
-	// Only FLAC is supported for now.
 	ext := strings.ToLower(filepath.Ext(audioPath))
-	if ext != ".flac" {
+
+	switch ext {
+	case ".flac":
+		size, files, err = splitFLAC(xFile, audioPath, cue, timestamps)
+	case ".ape":
+		size, files, err = convertAndSplitAPE(xFile, audioPath, cue, timestamps)
+	default:
 		return 0, nil, nil, fmt.Errorf("%w: %s", ErrUnsupportedAudio, ext)
 	}
-
-	size, files, err = splitFLAC(xFile, audioPath, cue, timestamps)
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -118,6 +123,56 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 	archives = []string{xFile.FilePath, audioPath}
 
 	return size, files, archives, nil
+}
+
+// convertAndSplitAPE converts an APE file to a temporary FLAC via ffmpeg,
+// then splits the FLAC using the existing splitFLAC pipeline.
+func convertAndSplitAPE(
+	xFile *XFile, apePath string, cue *CueSheet, timestamps []cueTimestamp,
+) (uint64, []string, error) {
+	flacPath, cleanup, err := convertToFLAC(apePath)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer cleanup()
+
+	xFile.Debugf("Converted APE to temporary FLAC: %s -> %s", apePath, flacPath)
+
+	return splitFLAC(xFile, flacPath, cue, timestamps)
+}
+
+// convertToFLAC converts an audio file (e.g. APE) to a temporary FLAC file using ffmpeg.
+// Returns the path to the temporary FLAC, a cleanup function to remove it, and any error.
+// The conversion uses compression level 0 for speed since the file will be split immediately.
+func convertToFLAC(audioPath string) (string, func(), error) {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: ffmpeg is required for APE splitting", ErrFFmpegNotFound)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "xtractr-ape-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	outPath := filepath.Join(tmpDir, "converted.flac")
+
+	cmd := exec.Command(ffmpegPath, //nolint:gosec // audioPath is from resolved file on disk.
+		"-i", audioPath,
+		"-c:a", "flac",
+		"-compression_level", "0",
+		"-y", outPath,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		cleanup()
+
+		return "", nil, fmt.Errorf("ffmpeg APE->FLAC conversion failed: %w\n%s", err, output)
+	}
+
+	return outPath, cleanup, nil
 }
 
 // parseCueSheetFile parses a CUE sheet from a file path and returns the sheet plus raw timestamps.
@@ -297,9 +352,10 @@ func parseCueSheet(reader io.Reader) (*CueSheet, []cueTimestamp, error) { //noli
 }
 
 // resolveCueAudioPath returns the path to the audio file referenced by the CUE.
-// If the CUE says FILE "album.wav" but the file on disk is album.flac, the .flac path is returned.
-// If the FILE line does not match any file (e.g. encoding or O vs Ö), it tries the FLAC with the same
-// base name as the CUE file (e.g. Artist - Album.cue -> Artist - Album.flac).
+// If the CUE says FILE "album.wav" but the file on disk is album.flac or album.ape,
+// it tries those extensions as fallbacks.
+// If the FILE line still does not match (e.g. encoding or O vs Ö), it tries files
+// with the same base name as the CUE file with .flac and .ape extensions.
 func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 	path := filepath.Join(cueDir, cueFile)
 
@@ -308,23 +364,32 @@ func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 		return path, nil
 	}
 
+	// Try alternate extensions when the referenced file doesn't exist.
 	ext := strings.ToLower(filepath.Ext(cueFile))
-	if ext == ".wav" {
-		flacPath := path[:len(path)-len(ext)] + ".flac"
+	basePath := path[:len(path)-len(ext)]
 
-		_, err = os.Stat(flacPath)
-		if err == nil {
-			return flacPath, nil
+	if ext == ".wav" {
+		for _, alt := range []string{".flac", ".ape"} {
+			altPath := basePath + alt
+
+			_, err = os.Stat(altPath)
+			if err == nil {
+				return altPath, nil
+			}
 		}
 	}
 
-	// Fallback: try the FLAC with the same base name as the CUE file (handles O vs Ö, encoding mismatches).
+	// Fallback: try same base name as the CUE file with supported extensions
+	// (handles O vs Ö, encoding mismatches).
 	baseNoExt := strings.TrimSuffix(filepath.Base(cueFilePath), filepath.Ext(cueFilePath))
-	fallbackPath := filepath.Join(cueDir, baseNoExt+".flac")
 
-	_, err = os.Stat(fallbackPath)
-	if err == nil {
-		return fallbackPath, nil
+	for _, alt := range []string{".flac", ".ape"} {
+		fallbackPath := filepath.Join(cueDir, baseNoExt+alt)
+
+		_, err = os.Stat(fallbackPath)
+		if err == nil {
+			return fallbackPath, nil
+		}
 	}
 
 	return "", fmt.Errorf("%w: %s", ErrAudioNotFound, path)

--- a/cue_test.go
+++ b/cue_test.go
@@ -947,3 +947,238 @@ func TestCueSupportedExtensions(t *testing.T) {
 
 	assert.True(t, found, ".cue should be in supported extensions list")
 }
+
+// TestCueAPEConvertAndSplit verifies that an APE+CUE album is converted to FLAC via ffmpeg
+// and split into individual tracks. This test requires ffmpeg on PATH; it is skipped otherwise.
+func TestCueAPEConvertAndSplit(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not found in PATH, skipping APE splitting test")
+	}
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	// Generate a test FLAC, then convert it to APE via ffmpeg to create test data.
+	totalSamples := uint64(3 * 60 * testSampleRate) // 3 minutes
+	flacPath := filepath.Join(tmpDir, "source.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	apePath := filepath.Join(tmpDir, "album.ape")
+	cmd := exec.Command("ffmpeg", "-i", flacPath, "-c:a", "ape", "-y", apePath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg FLAC->APE conversion failed: %s", output)
+
+	// Remove the source FLAC so we know the CUE handler must use the APE.
+	require.NoError(t, os.Remove(flacPath))
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "APE Test Artist"`,
+		`TITLE "APE Test Album"`,
+		`FILE "album.ape" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "First Song"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Second Song"`,
+		`    INDEX 01 01:30:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, archives, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE with APE file should succeed")
+	assert.Greater(t, size, uint64(0), "extracted size should be > 0")
+	assert.Len(t, files, 3, "should have 2 tracks + 1 CUE copy") // 2 tracks + cue
+	assert.Contains(t, archives, apePath, "archives should include the APE file")
+	assert.Contains(t, archives, cuePath, "archives should include the CUE file")
+
+	// Verify the split tracks are valid FLAC files.
+	track1Path := filepath.Join(outputDir, "01 - First Song.flac")
+	track2Path := filepath.Join(outputDir, "02 - Second Song.flac")
+	assert.FileExists(t, track1Path)
+	assert.FileExists(t, track2Path)
+
+	// Verify track 1 metadata.
+	f1, err := os.Open(track1Path)
+	require.NoError(t, err)
+
+	stream1, err := flac.Parse(f1)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(testSampleRate), stream1.Info.SampleRate)
+	require.NoError(t, f1.Close())
+
+	// Verify track 2 metadata.
+	f2, err := os.Open(track2Path)
+	require.NoError(t, err)
+
+	stream2, err := flac.Parse(f2)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(testSampleRate), stream2.Info.SampleRate)
+	require.NoError(t, f2.Close())
+
+	// Verify VorbisComment tags on track 1.
+	for _, blk := range stream1.Blocks {
+		if blk.Type == meta.TypeVorbisComment {
+			vc, ok := blk.Body.(*meta.VorbisComment)
+			require.True(t, ok)
+
+			tagMap := make(map[string]string)
+			for _, tag := range vc.Tags {
+				tagMap[strings.ToUpper(tag[0])] = tag[1]
+			}
+
+			assert.Equal(t, "APE Test Album", tagMap["ALBUM"])
+			assert.Equal(t, "APE Test Artist", tagMap["ARTIST"])
+			assert.Equal(t, "First Song", tagMap["TITLE"])
+			assert.Equal(t, "1", tagMap["TRACKNUMBER"])
+		}
+	}
+}
+
+// TestCueAPENoFFmpeg verifies that APE splitting returns ErrFFmpegNotFound
+// when ffmpeg is not available.
+func TestCueAPENoFFmpeg(t *testing.T) {
+	t.Parallel()
+
+	// This test manipulates PATH to hide ffmpeg. Skip if ffmpeg isn't even installed
+	// (the error path would be different).
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed, cannot test the 'ffmpeg missing' error path meaningfully")
+	}
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	// Create a minimal fake APE file (just needs to exist for path resolution).
+	apePath := filepath.Join(tmpDir, "album.ape")
+	require.NoError(t, os.WriteFile(apePath, []byte("fake-ape-data"), 0o600))
+
+	cueContent := strings.Join([]string{
+		`FILE "album.ape" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	// Override PATH to an empty directory so ffmpeg cannot be found.
+	emptyBin := filepath.Join(tmpDir, "emptybin")
+	require.NoError(t, os.MkdirAll(emptyBin, 0o755))
+	t.Setenv("PATH", emptyBin)
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	_, _, _, err := xtractr.ExtractCUE(xFile) //nolint:dogsled
+	assert.ErrorIs(t, err, xtractr.ErrFFmpegNotFound)
+}
+
+// TestCueWavReferenceAPEFile verifies that when the CUE says FILE "album.wav" WAVE
+// but only album.ape exists on disk, we find and use the .ape file.
+func TestCueWavReferenceAPEFile(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not found in PATH, skipping APE resolution test")
+	}
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	// Generate test FLAC and convert to APE.
+	totalSamples := uint64(2 * 60 * testSampleRate) // 2 minutes
+	flacPath := filepath.Join(tmpDir, "source.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	apePath := filepath.Join(tmpDir, "album.ape")
+	cmd := exec.Command("ffmpeg", "-i", flacPath, "-c:a", "ape", "-y", apePath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg FLAC->APE: %s", output)
+	require.NoError(t, os.Remove(flacPath))
+
+	// CUE references album.wav, but only album.ape exists.
+	cueContent := strings.Join([]string{
+		`PERFORMER "Test Artist"`,
+		`TITLE "Test Album"`,
+		`FILE "album.wav" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Only Track"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE should resolve .wav reference to .ape file")
+	assert.Greater(t, size, uint64(0))
+	assert.NotEmpty(t, files)
+	assert.FileExists(t, filepath.Join(outputDir, "01 - Only Track.flac"))
+}
+
+// TestCueBaseNameAPEFallback verifies that when the CUE FILE reference doesn't match
+// any file but a .ape file with the same basename as the CUE exists, it is found.
+func TestCueBaseNameAPEFallback(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not found in PATH, skipping APE basename fallback test")
+	}
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(2 * 60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "source.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	apePath := filepath.Join(tmpDir, "My Album.ape")
+	cmd := exec.Command("ffmpeg", "-i", flacPath, "-c:a", "ape", "-y", apePath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg FLAC->APE: %s", output)
+	require.NoError(t, os.Remove(flacPath))
+
+	// CUE references a non-existent file, but CUE basename matches "My Album.ape".
+	cueContent := strings.Join([]string{
+		`PERFORMER "Test Artist"`,
+		`TITLE "Test Album"`,
+		`FILE "nonexistent.wav" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "My Album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	size, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "ExtractCUE should fall back to .ape with same basename as CUE")
+	assert.Greater(t, size, uint64(0))
+	assert.NotEmpty(t, files)
+}

--- a/errors.go
+++ b/errors.go
@@ -26,7 +26,8 @@ var (
 	ErrNoCueFile        = errors.New("cue sheet does not reference a FILE")
 	ErrNoTracks         = errors.New("cue sheet contains no tracks")
 	ErrAudioNotFound    = errors.New("audio file referenced by cue sheet not found")
-	ErrUnsupportedAudio = errors.New("cue sheet references unsupported audio format (only FLAC is supported)")
+	ErrUnsupportedAudio = errors.New("cue sheet references unsupported audio format (only FLAC and APE are supported)")
+	ErrFFmpegNotFound   = errors.New("ffmpeg not found in PATH")
 
 	// RPM.
 


### PR DESCRIPTION
## Summary

- Adds APE (Monkey's Audio) + CUE sheet splitting support alongside existing FLAC+CUE
- APE files are converted to a temporary FLAC via `ffmpeg` (compression level 0), then split using the existing `splitFLAC()` pipeline — zero changes to the proven FLAC splitting path
- Graceful fallback: when ffmpeg is not installed, returns `ErrFFmpegNotFound` instead of silently failing
- `resolveCueAudioPath()` now tries `.ape` alongside `.flac` in all fallback paths

## Motivation

Closes Unpackerr/unpackerr#605 — APE+CUE albums are common in music downloads but were silently ignored by the `.flac`-only format gate. Lidarr cannot import single-image APE files, so they sit in completed directories forever.

## Approach: Convert-Then-Split (vs alternatives)

A pure-Go APE codec doesn't exist (and [a prior attempt was described as "pretty bleak"](https://github.com/Unpackerr/unpackerr/issues/605#issuecomment-2710605261)). This PR takes the minimal-risk approach:

1. **Detect** `.ape` audio file via CUE sheet resolution
2. **Convert** APE → temporary FLAC via `ffmpeg -c:a flac -compression_level 0`
3. **Split** using the existing `splitFLAC()` — sample-accurate, battle-tested
4. **Cleanup** temp FLAC after splitting

The conversion is lossless (APE → PCM → FLAC is a bit-for-bit round-trip). Compression level 0 minimizes conversion time since the file is split immediately anyway.

## Changes

| File | Change |
|------|--------|
| `cue.go` | Format dispatch: `.flac` → `splitFLAC()`, `.ape` → `convertAndSplitAPE()` |
| `cue.go` | New `convertToFLAC()` — ffmpeg shell-out with temp dir cleanup |
| `cue.go` | `resolveCueAudioPath()` — adds `.ape` to all fallback resolution paths |
| `errors.go` | New `ErrFFmpegNotFound`; updated `ErrUnsupportedAudio` message |
| `cue_test.go` | 4 new tests (all skip gracefully when ffmpeg unavailable) |

## New tests

- `TestCueAPEConvertAndSplit` — full end-to-end: generate FLAC → convert to APE → split via CUE → verify FLAC tracks + VorbisComment tags
- `TestCueAPENoFFmpeg` — verifies `ErrFFmpegNotFound` when PATH is overridden
- `TestCueWavReferenceAPEFile` — CUE says `.wav` but only `.ape` exists
- `TestCueBaseNameAPEFallback` — CUE filename mismatch, resolved via basename + `.ape`

## Test plan

- [ ] `go test ./...` passes (existing FLAC tests unaffected)
- [ ] APE tests pass when ffmpeg is installed
- [ ] APE tests skip gracefully when ffmpeg is not installed
- [ ] Manual test with real APE+CUE album on Unpackerr instance

## Prerequisites

Systems using APE splitting need `ffmpeg` installed with APE decoder support:
```bash
ffmpeg -decoders 2>/dev/null | grep -i ape
# Expected: " A....D ape    Monkey's Audio"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)