### PR TITLE
Fix corrupted audio in split FLAC tracks (double inter-channel correlation)

### DIFF
--- a/cue.go
+++ b/cue.go
@@ -996,10 +996,13 @@ func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
 // in the header) with variable-blocksize frames (which encode a sample position) produces
 // an invalid FLAC stream that many decoders — including GStreamer's flacparse — will reject.
 func buildOutputFrame(src *frame.Frame, offset, count int) *frame.Frame {
-	// Always correlate to get proper L/R samples before slicing.
-	// Correlate is a no-op when the frame is already in correlated form.
-	src.Correlate()
-
+	// The decoder's Frame.Parse already correlates subframes to independent L/R
+	// samples (see mewkiz/flac frame.Parse), so src.Subframes hold actual L/R here.
+	// We must NOT correlate again: doing so double-transforms inter-channel
+	// decorrelated frames (mid/side, left/side, right/side) and corrupts the output
+	// (notably the right channel) for every such frame. The encoder's WriteFrame
+	// re-applies decorrelation based on Header.Channels, so we pass L/R straight
+	// through. ref: Unpackerr/unpackerr#634.
 	outFrame := &frame.Frame{
 		Header: frame.Header{
 			HasFixedBlockSize: false,

--- a/cue_test.go
+++ b/cue_test.go
@@ -947,3 +947,186 @@ func TestCueSupportedExtensions(t *testing.T) {
 
 	assert.True(t, found, ".cue should be in supported extensions list")
 }
+
+// generateStereoFLAC writes a stereo FLAC with distinct left/right channels using
+// mid/side inter-channel decorrelation, and returns the exact per-channel samples it
+// wrote. Real-world FLACs (libFLAC, ffmpeg) routinely use mid/side and left/side
+// decorrelation; this exercises the channel-handling path that plain L==R sine-wave
+// fixtures (which only ever produce independent L/R frames) never reach.
+func generateStereoFLAC(t *testing.T, path string, totalSamples uint64) (left, right []int32) {
+	t.Helper()
+
+	outFile, err := os.Create(path)
+	require.NoError(t, err, "creating stereo test FLAC file")
+
+	info := &meta.StreamInfo{
+		BlockSizeMin:  testBlockSize,
+		BlockSizeMax:  testBlockSize,
+		SampleRate:    testSampleRate,
+		NChannels:     testNChannels,
+		BitsPerSample: testBitsPerSample,
+		NSamples:      totalSamples,
+	}
+
+	enc, err := flac.NewEncoder(outFile, info)
+	require.NoError(t, err, "creating stereo FLAC encoder")
+
+	left = make([]int32, 0, totalSamples)
+	right = make([]int32, 0, totalSamples)
+
+	samplesWritten := uint64(0)
+	for samplesWritten < totalSamples {
+		blockSize := uint64(testBlockSize)
+		if samplesWritten+blockSize > totalSamples {
+			blockSize = totalSamples - samplesWritten
+		}
+
+		leftSamples := make([]int32, blockSize)
+		rightSamples := make([]int32, blockSize)
+
+		for i := range blockSize {
+			n := samplesWritten + i
+			// Distinct, correlated-but-not-equal channels so the encoder benefits
+			// from mid/side decorrelation (and side = L-R is non-zero).
+			leftSamples[i] = int32(15000 * math.Sin(2*math.Pi*440*float64(n)/float64(testSampleRate)))
+			rightSamples[i] = int32(12000 * math.Sin(2*math.Pi*443*float64(n)/float64(testSampleRate)))
+		}
+
+		left = append(left, leftSamples...)
+		right = append(right, rightSamples...)
+
+		audioFrame := &frame.Frame{
+			Header: frame.Header{
+				HasFixedBlockSize: false,
+				BlockSize:         uint16(blockSize),
+				SampleRate:        testSampleRate,
+				// Force mid/side inter-channel decorrelation; the encoder converts
+				// the L/R samples we provide into mid/side on write.
+				Channels:      frame.ChannelsMidSide,
+				BitsPerSample: testBitsPerSample,
+			},
+			Subframes: []*frame.Subframe{
+				{
+					SubHeader: frame.SubHeader{Pred: frame.PredVerbatim, Order: 0},
+					Samples:   leftSamples,
+					NSamples:  int(blockSize),
+				},
+				{
+					SubHeader: frame.SubHeader{Pred: frame.PredVerbatim, Order: 0},
+					Samples:   rightSamples,
+					NSamples:  int(blockSize),
+				},
+			},
+		}
+
+		require.NoError(t, enc.WriteFrame(audioFrame), "writing stereo FLAC frame")
+
+		samplesWritten += blockSize
+	}
+
+	require.NoError(t, enc.Close(), "closing stereo FLAC encoder")
+
+	return left, right
+}
+
+// readAllSamples decodes every frame of a FLAC file and returns the per-channel samples.
+func readAllSamples(t *testing.T, path string) (left, right []int32) {
+	t.Helper()
+
+	file, err := os.Open(path)
+	require.NoError(t, err, "opening FLAC for sample verification: %s", path)
+
+	defer file.Close()
+
+	stream, err := flac.Parse(file)
+	require.NoError(t, err, "parsing FLAC for sample verification: %s", path)
+
+	require.Equal(t, uint8(testNChannels), stream.Info.NChannels, "expected stereo: %s", path)
+
+	for {
+		frm, err := stream.ParseNext()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err, "decoding frame from: %s", path)
+
+		left = append(left, frm.Subframes[0].Samples...)
+		right = append(right, frm.Subframes[1].Samples...)
+	}
+
+	return left, right
+}
+
+// TestCueStereoSampleAccuracy verifies that splitting a stereo FLAC encoded with
+// mid/side inter-channel decorrelation produces sample-accurate output. The decoder
+// already correlates subframes to L/R on Parse, so any extra Correlate() before
+// re-encoding double-transforms the samples and corrupts the right channel of every
+// non-independent-stereo frame (see Unpackerr/unpackerr#634).
+func TestCueStereoSampleAccuracy(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(30 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	srcLeft, srcRight := generateStereoFLAC(t, flacPath, totalSamples)
+
+	// Single track spanning the whole file: the split output must be sample-identical
+	// to the source across every frame.
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Whole"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	xFile := &xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	}
+
+	_, files, _, err := xtractr.ExtractCUE(xFile)
+	require.NoError(t, err, "extracting stereo CUE+FLAC")
+
+	trackPath := filepath.Join(outputDir, "01 - Whole.flac")
+	assert.Contains(t, files, trackPath)
+
+	gotLeft, gotRight := readAllSamples(t, trackPath)
+
+	require.Len(t, gotLeft, len(srcLeft), "left channel sample count")
+	require.Len(t, gotRight, len(srcRight), "right channel sample count")
+	assertSamplesEqual(t, "left", srcLeft, gotLeft)
+	assertSamplesEqual(t, "right", srcRight, gotRight)
+}
+
+// assertSamplesEqual compares two sample slices and fails with the first mismatch
+// (and a count) instead of dumping millions of values like assert.Equal would.
+func assertSamplesEqual(t *testing.T, channel string, want, got []int32) {
+	t.Helper()
+
+	mismatches := 0
+	firstIdx := -1
+
+	for i := range want {
+		if want[i] != got[i] {
+			if firstIdx < 0 {
+				firstIdx = i
+			}
+
+			mismatches++
+		}
+	}
+
+	if mismatches > 0 {
+		t.Errorf("%s channel: %d/%d samples differ; first mismatch at index %d: want %d, got %d",
+			channel, mismatches, len(want), firstIdx, want[firstIdx], got[firstIdx])
+	}
+}


### PR DESCRIPTION
## Summary

Split FLAC tracks produced from CUE sheets came out corrupted — intermittent right channel and distortion on parts of the audio. Reported in Unpackerr/unpackerr#634.

**Root cause:** the mewkiz decoder's `frame.Parse` already reverses inter-channel decorrelation, so after `ParseNext` the subframes hold actual L/R samples. `buildOutputFrame` then called `src.Correlate()` a **second** time. That is not a no-op on already-correlated data: it re-transforms mid/side, left/side, and right/side frames. The encoder's `WriteFrame` then applies `Decorrelate()` again, so every frame the source stored with inter-channel decorrelation was written corrupted (most audibly the right channel), while plain independent-L/R frames passed through unharmed — exactly matching the "intermittent right channel / distortion on some parts" report.

**Fix:** remove the redundant `Correlate()` and pass the decoder's L/R samples straight to the encoder, which decorrelates based on `Header.Channels`.

## Why existing tests missed it

Every fixture used a sine wave with `L == R`, which makes `side = 0` and forces the encoder into independent-L/R mode — the one mode where the double-correlate is harmless. Added `TestCueStereoSampleAccuracy`, which encodes a stereo source with **mid/side** decorrelation and distinct L/R channels, then asserts the split output is sample-identical to the source.

- Against the old code the new test fails hard (~1,322,880 / 1,323,000 samples differ).
- With the fix it passes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -covermode=atomic ./...`
- [x] New `TestCueStereoSampleAccuracy` fails before the fix, passes after

- Fixes Unpackerr/unpackerr#634
