### PR TITLE
fix(ape): pad split-track frame data to a uint32 boundary for FFmpeg

### DIFF
--- a/ape.go
+++ b/ape.go
@@ -552,6 +552,7 @@ type apeTrackContainer struct {
 	headerBytes    []byte
 	seekTableBytes []byte
 	trackDataSize  int64
+	framePadding   int // zero bytes appended after the frame data (uint32 alignment + read-ahead)
 }
 
 // buildAPETrackContainer computes the descriptor, header and seek table for a new APE file
@@ -579,6 +580,17 @@ func buildAPETrackContainer(info *apeInfo, startFrame, endFrame int) (*apeTrackC
 		trackDataSize += apeFrameDataSize(info, startFrame+i)
 	}
 
+	// FFmpeg's APE demuxer sizes the final frame as floor4(fileSize - lastFramePos) — it rounds
+	// the last frame DOWN to a uint32 boundary (libavformat/ape.c). A verbatim frame copy can
+	// leave the final frame ending mid-word, so FFmpeg drops the last 1-3 compressed bytes and
+	// then starves the range coder on the frame's final block ("Error decoding frame"). Real
+	// encoders always pad the frame-data region to a uint32 boundary; match that and add one
+	// extra uint32 of read-ahead slack the range decoder consumes past a frame's logical end.
+	lastFrameSize := apeFrameDataSize(info, endFrame)
+	alignPad := (bytesPerUint32 - int(lastFrameSize%bytesPerUint32)) % bytesPerUint32
+	framePadding := alignPad + apeTailPadding
+	paddedDataSize := trackDataSize + int64(framePadding)
+
 	hdr := apeHeader{
 		CompressionLevel: info.Header.CompressionLevel,
 		FormatFlags:      info.Header.FormatFlags | apeFormatFlagCreateWAV,
@@ -603,14 +615,15 @@ func buildAPETrackContainer(info *apeInfo, startFrame, endFrame int) (*apeTrackC
 			HeaderBytes:        apeHeaderSize,
 			SeekTableBytes:     seekTableSize,
 			HeaderDataBytes:    0, // CREATE_WAV_HEADER flag is set in the header above.
-			FrameDataBytes:     uint32(trackDataSize & maxUint32),
-			FrameDataBytesHigh: uint32((trackDataSize >> highDWordShift) & maxUint32),
+			FrameDataBytes:     uint32(paddedDataSize & maxUint32),
+			FrameDataBytesHigh: uint32((paddedDataSize >> highDWordShift) & maxUint32),
 			TerminatingBytes:   0,
 			// FileMD5 stays zero here; it's computed and patched in after the data is written.
 		},
 		headerBytes:    headerBytes,
 		seekTableBytes: seekTableBytes,
 		trackDataSize:  trackDataSize,
+		framePadding:   framePadding,
 	}, nil
 }
 
@@ -650,6 +663,17 @@ func writeTrackAPEContents(
 	err = writeAPEFrameData(dst, srcFile, info, startFrame, endFrame, con.trackDataSize)
 	if err != nil {
 		return 0, err
+	}
+
+	// Pad the frame-data region to a uint32 boundary (+ read-ahead) so FFmpeg's last-frame size
+	// calc keeps every compressed byte. These bytes are part of the frame-data region the format
+	// hashes, so they go to the file (via dst) and into the MD5. MAC ignores them: the final
+	// frame decodes FinalFrameBlocks samples and stops.
+	if con.framePadding > 0 {
+		_, err = dst.Write(make([]byte, con.framePadding))
+		if err != nil {
+			return 0, fmt.Errorf("writing ape frame padding: %w", err)
+		}
 	}
 
 	// The format hashes (header data) + frame data + (terminating data) + header + seek table.

--- a/ape_internal_test.go
+++ b/ape_internal_test.go
@@ -491,7 +491,15 @@ func TestBuildAPETrackContainer(t *testing.T) {
 
 	assert.Equal(t, uint32(2), con.descriptor.SeekTableBytes/bytesPerUint32)
 	assert.Equal(t, int64(2*testAPEFrameLen), con.trackDataSize)
-	assert.Equal(t, uint32(2*testAPEFrameLen), con.descriptor.FrameDataBytes)
+
+	// The frame-data region is padded after the last frame to a uint32 boundary plus a uint32 of
+	// read-ahead, so FFmpeg's last-frame size (floor4 of fileSize-lastFramePos) keeps every byte.
+	wantPad := (bytesPerUint32-testAPEFrameLen%bytesPerUint32)%bytesPerUint32 + apeTailPadding
+	assert.Equal(t, wantPad, con.framePadding)
+	assert.Equal(t, uint32(2*testAPEFrameLen+wantPad), con.descriptor.FrameDataBytes)
+	// The final frame must span a whole number of uint32 words (last frame length + padding).
+	assert.Zero(t, (int(con.descriptor.FrameDataBytes)-testAPEFrameLen)%bytesPerUint32)
+
 	assert.Equal(t, [4]byte{'M', 'A', 'C', ' '}, con.descriptor.ID)
 
 	// CREATE_WAV_HEADER flag must be set and there must be no stored header data.
@@ -598,9 +606,12 @@ func TestSplitAPEEndToEnd(t *testing.T) {
 	dataOffset := int(desc.DescriptorBytes + desc.HeaderBytes + desc.SeekTableBytes)
 	gotFrameData := track1[dataOffset : dataOffset+int(desc.FrameDataBytes)]
 
-	wantFrameData := frames[0]
-	wantFrameData = append(wantFrameData, frames[1]...)
-	assert.Equal(t, wantFrameData, gotFrameData, "aligned track frame data should be copied verbatim")
+	wantFrameData := append(append([]byte{}, frames[0]...), frames[1]...)
+	// The real compressed frames are copied verbatim; the remainder is zero alignment/read-ahead padding.
+	require.Greater(t, len(gotFrameData), len(wantFrameData), "frame data must include trailing padding")
+	assert.Equal(t, wantFrameData, gotFrameData[:len(wantFrameData)], "aligned track frame data should be copied verbatim")
+	padding := gotFrameData[len(wantFrameData):]
+	assert.Equal(t, make([]byte, len(padding)), padding, "trailing padding must be zero")
 }
 
 func TestSplitAPESingleTrack(t *testing.T) {


### PR DESCRIPTION
## Problem
On real EAC rips, the split `.ape` tracks are bit-for-bit lossless under the reference Monkey's Audio decoder, but **FFmpeg/libavcodec fails to decode ~⅔ of them** (`Error decoding frame`, ~104 ms truncated off the end).

## Root cause
FFmpeg's APE demuxer sizes the **last** frame from the file size and rounds it **down** to a uint32 boundary:
```c
// libavformat/ape.c
final_size  = file_size - frames[last].pos - wavtaillength;
final_size -= final_size & 3;   // round the LAST frame DOWN to a multiple of 4
```
Every other frame is rounded *up* (it can borrow from the next frame), but the last frame is bounded by EOF. A verbatim frame copy can leave the frame-data region ending mid-word, so FFmpeg discards the final 1–3 compressed bytes and the range coder then starves on the frame's last block. Real MACLib-encoded files never hit this because the encoder always pads frame data to a uint32 boundary (`nAPEFrameDataBytes % 4 == 0`); `mac` tolerates the short tail, `libavcodec` doesn't.

## Fix
Pad each split track's frame-data region up to a uint32 boundary plus one uint32 of read-ahead slack, count it in `FrameDataBytes`, and fold it into the file MD5. `mac` ignores the trailing bytes (the final frame decodes `FinalFrameBlocks` and stops); FFmpeg now keeps every real byte. (Uses the `apeTailPadding` constant that was already defined for this.)

## Verification
`go test` and golangci-lint pass. Functionally verified on **5 albums / 57 tracks** (compression levels 2000 and 3000), each a single-file `image.ape` + `.cue`:

- With the fix, **all 57 tracks decode cleanly under both FFmpeg 7.1.4 and the MAC 13.05 reference decoder**, and every split is **bit-for-bit lossless** vs the source image (concatenated track PCM MD5 == image PCM MD5, under both decoders).
- On the two albums tested *before* the fix (24 tracks), FFmpeg failed on 16; after, 0.
