### PR TITLE
fix: restore tar symlinks instead of empty files

### DIFF
--- a/files.go
+++ b/files.go
@@ -166,6 +166,13 @@ func (x *XFile) Debugf(format string, v ...any) {
 	}
 }
 
+// Printf calls the print method on the logger if it's not nil.
+func (x *XFile) Printf(format string, v ...any) {
+	if x.log != nil {
+		x.log.Printf(format, v...)
+	}
+}
+
 // GetFileList returns all the files in a path or paths.
 // This is non-recursive and only returns files _in_ the base paths provided.
 // This is a helper method and only exposed for convenience. You do not have to call this.

--- a/tar.go
+++ b/tar.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -175,7 +177,8 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 		return 0, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, file.Path, header.Name)
 	}
 
-	if header.Typeflag == tar.TypeDir {
+	switch header.Typeflag {
+	case tar.TypeDir:
 		x.Debugf("Writing archived directory: %s", file.Path)
 
 		err := x.mkDir(file.Path, header.FileInfo().Mode(), header.ModTime)
@@ -184,9 +187,55 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 		}
 
 		return 0, nil
+	case tar.TypeSymlink, tar.TypeLink:
+		// Symlinks (and hard links) have no file payload; writing them as regular
+		// files produces empty stubs — see https://github.com/golift/xtractr/issues/153
+		return x.untarLink(header, file.Path)
 	}
 
 	x.Debugf("Writing archived file: %s (bytes: %d)", file.Path, header.FileInfo().Size())
 
 	return x.write(file)
+}
+
+// untarLink creates a symlink or hard link from a tar header.
+func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
+	err := x.mkDir(filepath.Dir(path), x.DirMode, header.ModTime)
+	if err != nil {
+		return 0, fmt.Errorf("making tar link parent dir: %w", err)
+	}
+
+	// Replace anything already at path so Symlink/Link can succeed.
+	_ = os.Remove(path)
+
+	switch header.Typeflag {
+	case tar.TypeSymlink:
+		x.Debugf("Writing archived symlink: %s -> %s", path, header.Linkname)
+
+		err = os.Symlink(header.Linkname, path)
+		if err != nil {
+			return 0, fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, header.Linkname)
+		}
+	case tar.TypeLink:
+		target := x.clean(header.Linkname)
+		if !strings.HasPrefix(target, x.OutputDir) {
+			return 0, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, header.Linkname)
+		}
+
+		x.Debugf("Writing archived hard link: %s => %s", path, target)
+
+		err = os.Link(target, path)
+		if err != nil {
+			// Fall back to a symlink when hard links are unavailable (e.g. target
+			// not extracted yet, or the filesystem does not support them).
+			x.Debugf("Hard link failed (%v); falling back to symlink: %s -> %s", err, path, header.Linkname)
+
+			err = os.Symlink(header.Linkname, path)
+			if err != nil {
+				return 0, fmt.Errorf("%s: creating hard link: %w: %s => %s", x.FilePath, err, path, target)
+			}
+		}
+	}
+
+	return 0, nil
 }

--- a/tar.go
+++ b/tar.go
@@ -172,7 +172,7 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 		file.Atime = time.Now()
 	}
 
-	if !strings.HasPrefix(file.Path, x.OutputDir) {
+	if !x.pathWithinOutput(file.Path) {
 		// The file being written is trying to write outside of our base path. Malicious archive?
 		return 0, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, file.Path, header.Name)
 	}
@@ -198,6 +198,39 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 	return x.write(file)
 }
 
+// pathWithinOutput reports whether path is OutputDir or a descendant of it.
+// Uses filepath.Rel so prefix tricks like OutputDir=/tmp/out and path=/tmp/outside fail.
+func (x *XFile) pathWithinOutput(path string) bool {
+	outputDir := filepath.Clean(x.OutputDir)
+	cleanPath := filepath.Clean(path)
+
+	rel, err := filepath.Rel(outputDir, cleanPath)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// resolveLinkTarget returns the cleaned filesystem path a link would resolve to.
+func resolveLinkTarget(linkPath, linkName string) string {
+	if filepath.IsAbs(linkName) {
+		return filepath.Clean(linkName)
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(linkPath), linkName))
+}
+
+// ensureLinkWithinOutput rejects symlink targets that escape OutputDir.
+func (x *XFile) ensureLinkWithinOutput(linkPath, linkName string) error {
+	resolved := resolveLinkTarget(linkPath, linkName)
+	if !x.pathWithinOutput(resolved) {
+		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, resolved, linkName)
+	}
+
+	return nil
+}
+
 // untarLink creates a symlink or hard link from a tar header.
 func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
 	err := x.mkDir(filepath.Dir(path), x.DirMode, header.ModTime)
@@ -205,37 +238,65 @@ func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
 		return 0, fmt.Errorf("making tar link parent dir: %w", err)
 	}
 
-	// Replace anything already at path so Symlink/Link can succeed.
-	_ = os.Remove(path)
+	err = os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("%s: removing existing path for link: %w: %s", x.FilePath, err, path)
+	}
 
 	switch header.Typeflag {
 	case tar.TypeSymlink:
-		x.Debugf("Writing archived symlink: %s -> %s", path, header.Linkname)
-
-		err = os.Symlink(header.Linkname, path)
-		if err != nil {
-			return 0, fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, header.Linkname)
-		}
+		return 0, x.createSymlink(path, header.Linkname)
 	case tar.TypeLink:
-		target := x.clean(header.Linkname)
-		if !strings.HasPrefix(target, x.OutputDir) {
-			return 0, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, header.Linkname)
-		}
-
-		x.Debugf("Writing archived hard link: %s => %s", path, target)
-
-		err = os.Link(target, path)
-		if err != nil {
-			// Fall back to a symlink when hard links are unavailable (e.g. target
-			// not extracted yet, or the filesystem does not support them).
-			x.Debugf("Hard link failed (%v); falling back to symlink: %s -> %s", err, path, header.Linkname)
-
-			err = os.Symlink(header.Linkname, path)
-			if err != nil {
-				return 0, fmt.Errorf("%s: creating hard link: %w: %s => %s", x.FilePath, err, path, target)
-			}
-		}
+		return 0, x.createHardLink(path, header.Linkname)
 	}
 
 	return 0, nil
+}
+
+func (x *XFile) createSymlink(path, linkName string) error {
+	err := x.ensureLinkWithinOutput(path, linkName)
+	if err != nil {
+		return err
+	}
+
+	x.Debugf("Writing archived symlink: %s -> %s", path, linkName)
+
+	err = os.Symlink(linkName, path)
+	if err != nil {
+		return fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, linkName)
+	}
+
+	return nil
+}
+
+func (x *XFile) createHardLink(path, linkName string) error {
+	// Hard-link names are archive member paths, not arbitrary filesystem paths.
+	if linkName == "" || filepath.IsAbs(linkName) {
+		return fmt.Errorf("%s: %w: %s", x.FilePath, ErrInvalidPath, linkName)
+	}
+
+	target := x.clean(linkName)
+	if !x.pathWithinOutput(target) {
+		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, linkName)
+	}
+
+	x.Debugf("Writing archived hard link: %s => %s", path, target)
+
+	err := os.Link(target, path)
+	if err == nil {
+		return nil
+	}
+
+	linkErr := err
+
+	rel, relErr := filepath.Rel(filepath.Dir(path), target)
+	if relErr != nil {
+		return fmt.Errorf("%s: creating hard link: %w: %s => %s", x.FilePath, linkErr, path, target)
+	}
+
+	// Fall back to a relative symlink when hard links are unavailable
+	// (e.g. target not extracted yet, or the filesystem does not support them).
+	x.Debugf("Hard link failed (%v); falling back to symlink: %s -> %s", linkErr, path, rel)
+
+	return x.createSymlink(path, rel)
 }

--- a/tar.go
+++ b/tar.go
@@ -128,6 +128,9 @@ func ExtractTarLzip(xFile *XFile) (size uint64, filesList []string, err error) {
 	return xFile.prog.Wrote, files, err
 }
 
+// errSkipEntry is returned for non-fatal archive members that should be ignored.
+var errSkipEntry = errors.New("skip archive entry")
+
 func (x *XFile) untar(reader io.Reader) ([]string, error) {
 	tarReader := tar.NewReader(reader)
 	files := []string{}
@@ -143,6 +146,10 @@ func (x *XFile) untar(reader io.Reader) ([]string, error) {
 		}
 
 		fSize, err := x.untarFile(header, tarReader)
+		if errors.Is(err, errSkipEntry) {
+			continue
+		}
+
 		if err != nil {
 			return files, err
 		}
@@ -254,6 +261,12 @@ func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
 }
 
 func (x *XFile) createSymlink(path, linkName string) error {
+	if linkName == "" {
+		x.Printf("Warning: skipping symlink with empty target: %s", path)
+
+		return errSkipEntry
+	}
+
 	err := x.ensureLinkWithinOutput(path, linkName)
 	if err != nil {
 		return err
@@ -270,8 +283,14 @@ func (x *XFile) createSymlink(path, linkName string) error {
 }
 
 func (x *XFile) createHardLink(path, linkName string) error {
+	if linkName == "" {
+		x.Printf("Warning: skipping hard link with empty target: %s", path)
+
+		return errSkipEntry
+	}
+
 	// Hard-link names are archive member paths, not arbitrary filesystem paths.
-	if linkName == "" || filepath.IsAbs(linkName) {
+	if filepath.IsAbs(linkName) {
 		return fmt.Errorf("%s: %w: %s", x.FilePath, ErrInvalidPath, linkName)
 	}
 

--- a/tar_test.go
+++ b/tar_test.go
@@ -193,6 +193,40 @@ func TestTarSymlinkEscape(t *testing.T) {
 	}
 }
 
+// TestTarEmptyLinkSkipped warns and continues when a link target is empty.
+func TestTarEmptyLinkSkipped(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	archivePath := filepath.Join(tmp, "empty-link.tar.gz")
+	extractDir := filepath.Join(tmp, "out")
+
+	require.NoError(t, createEmptyLinkWithFileTarGzip(archivePath))
+
+	_, files, err := xtractr.ExtractTarGzip(&xtractr.XFile{
+		FilePath:  archivePath,
+		OutputDir: extractDir,
+		FileMode:  0o755,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep.txt"}, files)
+
+	_, err = os.Lstat(filepath.Join(extractDir, "empty.link"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	data, err := os.ReadFile(filepath.Join(extractDir, "keep.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "kept", string(data))
+}
+
 func mustFileSize(t *testing.T, path string) int64 {
 	t.Helper()
 
@@ -285,6 +319,54 @@ func createLinkOnlyTarGzip(dest, name, linkName string, kind byte) error {
 	err = tarWriter.WriteHeader(header)
 	if err != nil {
 		return fmt.Errorf("failed to write link header: %w", err)
+	}
+
+	return nil
+}
+
+func createEmptyLinkWithFileTarGzip(dest string) error {
+	archiveFile, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+	defer archiveFile.Close()
+
+	gzipWriter := gzip.NewWriter(archiveFile)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	emptyLink := &tar.Header{
+		Name:     "empty.link",
+		Linkname: "",
+		Mode:     0o755,
+		Typeflag: tar.TypeSymlink,
+		ModTime:  time.Now(),
+	}
+
+	err = tarWriter.WriteHeader(emptyLink)
+	if err != nil {
+		return fmt.Errorf("failed to write empty link header: %w", err)
+	}
+
+	payload := []byte("kept")
+	fileHeader := &tar.Header{
+		Name:     "keep.txt",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+		ModTime:  time.Now(),
+	}
+
+	err = tarWriter.WriteHeader(fileHeader)
+	if err != nil {
+		return fmt.Errorf("failed to write file header: %w", err)
+	}
+
+	_, err = tarWriter.Write(payload)
+	if err != nil {
+		return fmt.Errorf("failed to write file payload: %w", err)
 	}
 
 	return nil

--- a/tar_test.go
+++ b/tar_test.go
@@ -81,6 +81,12 @@ func TestTarSymlinks(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
 	archivePath := filepath.Join(tmp, "libs.tar.gz")
 	extractDir := filepath.Join(tmp, "out")
 
@@ -124,7 +130,66 @@ func TestTarSymlinks(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "libfoo.so.1.2.3", got)
 	} else {
-		assert.Equal(t, info.Size(), mustFileSize(t, realFile))
+		assert.Equal(t, mustFileSize(t, realFile), info.Size())
+	}
+}
+
+// TestTarSymlinkEscape rejects symlink and hard-link targets that leave OutputDir.
+func TestTarSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		linkName string
+		kind     byte
+	}{
+		{
+			name:     "absolute_symlink",
+			linkName: filepath.Join(tmp, "outside"),
+			kind:     tar.TypeSymlink,
+		},
+		{
+			name:     "relative_symlink",
+			linkName: "../outside",
+			kind:     tar.TypeSymlink,
+		},
+		{
+			name:     "absolute_hardlink",
+			linkName: filepath.Join(tmp, "outside"),
+			kind:     tar.TypeLink,
+		},
+		{
+			// filepath.Rel-based checks must reject .. escapes that HasPrefix can miss.
+			name:     "relative_hardlink_escape",
+			linkName: "../outside",
+			kind:     tar.TypeLink,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			archivePath := filepath.Join(tmp, testCase.name+".tar.gz")
+			extractDir := filepath.Join(tmp, testCase.name+"-out")
+
+			require.NoError(t, createLinkOnlyTarGzip(archivePath, "escape.link", testCase.linkName, testCase.kind))
+
+			// Call ExtractTarGzip directly: ExtractFile falls back to plain gzip on error.
+			_, _, err := xtractr.ExtractTarGzip(&xtractr.XFile{
+				FilePath:  archivePath,
+				OutputDir: extractDir,
+				FileMode:  0o755,
+				DirMode:   0o755,
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, xtractr.ErrInvalidPath)
+		})
 	}
 }
 
@@ -191,6 +256,35 @@ func createSymlinkTarGzip(dest string) error {
 		if err != nil {
 			return fmt.Errorf("failed to write link header: %w", err)
 		}
+	}
+
+	return nil
+}
+
+func createLinkOnlyTarGzip(dest, name, linkName string, kind byte) error {
+	archiveFile, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+	defer archiveFile.Close()
+
+	gzipWriter := gzip.NewWriter(archiveFile)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	header := &tar.Header{
+		Name:     name,
+		Linkname: linkName,
+		Mode:     0o755,
+		Typeflag: kind,
+		ModTime:  time.Now(),
+	}
+
+	err = tarWriter.WriteHeader(header)
+	if err != nil {
+		return fmt.Errorf("failed to write link header: %w", err)
 	}
 
 	return nil

--- a/tar_test.go
+++ b/tar_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dsnet/compress/bzip2"
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,120 @@ func TestTar(t *testing.T) {
 			assert.Len(t, archives, testFilesInfo.archiveCount)
 		})
 	}
+}
+
+// TestTarSymlinks ensures symlink (and hard-link) members are restored as links
+// instead of empty regular files. Regression for https://github.com/golift/xtractr/issues/153
+func TestTarSymlinks(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	archivePath := filepath.Join(tmp, "libs.tar.gz")
+	extractDir := filepath.Join(tmp, "out")
+
+	require.NoError(t, createSymlinkTarGzip(archivePath))
+
+	_, files, _, err := xtractr.ExtractFile(&xtractr.XFile{
+		FilePath:  archivePath,
+		OutputDir: extractDir,
+		FileMode:  0o755,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err)
+	assert.Len(t, files, 4)
+
+	realFile := filepath.Join(extractDir, "libfoo.so.1.2.3")
+	info, err := os.Lstat(realFile)
+	require.NoError(t, err)
+	assert.False(t, info.Mode()&os.ModeSymlink != 0, "real library should not be a symlink")
+	assert.Positive(t, info.Size())
+
+	for linkName, wantTarget := range map[string]string{
+		"libfoo.so.1": "libfoo.so.1.2.3",
+		"libfoo.so":   "libfoo.so.1",
+	} {
+		linkPath := filepath.Join(extractDir, linkName)
+		info, err = os.Lstat(linkPath)
+		require.NoError(t, err, linkName)
+		require.NotEqual(t, 0, info.Mode()&os.ModeSymlink, "%s should be a symlink, not a regular file", linkName)
+
+		got, err := os.Readlink(linkPath)
+		require.NoError(t, err, linkName)
+		assert.Equal(t, wantTarget, got, linkName)
+	}
+
+	hardPath := filepath.Join(extractDir, "libfoo.hard")
+	info, err = os.Lstat(hardPath)
+	require.NoError(t, err)
+	// Hard link when supported; otherwise we fall back to a symlink.
+	if info.Mode()&os.ModeSymlink != 0 {
+		got, err := os.Readlink(hardPath)
+		require.NoError(t, err)
+		assert.Equal(t, "libfoo.so.1.2.3", got)
+	} else {
+		assert.Equal(t, info.Size(), mustFileSize(t, realFile))
+	}
+}
+
+func mustFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	return info.Size()
+}
+
+func createSymlinkTarGzip(dest string) error {
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	payload := []byte("shared-object-bytes")
+	hdr := &tar.Header{
+		Name:     "libfoo.so.1.2.3",
+		Mode:     0o755,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+		ModTime:  time.Now(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := tw.Write(payload); err != nil {
+		return err
+	}
+
+	for _, link := range []struct {
+		name   string
+		target string
+		kind   byte
+	}{
+		{"libfoo.so.1", "libfoo.so.1.2.3", tar.TypeSymlink},
+		{"libfoo.so", "libfoo.so.1", tar.TypeSymlink},
+		{"libfoo.hard", "libfoo.so.1.2.3", tar.TypeLink},
+	} {
+		hdr = &tar.Header{
+			Name:     link.name,
+			Linkname: link.target,
+			Mode:     0o755,
+			Typeflag: link.kind,
+			ModTime:  time.Now(),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func writeTar(sourceDir string, destWriter io.Writer) error {

--- a/tar_test.go
+++ b/tar_test.go
@@ -98,7 +98,7 @@ func TestTarSymlinks(t *testing.T) {
 	realFile := filepath.Join(extractDir, "libfoo.so.1.2.3")
 	info, err := os.Lstat(realFile)
 	require.NoError(t, err)
-	assert.False(t, info.Mode()&os.ModeSymlink != 0, "real library should not be a symlink")
+	assert.Zero(t, info.Mode()&os.ModeSymlink, "real library should not be a symlink")
 	assert.Positive(t, info.Size())
 
 	for linkName, wantTarget := range map[string]string{
@@ -108,7 +108,7 @@ func TestTarSymlinks(t *testing.T) {
 		linkPath := filepath.Join(extractDir, linkName)
 		info, err = os.Lstat(linkPath)
 		require.NoError(t, err, linkName)
-		require.NotEqual(t, 0, info.Mode()&os.ModeSymlink, "%s should be a symlink, not a regular file", linkName)
+		require.NotZero(t, info.Mode()&os.ModeSymlink, "%s should be a symlink, not a regular file", linkName)
 
 		got, err := os.Readlink(linkPath)
 		require.NoError(t, err, linkName)
@@ -138,31 +138,36 @@ func mustFileSize(t *testing.T, path string) int64 {
 }
 
 func createSymlinkTarGzip(dest string) error {
-	f, err := os.Create(dest)
+	archiveFile, err := os.Create(dest)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create archive: %w", err)
 	}
-	defer f.Close()
+	defer archiveFile.Close()
 
-	gz := gzip.NewWriter(f)
-	defer gz.Close()
+	gzipWriter := gzip.NewWriter(archiveFile)
+	defer gzipWriter.Close()
 
-	tw := tar.NewWriter(gz)
-	defer tw.Close()
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
 
 	payload := []byte("shared-object-bytes")
-	hdr := &tar.Header{
+
+	header := &tar.Header{
 		Name:     "libfoo.so.1.2.3",
 		Mode:     0o755,
 		Size:     int64(len(payload)),
 		Typeflag: tar.TypeReg,
 		ModTime:  time.Now(),
 	}
-	if err := tw.WriteHeader(hdr); err != nil {
-		return err
+
+	err = tarWriter.WriteHeader(header)
+	if err != nil {
+		return fmt.Errorf("failed to write tar header: %w", err)
 	}
-	if _, err := tw.Write(payload); err != nil {
-		return err
+
+	_, err = tarWriter.Write(payload)
+	if err != nil {
+		return fmt.Errorf("failed to write tar payload: %w", err)
 	}
 
 	for _, link := range []struct {
@@ -174,15 +179,17 @@ func createSymlinkTarGzip(dest string) error {
 		{"libfoo.so", "libfoo.so.1", tar.TypeSymlink},
 		{"libfoo.hard", "libfoo.so.1.2.3", tar.TypeLink},
 	} {
-		hdr = &tar.Header{
+		header = &tar.Header{
 			Name:     link.name,
 			Linkname: link.target,
 			Mode:     0o755,
 			Typeflag: link.kind,
 			ModTime:  time.Now(),
 		}
-		if err := tw.WriteHeader(hdr); err != nil {
-			return err
+
+		err = tarWriter.WriteHeader(header)
+		if err != nil {
+			return fmt.Errorf("failed to write link header: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Tar/tar.gz extraction treated symlink and hard-link members as regular files, producing empty stubs (e.g. `libfoo.so` from library tarballs).
- Handle `TypeSymlink` / `TypeLink` via `untarLink`, with path checks for hard links and a symlink fallback when hard links fail.
- Add `TestTarSymlinks` regression coverage for #153.

Fixes #153

## Test plan
- [x] `go test ./...` (including `TestTarSymlinks`)
- [ ] Extract a tarball that contains shared-library symlinks (e.g. llama.cpp Ubuntu Vulkan release) and confirm `lib*.so` entries are real symlinks, not 0-byte files


Made with [Cursor](https://cursor.com)