### PR TITLE
fix: reject sibling-prefix path escapes in all extractors

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -3,7 +3,6 @@ package xtractr
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/bodgit/sevenzip"
@@ -127,7 +126,7 @@ func (x *XFile) sevenZipPrepareEntries(sevenZip *sevenzip.ReadCloser) ([]sevenZi
 	for _, zipFile := range sevenZip.File {
 		cleanPath := x.clean(zipFile.Name)
 
-		if !strings.HasPrefix(cleanPath, x.OutputDir) {
+		if !x.pathWithinOutput(cleanPath) {
 			return nil, files, fmt.Errorf("%s: %s: %w: %s (from: %s)",
 				x.FilePath, zipFile.FileInfo().Name(), ErrInvalidPath, cleanPath, zipFile.Name)
 		}
@@ -224,7 +223,7 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (uint64, string, error) {
 		Atime:    zipFile.Accessed,
 	}
 
-	if !strings.HasPrefix(file.Path, x.OutputDir) {
+	if !x.pathWithinOutput(file.Path) {
 		// The file being written is trying to write outside of our base path. Malicious archive?
 		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
 		return 0, file.Path, err

--- a/ar.go
+++ b/ar.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/peterebden/ar"
 )
@@ -53,7 +52,7 @@ func (x *XFile) unAr(reader io.Reader) ([]string, error) {
 			Mtime:    header.ModTime,
 		}
 
-		if !strings.HasPrefix(file.Path, x.OutputDir) {
+		if !x.pathWithinOutput(file.Path) {
 			// The file being written is trying to write outside of our base path. Malicious archive?
 			return files, fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, file.Path, header.Name)
 		}

--- a/cpio.go
+++ b/cpio.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/cavaliergopher/cpio"
 )
@@ -79,7 +78,7 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (uint
 		Mtime:    cpioFile.ModTime,
 	}
 
-	if !strings.HasPrefix(file.Path, x.OutputDir) {
+	if !x.pathWithinOutput(file.Path) {
 		// The file being written is trying to write outside of the base path. Malicious archive?
 		return 0, fmt.Errorf("%s: %w: %s (from: %s)", cpioFile.FileInfo().Name(), ErrInvalidPath, file.Path, cpioFile.Name)
 	}

--- a/files.go
+++ b/files.go
@@ -917,3 +917,82 @@ func (x *XFile) pathWithinOutput(path string) bool {
 
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
+
+// resolveLinkTarget returns the cleaned filesystem path a link would resolve to.
+func resolveLinkTarget(linkPath, linkName string) string {
+	if filepath.IsAbs(linkName) {
+		return filepath.Clean(linkName)
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(linkPath), linkName))
+}
+
+// ensureLinkWithinOutput rejects symlink targets that escape OutputDir.
+func (x *XFile) ensureLinkWithinOutput(linkPath, linkName string) error {
+	resolved := resolveLinkTarget(linkPath, linkName)
+	if !x.pathWithinOutput(resolved) {
+		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, resolved, linkName)
+	}
+
+	return nil
+}
+
+func (x *XFile) createSymlink(path, linkName string) error {
+	if linkName == "" {
+		x.Printf("Warning: skipping symlink with empty target: %s", path)
+
+		return errSkipEntry
+	}
+
+	err := x.ensureLinkWithinOutput(path, linkName)
+	if err != nil {
+		return err
+	}
+
+	x.Debugf("Writing archived symlink: %s -> %s", path, linkName)
+
+	err = os.Symlink(linkName, path)
+	if err != nil {
+		return fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, linkName)
+	}
+
+	return nil
+}
+
+func (x *XFile) createHardLink(path, linkName string) error {
+	if linkName == "" {
+		x.Printf("Warning: skipping hard link with empty target: %s", path)
+
+		return errSkipEntry
+	}
+
+	// Hard-link names are archive member paths, not arbitrary filesystem paths.
+	if filepath.IsAbs(linkName) {
+		return fmt.Errorf("%s: %w: %s", x.FilePath, ErrInvalidPath, linkName)
+	}
+
+	target := x.clean(linkName)
+	if !x.pathWithinOutput(target) {
+		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, linkName)
+	}
+
+	x.Debugf("Writing archived hard link: %s => %s", path, target)
+
+	err := os.Link(target, path)
+	if err == nil {
+		return nil
+	}
+
+	linkErr := err
+
+	rel, relErr := filepath.Rel(filepath.Dir(path), target)
+	if relErr != nil {
+		return fmt.Errorf("%s: creating hard link: %w: %s => %s", x.FilePath, linkErr, path, target)
+	}
+
+	// Fall back to a relative symlink when hard links are unavailable
+	// (e.g. target not extracted yet, or the filesystem does not support them).
+	x.Debugf("Hard link failed (%v); falling back to symlink: %s -> %s", linkErr, path, rel)
+
+	return x.createSymlink(path, rel)
+}

--- a/files.go
+++ b/files.go
@@ -902,3 +902,18 @@ func (x *XFile) clean(filePath string, trim ...string) string {
 
 	return filepath.Clean(filepath.Join(x.OutputDir, filePath))
 }
+
+// pathWithinOutput reports whether path is OutputDir or a descendant of it.
+// Uses filepath.Rel so sibling-prefix tricks like OutputDir=/tmp/out and
+// path=/tmp/out_evil fail (unlike strings.HasPrefix).
+func (x *XFile) pathWithinOutput(path string) bool {
+	outputDir := filepath.Clean(x.OutputDir)
+	cleanPath := filepath.Clean(path)
+
+	rel, err := filepath.Rel(outputDir, cleanPath)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/iso.go
+++ b/iso.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Unpackerr/iso9660"
 )
@@ -138,8 +137,7 @@ func (x *XFile) unisofile(isoFile *iso9660.File, wfile string) (uint64, []string
 		Mtime:    isoFile.ModTime(),
 	}
 
-	//nolint:gocritic // this 1-argument filepath.Join removes a ./ prefix should there be one.
-	if !strings.HasPrefix(file.Path, filepath.Join(x.OutputDir)) {
+	if !x.pathWithinOutput(file.Path) {
 		// The file being written is trying to write outside of our base path. Malicious ISO?
 		return 0, nil, fmt.Errorf("%s: %w: %s != %s (from: %s)",
 			x.FilePath, ErrInvalidPath, file.Path, x.OutputDir, isoFile.Name())

--- a/path_boundary_test.go
+++ b/path_boundary_test.go
@@ -1,0 +1,110 @@
+package xtractr_test
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golift.io/xtractr"
+)
+
+// TestSiblingPrefixBoundaryBypass ensures archive entries like ../out_evil/file
+// cannot escape OutputDir via a strings.HasPrefix sibling-prefix trick
+// (OutputDir=/tmp/out, escaped=/tmp/out_evil/...). See Unpackerr/unpackerr#641.
+func TestSiblingPrefixBoundaryBypass(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	require.NoError(t, os.MkdirAll(out, 0o750))
+
+	zipPath := filepath.Join(base, "malicious.zip")
+	tarPath := filepath.Join(base, "malicious.tar")
+
+	require.NoError(t, writeZipWithTraversal(zipPath, "../out_evil/escaped_zip.txt", "ZIP-BYPASS"))
+	require.NoError(t, writeTarWithTraversal(tarPath, "../out_evil/escaped_tar.txt", "TAR-BYPASS"))
+
+	_, _, zipErr := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  zipPath,
+		OutputDir: out,
+		FileMode:  0o644,
+		DirMode:   0o755,
+	})
+	_, _, tarErr := xtractr.ExtractTar(&xtractr.XFile{
+		FilePath:  tarPath,
+		OutputDir: out,
+		FileMode:  0o644,
+		DirMode:   0o755,
+	})
+
+	require.ErrorIs(t, zipErr, xtractr.ErrInvalidPath)
+	require.ErrorIs(t, tarErr, xtractr.ErrInvalidPath)
+
+	_, zipReadErr := os.ReadFile(filepath.Join(base, "out_evil", "escaped_zip.txt"))
+	_, tarReadErr := os.ReadFile(filepath.Join(base, "out_evil", "escaped_tar.txt"))
+
+	require.ErrorIs(t, zipReadErr, os.ErrNotExist)
+	require.ErrorIs(t, tarReadErr, os.ErrNotExist)
+}
+
+func writeZipWithTraversal(path, name, payload string) error {
+	var buf bytes.Buffer
+
+	zipWriter := zip.NewWriter(&buf)
+
+	writer, err := zipWriter.Create(name)
+	if err != nil {
+		return fmt.Errorf("create zip entry: %w", err)
+	}
+
+	_, err = writer.Write([]byte(payload))
+	if err != nil {
+		return fmt.Errorf("write zip payload: %w", err)
+	}
+
+	err = zipWriter.Close()
+	if err != nil {
+		return fmt.Errorf("close zip: %w", err)
+	}
+
+	err = os.WriteFile(path, buf.Bytes(), 0o600)
+	if err != nil {
+		return fmt.Errorf("write zip file: %w", err)
+	}
+
+	return nil
+}
+
+func writeTarWithTraversal(path, name, payload string) error {
+	var buf bytes.Buffer
+
+	tarWriter := tar.NewWriter(&buf)
+	data := []byte(payload)
+
+	err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(data))})
+	if err != nil {
+		return fmt.Errorf("write tar header: %w", err)
+	}
+
+	_, err = tarWriter.Write(data)
+	if err != nil {
+		return fmt.Errorf("write tar payload: %w", err)
+	}
+
+	err = tarWriter.Close()
+	if err != nil {
+		return fmt.Errorf("close tar: %w", err)
+	}
+
+	err = os.WriteFile(path, buf.Bytes(), 0o600)
+	if err != nil {
+		return fmt.Errorf("write tar file: %w", err)
+	}
+
+	return nil
+}

--- a/rar.go
+++ b/rar.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/nwaples/rardecode/v2"
@@ -129,8 +128,8 @@ func (x *XFile) unrar(rarReader *rardecode.ReadCloser) ([]string, error) {
 		case rardecode.RedirUnixSymlink, rardecode.RedirWindowsSymlink, rardecode.RedirWindowsJunction:
 			file.FileMode |= os.ModeSymlink
 		}
-		//nolint:gocritic // this 1-argument filepath.Join removes a ./ prefix should there be one.
-		if !strings.HasPrefix(file.Path, filepath.Join(x.OutputDir)) {
+
+		if !x.pathWithinOutput(file.Path) {
 			// The file being written is trying to write outside of our base path. Malicious archive?
 			return files, fmt.Errorf("%s: %w: %s != %s (from: %s)",
 				x.FilePath, ErrInvalidPath, file.Path, x.OutputDir, header.Name)

--- a/tar.go
+++ b/tar.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	lzw "github.com/sshaman1101/dcompress"
@@ -203,20 +202,6 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 	x.Debugf("Writing archived file: %s (bytes: %d)", file.Path, header.FileInfo().Size())
 
 	return x.write(file)
-}
-
-// pathWithinOutput reports whether path is OutputDir or a descendant of it.
-// Uses filepath.Rel so prefix tricks like OutputDir=/tmp/out and path=/tmp/outside fail.
-func (x *XFile) pathWithinOutput(path string) bool {
-	outputDir := filepath.Clean(x.OutputDir)
-	cleanPath := filepath.Clean(path)
-
-	rel, err := filepath.Rel(outputDir, cleanPath)
-	if err != nil {
-		return false
-	}
-
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // resolveLinkTarget returns the cleaned filesystem path a link would resolve to.

--- a/tar.go
+++ b/tar.go
@@ -204,25 +204,6 @@ func (x *XFile) untarFile(header *tar.Header, tarReader *tar.Reader) (uint64, er
 	return x.write(file)
 }
 
-// resolveLinkTarget returns the cleaned filesystem path a link would resolve to.
-func resolveLinkTarget(linkPath, linkName string) string {
-	if filepath.IsAbs(linkName) {
-		return filepath.Clean(linkName)
-	}
-
-	return filepath.Clean(filepath.Join(filepath.Dir(linkPath), linkName))
-}
-
-// ensureLinkWithinOutput rejects symlink targets that escape OutputDir.
-func (x *XFile) ensureLinkWithinOutput(linkPath, linkName string) error {
-	resolved := resolveLinkTarget(linkPath, linkName)
-	if !x.pathWithinOutput(resolved) {
-		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, resolved, linkName)
-	}
-
-	return nil
-}
-
 // untarLink creates a symlink or hard link from a tar header.
 func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
 	err := x.mkDir(filepath.Dir(path), x.DirMode, header.ModTime)
@@ -243,64 +224,4 @@ func (x *XFile) untarLink(header *tar.Header, path string) (uint64, error) {
 	}
 
 	return 0, nil
-}
-
-func (x *XFile) createSymlink(path, linkName string) error {
-	if linkName == "" {
-		x.Printf("Warning: skipping symlink with empty target: %s", path)
-
-		return errSkipEntry
-	}
-
-	err := x.ensureLinkWithinOutput(path, linkName)
-	if err != nil {
-		return err
-	}
-
-	x.Debugf("Writing archived symlink: %s -> %s", path, linkName)
-
-	err = os.Symlink(linkName, path)
-	if err != nil {
-		return fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, linkName)
-	}
-
-	return nil
-}
-
-func (x *XFile) createHardLink(path, linkName string) error {
-	if linkName == "" {
-		x.Printf("Warning: skipping hard link with empty target: %s", path)
-
-		return errSkipEntry
-	}
-
-	// Hard-link names are archive member paths, not arbitrary filesystem paths.
-	if filepath.IsAbs(linkName) {
-		return fmt.Errorf("%s: %w: %s", x.FilePath, ErrInvalidPath, linkName)
-	}
-
-	target := x.clean(linkName)
-	if !x.pathWithinOutput(target) {
-		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, linkName)
-	}
-
-	x.Debugf("Writing archived hard link: %s => %s", path, target)
-
-	err := os.Link(target, path)
-	if err == nil {
-		return nil
-	}
-
-	linkErr := err
-
-	rel, relErr := filepath.Rel(filepath.Dir(path), target)
-	if relErr != nil {
-		return fmt.Errorf("%s: creating hard link: %w: %s => %s", x.FilePath, linkErr, path, target)
-	}
-
-	// Fall back to a relative symlink when hard links are unavailable
-	// (e.g. target not extracted yet, or the filesystem does not support them).
-	x.Debugf("Hard link failed (%v); falling back to symlink: %s -> %s", linkErr, path, rel)
-
-	return x.createSymlink(path, rel)
 }

--- a/udf.go
+++ b/udf.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"golift.io/udf"
 )
@@ -122,8 +121,7 @@ func (x *XFile) unUDFFile(entry *udf.File, parent string) (uint64, []string, err
 		Mtime:    entry.ModTime(),
 	}
 
-	//nolint:gocritic
-	if !strings.HasPrefix(output.Path, filepath.Join(x.OutputDir)) {
+	if !x.pathWithinOutput(output.Path) {
 		return 0, nil, fmt.Errorf("%s: %w: %s != %s (from: %s)",
 			x.FilePath, ErrInvalidPath, output.Path, x.OutputDir, entry.Name())
 	}

--- a/zip.go
+++ b/zip.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 )
@@ -99,7 +98,7 @@ func (x *XFile) zipPrepareEntries(
 		decodedName := decodeZipFilename(zipFile.Name, zipFile.Extra, zipFile.NonUTF8, decoder)
 		cleanPath := x.clean(decodedName)
 
-		if !strings.HasPrefix(cleanPath, x.OutputDir) {
+		if !x.pathWithinOutput(cleanPath) {
 			return nil, files, fmt.Errorf("%s: %s: %w: %s (from: %s)",
 				x.FilePath, zipFile.FileInfo().Name(), ErrInvalidPath, cleanPath, decodedName)
 		}
@@ -196,7 +195,7 @@ func (x *XFile) unzipWithName(zipFile *zip.File, name string) (uint64, string, e
 		Atime:    time.Now(),
 	}
 
-	if !strings.HasPrefix(file.Path, x.OutputDir) {
+	if !x.pathWithinOutput(file.Path) {
 		// The file being written is trying to write outside of our base path. Malicious archive?
 		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, name)
 		return 0, file.Path, err


### PR DESCRIPTION
## Summary
- Replace `strings.HasPrefix(..., OutputDir)` with separator-aware `pathWithinOutput` across ZIP, 7z, RAR, CPIO, AR, ISO, and UDF (TAR already used it).
- Add regression coverage for the `../out_evil` sibling-prefix bypass from Unpackerr/unpackerr#641.

Re-opened for review after an accidental force-merge of the earlier PR (#157); that merge was reverted in #158 and the premature `v0.4.1` tag/release was deleted.

## Test plan
- [ ] `go test ./...`
- [ ] `golangci-lint run ./...`
- [ ] `TestSiblingPrefixBoundaryBypass` rejects ZIP and TAR traversal into `out_evil`

Made with [Cursor](https://cursor.com)