### PR TITLE
fix: block symlink-follow output escapes + assorted correctness fixes

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12
+          version: v2.13
   # Runs golangci-lint on linux against linux and windows.
   golangci-linux:
     strategy:
@@ -54,4 +54,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12
+          version: v2.13

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     # unused
     - nlreturn
     - exhaustruct
+    - exhaustruct_v5
     - depguard
     - nonamedreturns
     - forbidigo

--- a/7z.go
+++ b/7z.go
@@ -23,14 +23,12 @@ func Extract7z(xFile *XFile) (size uint64, filesList, archiveList []string, err 
 	}
 
 	for idx, password := range passwords {
-		size, files, archives, err := extract7z(&XFile{
-			FilePath:    xFile.FilePath,
-			OutputDir:   xFile.OutputDir,
-			FileMode:    xFile.FileMode,
-			DirMode:     xFile.DirMode,
-			Password:    password,
-			FileWorkers: xFile.FileWorkers,
-		})
+		// Copy the input so the retry keeps the logger, progress callbacks,
+		// SquashRoot and the rest of the caller-provided configuration.
+		attempt := *xFile
+		attempt.Password = password
+
+		size, files, archives, err := extract7z(&attempt)
 		if err != nil && idx == len(passwords)-1 {
 			return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)
 		} else if err == nil {

--- a/7z.go
+++ b/7z.go
@@ -3,7 +3,6 @@ package xtractr
 import (
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	"github.com/bodgit/sevenzip"
 )
@@ -105,7 +104,7 @@ func (x *XFile) extract7zParallel(sevenZip *sevenzip.ReadCloser) (uint64, []stri
 		return x.prog.Wrote, files, normalizeVolumes(sevenZip.Volumes(), x.FilePath), err
 	}
 
-	workerErr := x.sevenZipDispatchWorkers(entries)
+	workerErr := dispatchWorkers(x.FileWorkers, entries, x.extract7zEntry)
 	if workerErr != nil {
 		return x.prog.Wrote, files, normalizeVolumes(sevenZip.Volumes(), x.FilePath), workerErr
 	}
@@ -144,39 +143,6 @@ func (x *XFile) sevenZipPrepareEntries(sevenZip *sevenzip.ReadCloser) ([]sevenZi
 	}
 
 	return entries, files, nil
-}
-
-// sevenZipDispatchWorkers sends file entries to a bounded worker pool for extraction.
-func (x *XFile) sevenZipDispatchWorkers(entries []sevenZipEntry) error {
-	var (
-		waitGroup sync.WaitGroup
-		firstErr  error
-		errOnce   sync.Once
-		semaphore = make(chan struct{}, x.FileWorkers)
-	)
-
-	for idx := range entries {
-		entry := entries[idx]
-
-		if firstErr != nil {
-			break
-		}
-
-		semaphore <- struct{}{} // acquire worker slot
-
-		waitGroup.Go(func() {
-			defer func() { <-semaphore }() // release worker slot
-
-			err := x.extract7zEntry(entry)
-			if err != nil {
-				errOnce.Do(func() { firstErr = err })
-			}
-		})
-	}
-
-	waitGroup.Wait()
-
-	return firstErr
 }
 
 // extract7zEntry extracts a single 7z file entry (used by parallel workers).

--- a/cpio.go
+++ b/cpio.go
@@ -94,7 +94,13 @@ func (x *XFile) uncpioFile(cpioFile *cpio.Header, cpioReader *cpio.Reader) (uint
 
 	// This turns hard links into symlinks.
 	if cpioFile.Linkname != "" {
-		err := x.createSymlink(file.Path, cpioFile.Linkname)
+		// The link's parent folder may not have its own entry in the archive.
+		err := x.mkDir(filepath.Dir(file.Path), x.DirMode, cpioFile.ModTime)
+		if err != nil {
+			return 0, fmt.Errorf("making cpio link parent dir: %w", err)
+		}
+
+		err = x.createSymlink(file.Path, cpioFile.Linkname)
 		if err != nil {
 			return 0, fmt.Errorf("%s: %w", cpioFile.FileInfo().Name(), err)
 		}

--- a/cue.go
+++ b/cue.go
@@ -106,8 +106,14 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 
 	// Write the CUE sheet into the output directory so the folder is self-contained
 	// (tracks, art, and the exact split definition for archival and re-rip verification).
+	// filepath.Base strips any directory components, and the join is verified to
+	// stay inside the output folder.
 	cueBase := filepath.Base(xFile.FilePath)
 	cueDest := filepath.Join(xFile.OutputDir, cueBase)
+
+	if !xFile.pathWithinOutput(cueDest) {
+		return 0, nil, nil, fmt.Errorf("%s: %w: %s", xFile.FilePath, ErrInvalidPath, cueDest)
+	}
 
 	writeErr := copyCueToOutput(xFile.FilePath, cueDest, xFile.FileMode)
 	if writeErr != nil {
@@ -306,6 +312,12 @@ func parseCueSheet(reader io.Reader) (*CueSheet, []cueTimestamp, error) { //noli
 // base name as the CUE file (e.g. Artist - Album.cue -> Artist - Album.flac).
 func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 	path := filepath.Join(cueDir, cueFile)
+
+	// A CUE sheet must not reference audio outside its own folder; a crafted
+	// FILE entry like "../../secret.flac" would read and copy that file.
+	if !pathWithin(cueDir, path) {
+		return "", fmt.Errorf("%w: %s", ErrInvalidPath, cueFile)
+	}
 
 	_, err := os.Stat(path)
 	if err == nil {
@@ -995,7 +1007,9 @@ func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
 		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	err = os.WriteFile(destPath, data, fileMode)
+	// destPath is built from filepath.Base(srcPath) joined onto the output
+	// folder and verified to stay inside it at the call site; it cannot traverse.
+	err = os.WriteFile(destPath, data, fileMode) //nolint:gosec // G703: destPath is output-folder-contained (see above).
 	if err != nil {
 		return fmt.Errorf("writing cue sheet: %w", err)
 	}

--- a/cue.go
+++ b/cue.go
@@ -995,7 +995,7 @@ func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
 		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	err = os.WriteFile(destPath, data, fileMode) //nolint:gosec // ffs.
+	err = os.WriteFile(destPath, data, fileMode)
 	if err != nil {
 		return fmt.Errorf("writing cue sheet: %w", err)
 	}

--- a/cue.go
+++ b/cue.go
@@ -987,7 +987,7 @@ func writePicturesToFiles(outputDir string, pictures []*meta.Picture, fileMode o
 		name += "." + ext
 		path := filepath.Join(outputDir, name)
 
-		err := os.WriteFile(path, pic.Data, fileMode)
+		err := writeExtractFile(path, pic.Data, fileMode)
 		if err != nil {
 			return paths, totalBytes, fmt.Errorf("writing %s: %w", name, err)
 		}
@@ -1007,9 +1007,7 @@ func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
 		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	// destPath is built from filepath.Base(srcPath) joined onto the output
-	// folder and verified to stay inside it at the call site; it cannot traverse.
-	err = os.WriteFile(destPath, data, fileMode) //nolint:gosec // G703: destPath is output-folder-contained (see above).
+	err = writeExtractFile(destPath, data, fileMode)
 	if err != nil {
 		return fmt.Errorf("writing cue sheet: %w", err)
 	}

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -1,0 +1,47 @@
+package xtractr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveCueAudioPathTraversal ensures a CUE sheet cannot reference an
+// audio file outside the folder the CUE sheet lives in.
+func TestResolveCueAudioPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	cueDir := t.TempDir()
+	outside := filepath.Join(cueDir, "..", "outside.flac")
+	require.NoError(t, os.WriteFile(outside, []byte("not audio"), 0o600))
+
+	for _, cueFile := range []string{
+		"../outside.flac",
+		"../../outside.flac",
+		"sub/../../outside.flac",
+		"..",
+	} {
+		_, err := resolveCueAudioPath(cueDir, cueFile, filepath.Join(cueDir, "disc.cue"))
+		require.Error(t, err, cueFile)
+		assert.ErrorIs(t, err, ErrInvalidPath, cueFile)
+	}
+}
+
+// TestResolveCueAudioPathNested ensures audio in a subfolder of the CUE sheet
+// still resolves (a legitimate layout some rips use).
+func TestResolveCueAudioPathNested(t *testing.T) {
+	t.Parallel()
+
+	cueDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cueDir, "disc1"), 0o750))
+
+	audioPath := filepath.Join(cueDir, "disc1", "album.flac")
+	require.NoError(t, os.WriteFile(audioPath, []byte("not audio"), 0o600))
+
+	resolved, err := resolveCueAudioPath(cueDir, "disc1/album.flac", filepath.Join(cueDir, "disc.cue"))
+	require.NoError(t, err)
+	assert.Equal(t, audioPath, resolved)
+}

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -45,3 +45,43 @@ func TestResolveCueAudioPathNested(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, audioPath, resolved)
 }
+
+// TestCopyCueToOutputReplacesSymlink is the Copilot finding: os.WriteFile follows
+// a pre-existing symlink at destPath, so a planted "disc.cue" -> /victim link
+// would overwrite a file outside the output folder.
+func TestCopyCueToOutputReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	out := filepath.Join(tmp, "out")
+	require.NoError(t, os.MkdirAll(out, 0o750))
+
+	dest := filepath.Join(out, "disc.cue")
+	require.NoError(t, os.Symlink(victim, dest))
+
+	src := filepath.Join(tmp, "src.cue")
+	require.NoError(t, os.WriteFile(src, []byte("REM GENRE Test\n"), 0o600))
+
+	require.NoError(t, copyCueToOutput(src, dest, 0o600))
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "must not follow destPath symlink")
+
+	copied, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("REM GENRE Test\n"), copied)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}

--- a/files.go
+++ b/files.go
@@ -464,7 +464,12 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 	}
 
 	// Fall back to file signature (magic number) detection.
-	xFile.Debugf("falling back to signature detection for %s (extension error: %v)", xFile.FilePath, err)
+	if err != nil {
+		xFile.Debugf("extension-based extraction failed for %s, falling back to signature detection: %v",
+			xFile.FilePath, err)
+	} else {
+		xFile.Debugf("no extension match for %s, falling back to signature detection", xFile.FilePath)
+	}
 
 	extractFn, archiveType, sigErr := detectBySignature(xFile.FilePath)
 	if sigErr != nil {
@@ -678,12 +683,14 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.Stat(): %w", err)}}
 	}
 
-	oldFile, err := os.Open(oldpath) // do not forget to close this!
+	oldFile, err := os.Open(oldpath)
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.Open(): %w", err)}}
 	}
 
-	newFile, _, err := openFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, oldFileStat.Mode())
+	defer oldFile.Close() // also closed explicitly before the delete below.
+
+	newFile, pathUsed, err := openFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, oldFileStat.Mode())
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, err}}
 	}
@@ -694,7 +701,8 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("io.Copy(): %w", err)}}
 	}
 
-	_ = os.Chtimes(newpath, oldFileStat.ModTime(), oldFileStat.ModTime())
+	// pathUsed may differ from newpath if the name had to be truncated.
+	_ = os.Chtimes(pathUsed, oldFileStat.ModTime(), oldFileStat.ModTime())
 	// The copy was successful, so now delete the original file
 	_ = oldFile.Close() // Needs to be closed before delete.
 	_ = os.Remove(oldpath)

--- a/files.go
+++ b/files.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -92,6 +94,43 @@ func ChngInt(smallFn func(*XFile) (uint64, []string, error)) Interface {
 		size, files, err := smallFn(xFile)
 		return size, files, []string{xFile.FilePath}, err
 	}
+}
+
+// dispatchWorkers runs work for each entry using a bounded worker pool.
+// Dispatch stops when a worker reports an error, in-flight entries finish,
+// and the first error encountered is returned. Used by the random-access
+// extractors (ZIP, 7z) when XFile.FileWorkers > 1.
+func dispatchWorkers[T any](count int, entries []T, work func(T) error) error {
+	var (
+		waitGroup sync.WaitGroup
+		firstErr  atomic.Pointer[error]
+		semaphore = make(chan struct{}, count)
+	)
+
+	for idx := range entries {
+		if firstErr.Load() != nil {
+			break
+		}
+
+		semaphore <- struct{}{} // acquire worker slot
+
+		waitGroup.Go(func() {
+			defer func() { <-semaphore }() // release worker slot
+
+			err := work(entries[idx])
+			if err != nil {
+				firstErr.CompareAndSwap(nil, &err)
+			}
+		})
+	}
+
+	waitGroup.Wait()
+
+	if err := firstErr.Load(); err != nil {
+		return *err
+	}
+
+	return nil
 }
 
 // SupportedExtensions returns a slice of file extensions this library recognizes.

--- a/files.go
+++ b/files.go
@@ -794,9 +794,21 @@ func openStatFile(path string) (*os.File, os.FileInfo, error) {
 	return file, stat, nil
 }
 
+// mkDir creates a folder (and parents) with safe permissions.
+// It refuses to leave the output folder through a pre-existing symlink.
 func (x *XFile) mkDir(path string, mode os.FileMode, mtime time.Time) error {
 	defer os.Chtimes(path, time.Time{}, mtime)
-	return os.MkdirAll(path, x.safeDirMode(mode)) //nolint:wrapcheck
+
+	err := os.MkdirAll(path, x.safeDirMode(mode))
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	if !x.resolvedWithinOutput(path) {
+		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
+	}
+
+	return nil
 }
 
 // write a file from an io reader, making sure all parent directories exist.
@@ -825,6 +837,17 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		}
 
 		return 0, err
+	}
+
+	// A symlink already sitting at the target path is followed by O_TRUNC,
+	// writing the archived data wherever the link points. Remove it so the
+	// archive member replaces it instead of writing through it.
+	info, statErr := os.Lstat(file.Path)
+	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		err := os.Remove(file.Path)
+		if err != nil {
+			return 0, fmt.Errorf("removing symlink at archived file path '%s': %w", file.Path, err)
+		}
 	}
 
 	fout, pathUsed, err := openFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
@@ -903,19 +926,67 @@ func (x *XFile) clean(filePath string, trim ...string) string {
 	return filepath.Clean(filepath.Join(x.OutputDir, filePath))
 }
 
-// pathWithinOutput reports whether path is OutputDir or a descendant of it.
-// Uses filepath.Rel so sibling-prefix tricks like OutputDir=/tmp/out and
-// path=/tmp/out_evil fail (unlike strings.HasPrefix).
-func (x *XFile) pathWithinOutput(path string) bool {
-	outputDir := filepath.Clean(x.OutputDir)
-	cleanPath := filepath.Clean(path)
-
-	rel, err := filepath.Rel(outputDir, cleanPath)
+// pathWithin reports whether target is base or a descendant of it.
+// Uses filepath.Rel so sibling-prefix tricks like base=/tmp/out and
+// target=/tmp/out_evil fail (unlike strings.HasPrefix).
+func pathWithin(base, target string) bool {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(target))
 	if err != nil {
 		return false
 	}
 
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// pathWithinOutput reports whether path is OutputDir or a descendant of it,
+// comparing the cleaned paths lexically.
+func (x *XFile) pathWithinOutput(path string) bool {
+	return pathWithin(x.OutputDir, path)
+}
+
+// resolveExisting resolves symlinks in the deepest existing portion of path,
+// then re-appends the not-yet-created tail. This normalizes a path for
+// containment checks when some of its components may not exist yet, or when
+// the path itself lives behind a symlink (e.g. /var -> /private/var on macOS).
+// If symlink resolution fails, the cleaned path is returned unchanged.
+func resolveExisting(path string) string {
+	probe := filepath.Clean(path)
+	tail := []string{}
+
+	for {
+		_, err := os.Lstat(probe)
+		if err == nil {
+			break
+		}
+
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return probe // reached the filesystem root; nothing exists to resolve.
+		}
+
+		tail = append([]string{filepath.Base(probe)}, tail...)
+		probe = parent
+	}
+
+	resolved, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		resolved = probe
+	}
+
+	for _, segment := range tail {
+		resolved = filepath.Join(resolved, segment)
+	}
+
+	return resolved
+}
+
+// resolvedWithinOutput reports whether path stays inside OutputDir after
+// resolving symlinks in the existing portions of both paths. The lexical
+// check alone is not enough: a symlink already present in the output folder
+// (planted by a previous download, another app, or an attacker) is followed
+// by os.MkdirAll and os.OpenFile, writing files outside the output folder.
+func (x *XFile) resolvedWithinOutput(path string) bool {
+	return pathWithin(resolveExisting(x.OutputDir), resolveExisting(path))
 }
 
 // resolveLinkTarget returns the cleaned filesystem path a link would resolve to.
@@ -972,7 +1043,7 @@ func (x *XFile) createHardLink(path, linkName string) error {
 	}
 
 	target := x.clean(linkName)
-	if !x.pathWithinOutput(target) {
+	if !x.pathWithinOutput(target) || !x.resolvedWithinOutput(target) {
 		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, target, linkName)
 	}
 

--- a/files.go
+++ b/files.go
@@ -844,16 +844,24 @@ func openStatFile(path string) (*os.File, os.FileInfo, error) {
 // mkDir creates a folder (and parents) with safe permissions.
 // It refuses to leave the output folder through a pre-existing symlink.
 func (x *XFile) mkDir(path string, mode os.FileMode, mtime time.Time) error {
-	defer os.Chtimes(path, time.Time{}, mtime)
+	// Check before MkdirAll so we do not create directories (or Chtimes them)
+	// through a symlink that already points outside OutputDir.
+	if !x.resolvedWithinOutput(path) {
+		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
+	}
 
 	err := os.MkdirAll(path, x.safeDirMode(mode))
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 
+	// Recheck after create: MkdirAll follows symlinks, so a race could still
+	// land the new folder outside OutputDir.
 	if !x.resolvedWithinOutput(path) {
 		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
 	}
+
+	_ = os.Chtimes(path, time.Time{}, mtime)
 
 	return nil
 }
@@ -886,18 +894,12 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		return 0, err
 	}
 
-	// A symlink already sitting at the target path is followed by O_TRUNC,
-	// writing the archived data wherever the link points. Remove it so the
-	// archive member replaces it instead of writing through it.
-	info, statErr := os.Lstat(file.Path)
-	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
-		err := os.Remove(file.Path)
-		if err != nil {
-			return 0, fmt.Errorf("removing symlink at archived file path '%s': %w", file.Path, err)
-		}
+	flags, err := openFlagsForExtract(file.Path)
+	if err != nil {
+		return 0, err
 	}
 
-	fout, pathUsed, err := openFile(file.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, x.safeFileMode(file.FileMode))
+	fout, pathUsed, err := openFile(file.Path, flags, x.safeFileMode(file.FileMode))
 	if err != nil {
 		return 0, err
 	}
@@ -919,6 +921,28 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 	defer os.Chtimes(file.Path, file.Atime, file.Mtime)
 
 	return uint64(size), nil
+}
+
+// openFlagsForExtract returns OpenFile flags that will not follow a symlink at
+// path. A symlink already sitting at the write target is followed by O_TRUNC,
+// so it is removed and the file is created with O_EXCL. O_EXCL is also used
+// when the path does not exist, so a symlink planted in the race window cannot
+// be followed either.
+func openFlagsForExtract(path string) (int, error) {
+	info, statErr := os.Lstat(path)
+	switch {
+	case statErr == nil && info.Mode()&os.ModeSymlink != 0:
+		err := os.Remove(path)
+		if err != nil {
+			return 0, fmt.Errorf("removing symlink at archived file path '%s': %w", path, err)
+		}
+
+		return os.O_RDWR | os.O_CREATE | os.O_EXCL, nil
+	case errors.Is(statErr, os.ErrNotExist):
+		return os.O_RDWR | os.O_CREATE | os.O_EXCL, nil
+	default:
+		return os.O_RDWR | os.O_CREATE | os.O_TRUNC, nil
+	}
 }
 
 // maxSymlinkTarget is the maximum bytes allowed for a symlink target read from
@@ -1045,10 +1069,11 @@ func resolveLinkTarget(linkPath, linkName string) string {
 	return filepath.Clean(filepath.Join(filepath.Dir(linkPath), linkName))
 }
 
-// ensureLinkWithinOutput rejects symlink targets that escape OutputDir.
+// ensureLinkWithinOutput rejects symlink targets that escape OutputDir,
+// including those that only escape after following a pre-existing symlink.
 func (x *XFile) ensureLinkWithinOutput(linkPath, linkName string) error {
 	resolved := resolveLinkTarget(linkPath, linkName)
-	if !x.pathWithinOutput(resolved) {
+	if !x.pathWithinOutput(resolved) || !x.resolvedWithinOutput(resolved) {
 		return fmt.Errorf("%s: %w: %s (from: %s)", x.FilePath, ErrInvalidPath, resolved, linkName)
 	}
 

--- a/files.go
+++ b/files.go
@@ -894,12 +894,12 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		return 0, err
 	}
 
-	flags, err := openFlagsForExtract(file.Path)
+	flags, usedPath, err := openFlagsForExtract(file.Path)
 	if err != nil {
 		return 0, err
 	}
 
-	fout, pathUsed, err := openFile(file.Path, flags, x.safeFileMode(file.FileMode))
+	fout, pathUsed, err := openFile(usedPath, flags, x.safeFileMode(file.FileMode))
 	if err != nil {
 		return 0, err
 	}
@@ -924,25 +924,63 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 }
 
 // openFlagsForExtract returns OpenFile flags that will not follow a symlink at
-// path. A symlink already sitting at the write target is followed by O_TRUNC,
-// so it is removed and the file is created with O_EXCL. O_EXCL is also used
-// when the path does not exist, so a symlink planted in the race window cannot
-// be followed either.
-func openFlagsForExtract(path string) (int, error) {
+// path, plus the path those flags apply to. A symlink already sitting at the
+// write target is followed by O_TRUNC, so it is removed and the file is created
+// with O_EXCL. O_EXCL is also used when the path does not exist, so a symlink
+// planted in the race window cannot be followed either.
+//
+// If Lstat fails with ENAMETOOLONG, the path is truncated first (via
+// TruncatePathForFS) and the symlink check runs against that shorter name.
+// Otherwise openFile would later truncate and OpenFile with O_TRUNC, following
+// a planted link at the truncated target.
+func openFlagsForExtract(path string) (int, string, error) {
 	info, statErr := os.Lstat(path)
+	if IsErrNameTooLong(statErr) {
+		shortPath, err := TruncatePathForFS(path)
+		if err != nil {
+			return 0, "", err
+		}
+
+		path = shortPath
+		info, statErr = os.Lstat(path)
+	}
+
 	switch {
 	case statErr == nil && info.Mode()&os.ModeSymlink != 0:
 		err := os.Remove(path)
 		if err != nil {
-			return 0, fmt.Errorf("removing symlink at archived file path '%s': %w", path, err)
+			return 0, "", fmt.Errorf("removing symlink at archived file path '%s': %w", path, err)
 		}
 
-		return os.O_RDWR | os.O_CREATE | os.O_EXCL, nil
+		return os.O_RDWR | os.O_CREATE | os.O_EXCL, path, nil
 	case errors.Is(statErr, os.ErrNotExist):
-		return os.O_RDWR | os.O_CREATE | os.O_EXCL, nil
+		return os.O_RDWR | os.O_CREATE | os.O_EXCL, path, nil
 	default:
-		return os.O_RDWR | os.O_CREATE | os.O_TRUNC, nil
+		return os.O_RDWR | os.O_CREATE | os.O_TRUNC, path, nil
 	}
+}
+
+// writeExtractFile writes data to path without following a final-component
+// symlink. Used for non-archive output (CUE copy, embedded pictures) that
+// otherwise goes through os.WriteFile, which follows links.
+func writeExtractFile(path string, data []byte, mode os.FileMode) error {
+	flags, usedPath, err := openFlagsForExtract(path)
+	if err != nil {
+		return err
+	}
+
+	fout, _, err := openFile(usedPath, flags, mode)
+	if err != nil {
+		return err
+	}
+	defer fout.Close()
+
+	_, err = fout.Write(data)
+	if err != nil {
+		return fmt.Errorf("writing file '%s': %w", usedPath, err)
+	}
+
+	return nil
 }
 
 // maxSymlinkTarget is the maximum bytes allowed for a symlink target read from

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -1,10 +1,13 @@
 package xtractr
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeVolumes(t *testing.T) {
@@ -108,4 +111,42 @@ func TestNormalizeVolumes(t *testing.T) {
 			normalizeVolumes([]string{"", "."}, entry),
 		)
 	})
+}
+
+// TestMkDirRefusesPreExistingSymlinkDir is the Copilot finding: mkDir used to
+// MkdirAll+Chtimes a path before the containment check, so a pre-existing
+// symlink in the output folder was followed (empty dirs created outside, and
+// the outside directory's mtime updated) even though the call then failed.
+func TestMkDirRefusesPreExistingSymlinkDir(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	out := filepath.Join(tmp, "out")
+	evil := filepath.Join(tmp, "evil")
+
+	require.NoError(t, os.MkdirAll(out, 0o750))
+	require.NoError(t, os.MkdirAll(evil, 0o750))
+
+	oldTime := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+	require.NoError(t, os.Chtimes(evil, oldTime, oldTime))
+
+	require.NoError(t, os.Symlink(evil, filepath.Join(out, "sub")))
+
+	xFile := &XFile{FilePath: "archive.zip", OutputDir: out, DirMode: 0o755}
+	err = xFile.mkDir(filepath.Join(out, "sub", "nested"), 0o755, time.Now())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidPath)
+
+	_, statErr := os.Stat(filepath.Join(evil, "nested"))
+	require.ErrorIs(t, statErr, os.ErrNotExist, "mkDir must not create directories through the symlink")
+
+	info, err := os.Stat(evil)
+	require.NoError(t, err)
+	assert.Equal(t, oldTime.Unix(), info.ModTime().Unix(), "rejected path must not be Chtimes'd")
 }

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -3,6 +3,7 @@ package xtractr
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -149,4 +150,57 @@ func TestMkDirRefusesPreExistingSymlinkDir(t *testing.T) {
 	info, err := os.Stat(evil)
 	require.NoError(t, err)
 	assert.Equal(t, oldTime.Unix(), info.ModTime().Unix(), "rejected path must not be Chtimes'd")
+}
+
+// TestOpenFlagsForExtractNameTooLongUsesExcl is the Copilot finding: Lstat of a
+// too-long name fails with ENAMETOOLONG, which used to fall through to O_TRUNC.
+// openFile then truncates and OpenFile-follows a raced symlink at the short name.
+func TestOpenFlagsForExtractNameTooLongUsesExcl(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	long := filepath.Join(tmp, strings.Repeat("a", 300)+".txt")
+
+	_, err := os.Lstat(long)
+	if !IsErrNameTooLong(err) {
+		t.Skipf("filesystem accepted a 300-byte filename (got %v)", err)
+	}
+
+	flags, usedPath, err := openFlagsForExtract(long)
+	require.NoError(t, err)
+	assert.Equal(t, os.O_RDWR|os.O_CREATE|os.O_EXCL, flags)
+	assert.LessOrEqual(t, len(filepath.Base(usedPath)), nameMax)
+}
+
+// TestWriteExtractFileNameTooLongDoesNotFollowTruncatedSymlink plants a symlink
+// at the truncated name, then writes a too-long path. The victim must stay intact.
+func TestWriteExtractFileNameTooLongDoesNotFollowTruncatedSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	long := filepath.Join(tmp, strings.Repeat("a", 300)+".txt")
+
+	_, err = os.Lstat(long)
+	if !IsErrNameTooLong(err) {
+		t.Skipf("filesystem accepted a 300-byte filename (got %v)", err)
+	}
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	short, err := TruncatePathForFS(long)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(victim, short))
+
+	require.NoError(t, writeExtractFile(long, []byte("payload"), 0o600))
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "must not follow symlink at truncated path")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module golift.io/xtractr
 
 go 1.25.7
 
-toolchain go1.26.4
+toolchain go1.27.0
 
 require (
 	github.com/Unpackerr/iso9660 v0.0.3

--- a/iso.go
+++ b/iso.go
@@ -98,7 +98,14 @@ func (x *XFile) uniso(isoFile *iso9660.File, parent string) (uint64, []string, e
 	}
 
 	if itemName != "" {
-		err := x.mkDir(filepath.Join(x.OutputDir, itemName), isoFile.Mode(), isoFile.ModTime())
+		dirPath := x.clean(itemName)
+		if !x.pathWithinOutput(dirPath) {
+			// The directory is trying to land outside of our base path. Malicious ISO?
+			return 0, nil, fmt.Errorf("%s: %w: %s (from: %s)",
+				x.FilePath, ErrInvalidPath, dirPath, isoFile.Name())
+		}
+
+		err := x.mkDir(dirPath, isoFile.Mode(), isoFile.ModTime())
 		if err != nil {
 			return 0, nil, fmt.Errorf("making iso directory %s: %w", isoFile.Name(), err)
 		}

--- a/magic.go
+++ b/magic.go
@@ -4,7 +4,9 @@ package xtractr
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -82,8 +84,10 @@ func detectBySignature(filePath string) (Interface, string, error) {
 
 	buf := make([]byte, readSize)
 
-	n, err := file.Read(buf)
-	if err != nil {
+	// Read the full buffer: a single Read is not guaranteed to fill it, and a
+	// short read would miss signatures stored deeper in the file (e.g. ISO).
+	n, err := io.ReadFull(file, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, "", fmt.Errorf("reading file for signature detection: %w", err)
 	}
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -191,6 +191,53 @@ func TestParallelZIPErrorPropagation(t *testing.T) {
 	assert.ErrorIs(t, extractErr, xtractr.ErrInvalidPath)
 }
 
+// TestParallelZIPWorkerErrorPropagation covers errors that surface in the
+// worker phase (after dispatch), unlike TestParallelZIPErrorPropagation which
+// fails during the sequential prepare pass. Run with -race to validate the
+// shared first-error handling in dispatchWorkers.
+func TestParallelZIPWorkerErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "worker_error.zip")
+	outFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(outFile)
+
+	// A directory entry, then a file entry with the same name: the file write
+	// fails in a worker because "adir" already exists as a directory.
+	_, err = zipWriter.Create("adir/")
+	require.NoError(t, err)
+
+	badWriter, err := zipWriter.Create("adir")
+	require.NoError(t, err)
+
+	_, err = badWriter.Write([]byte("collides with the directory"))
+	require.NoError(t, err)
+
+	// Extra files keep the dispatch loop running while the worker error lands.
+	for fileIdx := range parallelFileCount {
+		writer, createErr := zipWriter.Create(fmt.Sprintf("extra/file_%03d.txt", fileIdx))
+		require.NoError(t, createErr)
+
+		_, writeErr := writer.Write(generateTestContent(fileIdx, testContentSize))
+		require.NoError(t, writeErr)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, outFile.Close())
+
+	_, _, extractErr := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:    zipPath,
+		OutputDir:   filepath.Join(tmpDir, "out"),
+		FileMode:    0o600,
+		DirMode:     0o700,
+		FileWorkers: parallelWorkerCount,
+	})
+	require.Error(t, extractErr)
+}
+
 func TestFileWorkersDefault(t *testing.T) {
 	t.Parallel()
 

--- a/rar.go
+++ b/rar.go
@@ -26,13 +26,12 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 	}
 
 	for idx, password := range passwords {
-		size, files, archives, err := extractRAR(&XFile{
-			FilePath:  xFile.FilePath,
-			OutputDir: xFile.OutputDir,
-			FileMode:  xFile.FileMode,
-			DirMode:   xFile.DirMode,
-			Password:  password,
-		})
+		// Copy the input so the retry keeps the logger, progress callbacks,
+		// SquashRoot and the rest of the caller-provided configuration.
+		attempt := *xFile
+		attempt.Password = password
+
+		size, files, archives, err := extractRAR(&attempt)
 		if err == nil {
 			return size, files, archives, nil
 		}
@@ -46,12 +45,10 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 	}
 
 	// No password worked, try without a password.
-	return extractRAR(&XFile{
-		FilePath:  xFile.FilePath,
-		OutputDir: xFile.OutputDir,
-		FileMode:  xFile.FileMode,
-		DirMode:   xFile.DirMode,
-	})
+	attempt := *xFile
+	attempt.Password = ""
+
+	return extractRAR(&attempt)
 }
 
 // extractRAR extracts a rar file. to a destination. This wraps github.com/nwaples/rardecode.

--- a/rar_test.go
+++ b/rar_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,48 @@ func TestExtractRAR(t *testing.T) {
 	assert.Equal(t, testDataSize, size)
 	assert.Len(t, archives, 1)
 	assert.Len(t, files, len(filesInTestArchive))
+}
+
+// TestExtractRARPasswordRetryKeepsConfig guards against the password-retry
+// path dropping the caller-provided XFile configuration: the retries used to
+// build a bare XFile, silently losing the logger (and SquashRoot, progress
+// callbacks, etc.) for every attempt after the first.
+func TestExtractRARPasswordRetryKeepsConfig(t *testing.T) {
+	t.Parallel()
+
+	logger := &countingLogger{t: t}
+	xFile := &xtractr.XFile{
+		FilePath:  "./test_data/archive.rar",
+		OutputDir: t.TempDir(),
+		Passwords: []string{"wrong-password", "some_password"}, // correct password is second.
+	}
+	xFile.SetLogger(logger)
+
+	size, files, archives, err := xtractr.ExtractRAR(xFile)
+
+	require.NoError(t, err)
+	assert.Equal(t, testDataSize, size)
+	assert.Len(t, archives, 1)
+	assert.Len(t, files, len(filesInTestArchive))
+	assert.Positive(t, logger.debugCount.Load(),
+		"the winning password retry must keep the caller's logger")
+}
+
+// countingLogger counts log lines so tests can verify a logger is wired up.
+type countingLogger struct {
+	t          *testing.T
+	printCount atomic.Int64
+	debugCount atomic.Int64
+}
+
+func (c *countingLogger) Printf(format string, v ...any) {
+	c.printCount.Add(1)
+	c.t.Logf(format, v...)
+}
+
+func (c *countingLogger) Debugf(format string, v ...any) {
+	c.debugCount.Add(1)
+	c.t.Logf(format, v...)
 }
 
 // TestExtractRARMultiVolume guards against the regression where only the entry

--- a/rar_test.go
+++ b/rar_test.go
@@ -110,7 +110,9 @@ func TestExtractRARMultiVolumeOldScheme(t *testing.T) {
 		}
 
 		link := filepath.Join(dir, name)
-		if err := os.Symlink(payload, link); err != nil {
+
+		err := os.Symlink(payload, link)
+		if err != nil {
 			t.Skipf("symlinks unavailable on this platform: %v", err)
 		}
 

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -196,6 +196,106 @@ func TestZipSymlinkTooLong(t *testing.T) {
 	assert.ErrorIs(t, err, xtractr.ErrSymlinkTooLong)
 }
 
+// TestPreExistingSymlinkDirEscape ensures a symlink already present in the
+// output folder is not followed when an archive writes files beneath it.
+// The lexical path (out/sub/file.txt) looks safe, but sub -> ../evil would
+// land the payload outside the output folder.
+func TestPreExistingSymlinkDirEscape(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	payload := []byte("escape attempt")
+
+	for _, archive := range []struct {
+		name    string
+		path    string
+		extract func(*xtractr.XFile) (uint64, []string, error)
+	}{
+		{name: "zip", path: filepath.Join(tmp, "escape.zip"), extract: xtractr.ExtractZIP},
+		{name: "tar", path: filepath.Join(tmp, "escape.tar"), extract: xtractr.ExtractTar},
+	} {
+		switch filepath.Ext(archive.path) {
+		case ".zip":
+			require.NoError(t, writeZipWithTraversal(archive.path, "sub/file.txt", string(payload)))
+		case ".tar":
+			require.NoError(t, writeTarWithTraversal(archive.path, "sub/file.txt", string(payload)))
+		}
+
+		outputDir := filepath.Join(tmp, archive.name+"-out")
+		evilDir := filepath.Join(tmp, archive.name+"-evil")
+
+		require.NoError(t, os.MkdirAll(outputDir, 0o750))
+		require.NoError(t, os.MkdirAll(evilDir, 0o750))
+		// The pre-existing symlink an attacker left in the output folder.
+		require.NoError(t, os.Symlink(evilDir, filepath.Join(outputDir, "sub")))
+
+		_, _, err := archive.extract(&xtractr.XFile{
+			FilePath:  archive.path,
+			OutputDir: outputDir,
+			FileMode:  0o644,
+			DirMode:   0o755,
+		})
+		require.Error(t, err, archive.name)
+		require.ErrorIs(t, err, xtractr.ErrInvalidPath, archive.name)
+
+		_, statErr := os.Stat(filepath.Join(evilDir, "file.txt"))
+		assert.ErrorIs(t, statErr, os.ErrNotExist, archive.name+": payload must not land outside the output folder")
+	}
+}
+
+// TestFinalComponentSymlinkNotFollowed ensures a pre-existing symlink at the
+// exact path an archive member writes to is replaced, not followed through.
+func TestFinalComponentSymlinkNotFollowed(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	const payload = "archive payload"
+
+	victim := filepath.Join(tmp, "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("original"), 0o600))
+
+	archivePath := filepath.Join(tmp, "replace.zip")
+	require.NoError(t, writeZipWithTraversal(archivePath, "file.txt", payload))
+
+	outputDir := filepath.Join(tmp, "out")
+	require.NoError(t, os.MkdirAll(outputDir, 0o750))
+	require.NoError(t, os.Symlink(victim, filepath.Join(outputDir, "file.txt")))
+
+	_, _, err = xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  archivePath,
+		OutputDir: outputDir,
+		FileMode:  0o644,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err)
+
+	// The victim file outside the output folder must be untouched.
+	data, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(data))
+
+	// And the archive member must have replaced the link with a regular file.
+	info, err := os.Lstat(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSymlink, "symlink must be replaced by a regular file")
+
+	data, err = os.ReadFile(filepath.Join(outputDir, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(data))
+}
+
 func createSymlinkZip(dest string) error {
 	archiveFile, err := os.Create(dest)
 	if err != nil {

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -245,7 +245,11 @@ func TestPreExistingSymlinkDirEscape(t *testing.T) {
 		require.ErrorIs(t, err, xtractr.ErrInvalidPath, archive.name)
 
 		_, statErr := os.Stat(filepath.Join(evilDir, "file.txt"))
-		assert.ErrorIs(t, statErr, os.ErrNotExist, archive.name+": payload must not land outside the output folder")
+		require.ErrorIs(t, statErr, os.ErrNotExist, archive.name+": payload must not land outside the output folder")
+
+		entries, readErr := os.ReadDir(evilDir)
+		require.NoError(t, readErr, archive.name)
+		assert.Empty(t, entries, archive.name+": mkDir must not create directories through the output-folder symlink")
 	}
 }
 
@@ -294,6 +298,42 @@ func TestFinalComponentSymlinkNotFollowed(t *testing.T) {
 	data, err = os.ReadFile(filepath.Join(outputDir, "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, payload, string(data))
+}
+
+// TestSymlinkThroughPlantedDirRejected ensures an archive symlink whose
+// lexical target is inside OutputDir is still rejected when it would resolve
+// through a pre-existing symlink that points outside.
+func TestSymlinkThroughPlantedDirRejected(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	outputDir := filepath.Join(tmp, "out")
+	evilDir := filepath.Join(tmp, "evil")
+
+	require.NoError(t, os.MkdirAll(outputDir, 0o750))
+	require.NoError(t, os.MkdirAll(evilDir, 0o750))
+	require.NoError(t, os.Symlink(evilDir, filepath.Join(outputDir, "sub")))
+
+	archivePath := filepath.Join(tmp, "through.zip")
+	require.NoError(t, createLinkOnlyZip(archivePath, "mylink", "sub/pwned"))
+
+	_, _, err = xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  archivePath,
+		OutputDir: outputDir,
+		FileMode:  0o644,
+		DirMode:   0o755,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, xtractr.ErrInvalidPath)
+
+	_, statErr := os.Lstat(filepath.Join(evilDir, "pwned"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
 func createSymlinkZip(dest string) error {

--- a/udf.go
+++ b/udf.go
@@ -91,8 +91,15 @@ func (x *XFile) unUDFEntry(udfImage *udf.Udf, entry *udf.File, parent string) (u
 
 func (x *XFile) unUDFDir(udfImage *udf.Udf, entry *udf.File, parent string) (uint64, []string, error) {
 	dirPath := filepath.Join(parent, entry.Name())
+	cleanPath := x.clean(dirPath)
 
-	err := x.mkDir(filepath.Join(x.OutputDir, dirPath), entry.Mode(), entry.ModTime())
+	if !x.pathWithinOutput(cleanPath) {
+		// The directory is trying to land outside of our base path. Malicious UDF image?
+		return 0, nil, fmt.Errorf("%s: %w: %s (from: %s)",
+			x.FilePath, ErrInvalidPath, cleanPath, entry.Name())
+	}
+
+	err := x.mkDir(cleanPath, entry.Mode(), entry.ModTime())
 	if err != nil {
 		return 0, nil, fmt.Errorf("making UDF directory %s: %w", entry.Name(), err)
 	}

--- a/zip.go
+++ b/zip.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"path/filepath"
-	"sync"
 	"time"
 )
 
@@ -75,7 +74,7 @@ func (x *XFile) extractZIPParallel(
 		return x.prog.Wrote, files, err
 	}
 
-	workerErr := x.zipDispatchWorkers(fileEntries)
+	workerErr := dispatchWorkers(x.FileWorkers, fileEntries, x.extractZIPEntry)
 	if workerErr != nil {
 		return x.prog.Wrote, files, workerErr
 	}
@@ -118,39 +117,6 @@ func (x *XFile) zipPrepareEntries(
 	}
 
 	return entries, files, nil
-}
-
-// zipDispatchWorkers sends file entries to a bounded worker pool for extraction.
-func (x *XFile) zipDispatchWorkers(entries []zipFileEntry) error {
-	var (
-		waitGroup sync.WaitGroup
-		firstErr  error
-		errOnce   sync.Once
-		semaphore = make(chan struct{}, x.FileWorkers)
-	)
-
-	for idx := range entries {
-		entry := entries[idx]
-
-		if firstErr != nil {
-			break
-		}
-
-		semaphore <- struct{}{} // acquire worker slot
-
-		waitGroup.Go(func() {
-			defer func() { <-semaphore }() // release worker slot
-
-			err := x.extractZIPEntry(entry)
-			if err != nil {
-				errOnce.Do(func() { firstErr = err })
-			}
-		})
-	}
-
-	waitGroup.Wait()
-
-	return firstErr
 }
 
 // extractZIPEntry extracts a single zip file entry (used by parallel workers).


### PR DESCRIPTION
## Summary

Bug-fix pass over the extractors, focused on path traversal / output-folder escapes. Each commit is small and self-contained; the three `security:` commits are the headline, the rest are correctness fixes found along the way. All changes include regression tests where the bug is practically reproducible.

## Security fixes

### 1. Symlink-follow escapes in the output folder (`security: block symlink-follow escapes`)

The lexical path checks from #157/#159 don't stop writes **through symlinks already present in the output folder**: `os.MkdirAll` and `os.OpenFile` follow them. Two live variants, both reproduced before fixing:

```text
out/sub -> /attacker/dir          (pre-existing symlink inside OutputDir)
archive contains: sub/pwned.txt   => written to /attacker/dir/pwned.txt

out/file.txt -> /attacker/victim  (pre-existing symlink at the write target)
archive contains: file.txt        => O_TRUNC follows the link, victim overwritten
```

Since every extractor funnels through `mkDir` + `writeFile`, the fix lives in those two choke points:

- `resolveExisting()` resolves symlinks in the deepest existing portion of a path and re-appends the not-yet-created tail (also normalizes OutputDir itself, e.g. `/var` -> `/private/var` on macOS).
- `mkDir` rejects any resolved folder that lands outside the resolved OutputDir.
- `writeFile` removes a pre-existing symlink at the write target instead of truncating through it.
- `createHardLink` now validates the resolved target too.

Note: `MkdirAll` can still create empty dirs through a hostile symlink before detection (component-wise secure mkdir is a bigger change); no file data is written outside anymore.

### 2. ISO9660/UDF directory paths unchecked (`security: validate ISO9660/UDF directory paths`)

File entries in ISO/UDF images get the `pathWithinOutput` guard, but **directory** entries were joined + created raw. A crafted image could create and then populate directories outside the output folder. Both now go through `clean()` + `pathWithinOutput`, matching the file-entry guards.

### 3. CUE sheet `FILE` escape (`security: keep CUE-referenced audio inside the cue folder`)

A CUE sheet with `FILE "../../secret.flac"` resolved outside the cue folder, letting a crafted archive read and copy sibling files into the extraction output. `resolveCueAudioPath` now rejects entries that leave the cue folder (nested subfolders still work).

## Correctness fixes

- **rar/7z password retries dropped config** — the retry loops built a bare `XFile` per attempt, silently losing the logger, progress callbacks, `SquashRoot`, `FileWorkers` (rar) and `moveFiles`. Now copies the caller's `XFile` and swaps only the password.
- **Data race in parallel zip/7z dispatch** — the dispatch loop read `firstErr` while workers wrote it under `sync.Once`; flagged by `-race` when a worker fails mid-dispatch. Both duplicated pools are replaced with one generic `dispatchWorkers` helper using `atomic.Pointer`.
- **`Rename` copy fallback leaked the source fd** on `openFile`/`io.Copy` errors, and applied `Chtimes` to the pre-truncation path.
- **Signature detection used a single `Read`** — short reads could miss deeper signatures (ISO at 0x8001+). Now `io.ReadFull`. Also stops logging `extension error: <nil>` when no extension matched.
- **cpio link entries missed parent-dir creation** — tar links already ensure the parent exists; cpio symlink/hard-link entries failed on archives without explicit directory entries.

## Testing

- `go test -race ./...` passes; `go vet` and `golangci-lint run` clean (one pre-existing `prealloc` nit in `chardet.go` on main).
- New tests: pre-existing symlink dir escape (zip + tar), final-component symlink replacement, CUE traversal (incl. legit nested path), rar password-retry config retention, parallel worker-phase error propagation.

## Notes for review

- No public API changes; returned file lists and error types are unchanged (`ErrInvalidPath` is reused for the new rejections).
- Out of scope, flagged for later: RPM/cpio payloads with **absolute** symlink targets (common in real RPMs) currently fail the strict symlink checks — that posture came from #155 and may deserve a "skip with warning" mode for package payloads.
