### PR TITLE
fix: detect CUE sheets named .cue.txt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,14 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["go", "github-releases", "github-tags"],
+      "description": "Automerge non-major Go module updates when checks pass",
+      "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions updates, including majors, when checks pass",
+      "matchManagers": ["github-actions"],
       "automerge": true
     }
   ]

--- a/cue.go
+++ b/cue.go
@@ -72,7 +72,7 @@ func (t cueTimestamp) toSamples(sampleRate uint32) uint64 {
 }
 
 // ExtractCUE extracts individual tracks from a FLAC file referenced by a CUE sheet.
-// The xFile.FilePath should point to the .cue file.
+// The xFile.FilePath should point to the .cue file (or .cue.txt).
 func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error) {
 	cue, timestamps, err := parseCueSheetFile(xFile.FilePath)
 	if err != nil {
@@ -330,7 +330,7 @@ func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 	}
 
 	// Fallback: try audio files with the same base name as the CUE file (handles O vs Ö, encoding mismatches).
-	baseNoExt := strings.TrimSuffix(filepath.Base(cueFilePath), filepath.Ext(cueFilePath))
+	baseNoExt := cueBaseName(cueFilePath)
 
 	for _, fallbackExt := range []string{".flac", ".ape"} {
 		fallbackPath := filepath.Join(cueDir, baseNoExt+fallbackExt)
@@ -342,6 +342,21 @@ func resolveCueAudioPath(cueDir, cueFile, cueFilePath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("%w: %s", ErrAudioNotFound, path)
+}
+
+// cueBaseName returns the CUE sheet filename without its sheet suffix.
+// Release groups sometimes ship the sheet as .cue.txt; filepath.Ext would only
+// strip .txt and leave a ".cue" stem that does not match album.flac.
+func cueBaseName(path string) string {
+	base := filepath.Base(path)
+	lower := strings.ToLower(base)
+
+	const cueTxtSuffix = ".cue.txt"
+	if strings.HasSuffix(lower, cueTxtSuffix) {
+		return base[:len(base)-len(cueTxtSuffix)]
+	}
+
+	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
 // splitCueLine splits a CUE line into its command and arguments.

--- a/cue_test.go
+++ b/cue_test.go
@@ -167,6 +167,8 @@ func TestCueParseCueSheet(t *testing.T) {
 
 	assert.True(t, xtractr.IsArchiveFile("test.cue"), ".cue should be recognized as an archive file")
 	assert.True(t, xtractr.IsArchiveFile("TEST.CUE"), ".CUE (uppercase) should be recognized")
+	assert.True(t, xtractr.IsArchiveFile("album.cue.txt"), ".cue.txt should be recognized as an archive file")
+	assert.True(t, xtractr.IsArchiveFile("ALBUM.CUE.TXT"), ".CUE.TXT (uppercase) should be recognized")
 }
 
 func TestCueExtractCUE(t *testing.T) {
@@ -380,6 +382,86 @@ func TestCueExtractViaExtractFile(t *testing.T) {
 	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
 	assert.Len(t, archiveList, 2)
 	assert.Positive(t, size)
+}
+
+// TestCueTxtExtractViaExtractFile covers release groups that ship the sheet as .cue.txt.
+func TestCueTxtExtractViaExtractFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(30 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track Two"`,
+		`    INDEX 01 00:15:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "album.cue.txt")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	found := xtractr.FindCompressedFiles(xtractr.Filter{Path: tmpDir})
+	require.Contains(t, found.List(), cuePath)
+
+	size, files, archiveList, err := xtractr.ExtractFile(&xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err, "ExtractFile with .cue.txt")
+	assert.Len(t, files, 3, "expected 2 track files + CUE sheet")
+	assert.Len(t, archiveList, 2)
+	assert.Positive(t, size)
+	assert.Contains(t, files, filepath.Join(outputDir, "album.cue.txt"))
+}
+
+// TestCueTxtBasenameFallback ensures album.cue.txt still finds album.flac when
+// the FILE line does not match (filepath.Ext would otherwise leave a ".cue" stem).
+func TestCueTxtBasenameFallback(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+
+	totalSamples := uint64(60 * testSampleRate)
+	flacPath := filepath.Join(tmpDir, "Album.flac")
+	generateTestFLAC(t, flacPath, totalSamples)
+
+	cueContent := strings.Join([]string{
+		`PERFORMER "Artist"`,
+		`TITLE "Album"`,
+		`FILE "Other Name.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "Track One"`,
+		`    INDEX 01 00:00:00`,
+		`  TRACK 02 AUDIO`,
+		`    TITLE "Track Two"`,
+		`    INDEX 01 00:30:00`,
+	}, "\n") + "\n"
+	cuePath := filepath.Join(tmpDir, "Album.cue.txt")
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	size, files, archiveList, err := xtractr.ExtractCUE(&xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err, "ExtractCUE should find Album.flac via same-basename fallback")
+	assert.Len(t, files, 3)
+	assert.Len(t, archiveList, 2)
+	assert.Positive(t, size)
+	assert.Contains(t, archiveList, flacPath)
 }
 
 func TestCueMissingFlac(t *testing.T) {
@@ -946,6 +1028,17 @@ func TestCueSupportedExtensions(t *testing.T) {
 	}
 
 	assert.True(t, found, ".cue should be in supported extensions list")
+
+	foundTxt := false
+
+	for _, ext := range extensions {
+		if strings.EqualFold(ext, ".cue.txt") {
+			foundTxt = true
+			break
+		}
+	}
+
+	assert.True(t, foundTxt, ".cue.txt should be in supported extensions list")
 }
 
 // generateStereoFLAC writes a stereo FLAC with distinct left/right channels using

--- a/files.go
+++ b/files.go
@@ -81,6 +81,7 @@ var extension2function = []archive{
 	{Type: "zstandard", Ext: ".zst", Fn: ChngInt(ExtractZstandard)},
 	{Type: "zstandard", Ext: ".zstd", Fn: ChngInt(ExtractZstandard)},
 	{Type: "zlib", Ext: ".zz", Fn: ChngInt(ExtractZlib)},
+	{Type: "flac", Ext: ".cue.txt", Fn: ExtractCUE},
 	{Type: "flac", Ext: ".cue", Fn: ExtractCUE},
 }
 
@@ -666,13 +667,23 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 // AllExcept can be used as an input to ExcludeSuffix in a Filter.
 // Returns a list of supported extensions minus the ones provided.
 // Extensions for like-types such as .rar and .r00 need to both be provided.
-// Same for .tar.gz and .tgz variants.
+// Same for .tar.gz and .tgz variants. Passing .cue also keeps .cue.txt.
 func AllExcept(onlyThese ...string) Exclude {
+	keep := make([]string, 0, len(onlyThese)+1)
+	keep = append(keep, onlyThese...)
+
+	for _, str := range onlyThese {
+		if strings.EqualFold(str, ".cue") {
+			keep = append(keep, ".cue.txt")
+			break
+		}
+	}
+
 	// Start by excluding everything.
 	output := SupportedExtensions()
 
 	// Loop through the extensions we want to keep.
-	for _, str := range onlyThese {
+	for _, str := range keep {
 		idx := 0
 		// Remove each one from the output list.
 		for _, ext := range output {

--- a/files_test.go
+++ b/files_test.go
@@ -149,6 +149,11 @@ func TestAllExcept(t *testing.T) {
 
 	assert.Len(t, allExcept, len(xtractr.SupportedExtensions())-len(includeOnlyThese),
 		"we should have 3 fewer entries that the total supported extensions")
+
+	// Callers that keep .cue (e.g. Unpackerr SplitFlac) should also keep .cue.txt.
+	exceptCue := xtractr.AllExcept(".cue")
+	assert.NotContains(t, exceptCue, ".cue")
+	assert.NotContains(t, exceptCue, ".cue.txt")
 }
 
 func TestIsErrNameTooLong(t *testing.T) {


### PR DESCRIPTION
## Summary
- Recognize `.cue.txt` as a CUE sheet so discovery (`IsArchiveFile` / `FindCompressedFiles` / `ExtractFile`) picks up releases that ship the sheet that way.
- Strip the full `.cue.txt` suffix when falling back to a same-basename audio file, and keep `.cue.txt` when `AllExcept(".cue")` is used (Unpackerr's SplitFlac filter).
- Automerge passing non-major `gomod` PRs, and GitHub Actions PRs even when major.
- Closes https://github.com/Unpackerr/unpackerr/issues/651

## Test plan
- [ ] `go test` covers `.cue.txt` detection, ExtractFile, basename fallback, and `AllExcept(".cue")`
- [ ] Unpackerr with this xtractr version queues a folder that only has `album.flac` + `album.cue.txt`


Made with [Cursor](https://cursor.com)