### PR TITLE
feat: let the caller decide when to replace an occupied destination

### DIFF
--- a/files.go
+++ b/files.go
@@ -3,6 +3,7 @@ package xtractr
 /* Code to find, write, move and delete files. */
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -175,6 +176,10 @@ type XFile struct {
 	// this true will cause the extracted content to be moved into the
 	// output folder, and the root folder in the archive to be removed.
 	SquashRoot bool
+	// ReplaceExisting reports whether a destination path already occupied by
+	// another file should be replaced by the freshly extracted copy.
+	// Nil, the default, always keeps the existing file. See Config.ReplaceExisting.
+	ReplaceExisting func(check *ReplaceCheck) bool
 	// SkipOnRecursion, if set by an extractor, lists paths that were copied into
 	// the output (e.g. a CUE sheet) and must not be re-extracted when recursing.
 	SkipOnRecursion []string
@@ -503,7 +508,7 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 // Returns the new file paths.
 // This is a helper method and only exposed for convenience. You do not have to call this.
 func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) {
-	return moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
+	return moveFiles(x.config, x.config.DirMode, x.config.ReplaceExisting, fromPath, toPath, overwrite)
 }
 
 // bindMoveFiles wires ExtractFile to this job's logger and DirMode.
@@ -516,13 +521,14 @@ func (x *XFile) bindMoveFiles() { //nolint:funcorder // kept next to MoveFiles
 	}
 
 	x.moveFiles = func(fromPath, toPath string, overwrite bool) ([]string, error) {
-		return moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
+		return moveFiles(x.log, x.DirMode, x.ReplaceExisting, fromPath, toPath, overwrite)
 	}
 }
 
 func moveFiles( //nolint:cyclop,funlen
 	log Logger,
 	dirMode os.FileMode,
+	replace func(*ReplaceCheck) bool,
 	fromPath, toPath string,
 	overwrite bool,
 ) ([]string, error) {
@@ -568,8 +574,7 @@ func moveFiles( //nolint:cyclop,funlen
 		_, err = os.Stat(newFile)
 		exists := !os.IsNotExist(err)
 
-		if exists && !overwrite {
-			log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
+		if exists && !overwrite && keepExistingFile(log, replace, file, newFile) {
 			// keep trying.
 			continue
 		}
@@ -596,6 +601,154 @@ func moveFiles( //nolint:cyclop,funlen
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
 	return newFiles, keepErr
+}
+
+// ReplaceCheck describes a destination path that is occupied by a file other
+// than the one just extracted. It is passed to Config.ReplaceExisting.
+type ReplaceCheck struct {
+	// Src is the extracted copy, waiting in the temporary folder.
+	Src string
+	// Dest is the destination path, already occupied.
+	Dest string
+	// SrcInfo is the lstat of Src. Always a regular file.
+	SrcInfo os.FileInfo
+	// DestInfo is the lstat of Dest. Always a regular file.
+	DestInfo os.FileInfo
+}
+
+// prefixChunk is the read size used when comparing a destination against the
+// leading bytes of the extracted copy.
+const prefixChunk = 64 * 1024
+
+// ReplaceTruncated is a Config.ReplaceExisting policy that replaces a
+// destination only when it is a truncated copy of the extracted file: shorter,
+// and byte for byte identical to the leading bytes of it.
+//
+// That is exactly what an interrupted extraction leaves behind, since output is
+// written in order. Because the partial file then occupies the destination
+// name, every later extraction of the same archive refuses in the same way, so
+// the damage becomes permanent and silent.
+//
+// Anything that is not a prefix is kept, so a file that arrived with the
+// download rather than from an archive is never replaced by a different file of
+// the same name, and no file is ever shortened. Reads stop at the first byte
+// that differs, and never exceed the length of the destination, so an unrelated
+// file costs a single chunk. Nothing is read at all unless the destination is
+// shorter than the extracted copy.
+//
+// A read error is treated as "do not replace".
+func ReplaceTruncated(check *ReplaceCheck) bool {
+	if check.DestInfo.Size() >= check.SrcInfo.Size() {
+		return false
+	}
+
+	prefix, err := samePrefix(check.Dest, check.Src, check.DestInfo.Size())
+
+	return err == nil && prefix
+}
+
+// samePrefix reports whether the first size bytes of shortPath and longPath are
+// identical. It returns on the first chunk that differs.
+func samePrefix(shortPath, longPath string, size int64) (bool, error) {
+	shortFile, err := os.Open(shortPath)
+	if err != nil {
+		return false, fmt.Errorf("os.Open(): %w", err)
+	}
+
+	defer shortFile.Close()
+
+	longFile, err := os.Open(longPath)
+	if err != nil {
+		return false, fmt.Errorf("os.Open(): %w", err)
+	}
+
+	defer longFile.Close()
+
+	shortBuf := make([]byte, prefixChunk)
+	longBuf := make([]byte, prefixChunk)
+
+	for remain := size; remain > 0; {
+		read := min(int64(prefixChunk), remain)
+
+		_, err = io.ReadFull(shortFile, shortBuf[:read])
+		if err != nil {
+			return false, fmt.Errorf("io.ReadFull(): %w", err)
+		}
+
+		_, err = io.ReadFull(longFile, longBuf[:read])
+		if err != nil {
+			return false, fmt.Errorf("io.ReadFull(): %w", err)
+		}
+
+		if !bytes.Equal(shortBuf[:read], longBuf[:read]) {
+			return false, nil
+		}
+
+		remain -= read
+	}
+
+	return true, nil
+}
+
+// keepExistingFile reports whether a file already occupying a destination path
+// should be left alone rather than replaced by the freshly extracted copy.
+//
+// The default, and the behavior when Config.ReplaceExisting is nil, is to
+// always keep it. The occupying file may have arrived with the download instead
+// of from an archive, and replacing it would invalidate the download.
+// Deciding otherwise needs context this library does not have, so the decision
+// is delegated. ReplaceTruncated covers the common case.
+//
+// Only regular files are eligible either way. A directory or a symlink at
+// either path is always kept, so an archive cannot use a link to redirect a
+// write outside the extraction path.
+func keepExistingFile(log Logger, replace func(*ReplaceCheck) bool, src, dest string) bool {
+	if replace == nil {
+		log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", src, dest)
+		return true
+	}
+
+	check, err := newReplaceCheck(src, dest)
+
+	switch {
+	case err != nil:
+		log.Printf("Error: Comparing Temp File: %v to %v: %v (refusing to overwrite existing file)",
+			src, dest, err)
+
+		return true
+	case check == nil:
+		log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing non-regular file)",
+			src, dest)
+
+		return true
+	case !replace(check):
+		log.Debugf("Skipped Temp File: %v -> %v (existing file kept)", src, dest)
+		return true
+	default:
+		log.Printf("Replacing existing file with archive content: %v", dest)
+		return false
+	}
+}
+
+// newReplaceCheck lstats both paths. It returns a nil check and a nil error
+// when either path is not a regular file, meaning the destination is not
+// eligible for replacement.
+func newReplaceCheck(src, dest string) (*ReplaceCheck, error) {
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return nil, fmt.Errorf("os.Lstat(): %w", err)
+	}
+
+	destInfo, err := os.Lstat(dest)
+	if err != nil {
+		return nil, fmt.Errorf("os.Lstat(): %w", err)
+	}
+
+	if !srcInfo.Mode().IsRegular() || !destInfo.Mode().IsRegular() {
+		return nil, nil //nolint:nilnil // Not an error; the destination is simply not eligible.
+	}
+
+	return &ReplaceCheck{Src: src, Dest: dest, SrcInfo: srcInfo, DestInfo: destInfo}, nil
 }
 
 // DeleteFiles obliterates things and logs. Use with caution.

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -217,7 +217,7 @@ func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
+	_, err := moveFiles(NoLogger(), 0o700, nil, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -262,7 +262,7 @@ func TestMoveFilesZeroDirModeUsesDefault(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
+	_, err := moveFiles(NoLogger(), 0, nil, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -327,7 +327,7 @@ func TestMoveFilesDoesNotDeleteSourceFile(t *testing.T) {
 	src := filepath.Join(dir, "a.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hi"), 0o600))
 
-	got, err := moveFiles(NoLogger(), 0o755, src, dir, false)
+	got, err := moveFiles(NoLogger(), 0o755, nil, src, dir, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{src}, got)
 	require.FileExists(t, src)

--- a/movefiles_replace_internal_test.go
+++ b/movefiles_replace_internal_test.go
@@ -1,0 +1,267 @@
+package xtractr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	payload = "the complete extracted payload"
+	// short is what an interrupted extraction leaves at the destination.
+	short = "the complete"
+)
+
+func newTestQueue(t *testing.T, replace func(*ReplaceCheck) bool) *Xtractr {
+	t.Helper()
+
+	xtractr := NewQueue(&Config{
+		Parallel:        1,
+		Suffix:          "_unpackerred",
+		FileMode:        0o644,
+		DirMode:         0o755,
+		ReplaceExisting: replace,
+	})
+	t.Cleanup(xtractr.Stop)
+
+	return xtractr
+}
+
+// dirs returns a temporary and a destination folder, both created.
+func dirs(t *testing.T) (string, string) {
+	t.Helper()
+
+	base := t.TempDir()
+	fromDir := filepath.Join(base, "temp")
+	toDir := filepath.Join(base, "final")
+
+	for _, dir := range []string{fromDir, toDir} {
+		err := os.MkdirAll(dir, 0o750)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return fromDir, toDir
+}
+
+func writeFile(t *testing.T, path, data string) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(data), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A short file left behind by an interrupted extraction must not shield itself
+// from repair. Because it occupies the destination name, MoveFiles refused to
+// touch it, so every later extraction of the same archive failed identically.
+func TestMoveFilesReplaceTruncated(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		existing string
+		replace  func(*ReplaceCheck) bool
+		want     string
+	}{
+		{"truncated prefix is replaced", short, ReplaceTruncated, payload},
+		{"empty file is replaced", "", ReplaceTruncated, payload},
+		{"identical file is kept", payload, ReplaceTruncated, payload},
+		{"longer file is kept", payload + " and more", ReplaceTruncated, payload + " and more"},
+		{"shorter but not a prefix is kept", "XXX complete", ReplaceTruncated, "XXX complete"},
+		{"shorter, differing only at its last byte, is kept", "the completX", ReplaceTruncated, "the completX"},
+		{"nil policy keeps the historical behavior", short, nil, short},
+		{"policy may accept anything", payload + " and more", func(*ReplaceCheck) bool { return true }, payload},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fromDir, toDir := dirs(t)
+			writeFile(t, filepath.Join(fromDir, "payload.bin"), payload)
+			writeFile(t, filepath.Join(toDir, "payload.bin"), test.existing)
+
+			_, err := newTestQueue(t, test.replace).MoveFiles(fromDir, toDir, false)
+			if err != nil {
+				t.Fatalf("MoveFiles: %v", err)
+			}
+
+			got, err := os.ReadFile(filepath.Join(toDir, "payload.bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(got) != test.want {
+				t.Errorf("destination = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// A symlink at the destination must never be replaced, and must never be
+// written through, whatever the policy returns. Archives can carry symlinks, so
+// following one would let an archive redirect a write outside the destination.
+func TestMoveFilesKeepsSymlinkDestination(t *testing.T) {
+	t.Parallel()
+
+	fromDir, toDir := dirs(t)
+	outside := filepath.Join(t.TempDir(), "outside.bin")
+	writeFile(t, outside, "do not touch")
+	writeFile(t, filepath.Join(fromDir, "payload.bin"), payload)
+
+	err := os.Symlink(outside, filepath.Join(toDir, "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = newTestQueue(t, func(*ReplaceCheck) bool { return true }).MoveFiles(fromDir, toDir, false)
+	if err != nil {
+		t.Fatalf("MoveFiles: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(toDir, "payload.bin"))
+	if err != nil {
+		t.Fatalf("destination is no longer a symlink: %v", err)
+	}
+
+	if target != outside {
+		t.Errorf("symlink target = %q, want %q", target, outside)
+	}
+
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != "do not touch" {
+		t.Errorf("wrote through the symlink: %q", got)
+	}
+}
+
+// GetFileList returns directory entries alongside regular files, so a folder
+// can occupy a destination name. It must never be considered for replacement.
+func TestMoveFilesKeepsDirectoryDestination(t *testing.T) {
+	t.Parallel()
+
+	fromDir, toDir := dirs(t)
+	writeFile(t, filepath.Join(fromDir, "payload.bin"), payload)
+
+	nested := filepath.Join(toDir, "payload.bin")
+
+	err := os.MkdirAll(nested, 0o750)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(nested, "keep.txt"), "still here")
+
+	_, err = newTestQueue(t, func(*ReplaceCheck) bool { return true }).MoveFiles(fromDir, toDir, false)
+	if err != nil {
+		t.Fatalf("MoveFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(nested, "keep.txt"))
+	if err != nil {
+		t.Fatalf("directory destination was clobbered: %v", err)
+	}
+
+	if string(got) != "still here" {
+		t.Errorf("directory contents = %q", got)
+	}
+}
+
+// A folder extracted from an archive is moved as a unit. When the destination
+// is free the folder lands intact, with the files below it untouched.
+func TestMoveFilesMovesNestedDirectory(t *testing.T) {
+	t.Parallel()
+
+	fromDir, toDir := dirs(t)
+	nested := filepath.Join(fromDir, "subdir")
+
+	err := os.MkdirAll(nested, 0o750)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(nested, "payload.bin"), payload)
+
+	_, err = newTestQueue(t, ReplaceTruncated).MoveFiles(fromDir, toDir, false)
+	if err != nil {
+		t.Fatalf("MoveFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(toDir, "subdir", "payload.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != payload {
+		t.Errorf("nested file = %q, want %q", got, payload)
+	}
+}
+
+// A truncated file larger than one read chunk must still be recognised, and a
+// difference past the first chunk must still be caught.
+func TestReplaceTruncatedAcrossChunks(t *testing.T) {
+	t.Parallel()
+
+	const size = prefixChunk*3 + 17
+
+	full := make([]byte, size)
+	for i := range full {
+		full[i] = byte(i % 251)
+	}
+
+	for _, test := range []struct {
+		name   string
+		mangle func([]byte) []byte
+		want   bool
+	}{
+		{"exact prefix", func(b []byte) []byte { return b }, true},
+		{"differs in the final chunk", func(b []byte) []byte {
+			b[len(b)-1] ^= 0xFF
+
+			return b
+		}, false},
+		{"differs on the first byte", func(b []byte) []byte {
+			b[0] ^= 0xFF
+
+			return b
+		}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fromDir, toDir := dirs(t)
+			src := filepath.Join(fromDir, "payload.bin")
+			dest := filepath.Join(toDir, "payload.bin")
+
+			err := os.WriteFile(src, full, 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			partial := test.mangle(append([]byte(nil), full[:prefixChunk*2+5]...))
+
+			err = os.WriteFile(dest, partial, 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = newTestQueue(t, ReplaceTruncated).MoveFiles(fromDir, toDir, false)
+			if err != nil {
+				t.Fatalf("MoveFiles: %v", err)
+			}
+
+			got, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if replaced := len(got) == size; replaced != test.want {
+				t.Errorf("replaced = %v, want %v (destination is %d bytes)", replaced, test.want, len(got))
+			}
+		})
+	}
+}

--- a/queue.go
+++ b/queue.go
@@ -382,16 +382,17 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	x.config.Debugf("Extracting File: %v to %v", filename, resp.Output)
 
 	xFile := &XFile{
-		FilePath:    filename,
-		OutputDir:   resp.Output,
-		FileMode:    x.config.FileMode,
-		DirMode:     x.config.DirMode,
-		Passwords:   resp.X.Passwords,
-		Password:    resp.X.Password,
-		FileWorkers: x.config.FileWorkers,
-		log:         x.config.Logger,
-		Updates:     resp.X.Updates,
-		Progress:    resp.X.Progress,
+		FilePath:        filename,
+		OutputDir:       resp.Output,
+		FileMode:        x.config.FileMode,
+		DirMode:         x.config.DirMode,
+		Passwords:       resp.X.Passwords,
+		Password:        resp.X.Password,
+		FileWorkers:     x.config.FileWorkers,
+		ReplaceExisting: x.config.ReplaceExisting,
+		log:             x.config.Logger,
+		Updates:         resp.X.Updates,
+		Progress:        resp.X.Progress,
 	}
 
 	bytes, files, archives, err := ExtractFile(xFile)

--- a/start.go
+++ b/start.go
@@ -40,6 +40,14 @@ type Config struct {
 	TryNames bool
 	// The suffix used for temporary folders.
 	Suffix string
+	// ReplaceExisting reports whether a destination path already occupied by
+	// another file should be replaced by the freshly extracted copy.
+	// Nil, the default, always keeps the existing file, which is the historical
+	// behavior: an occupying file may have arrived with the download rather than
+	// from an archive, and replacing it would invalidate the download.
+	// Only regular files are ever offered; directories and symlinks are always
+	// kept regardless of what this returns. See ReplaceTruncated.
+	ReplaceExisting func(check *ReplaceCheck) bool
 }
 
 // Logger allows this library to write logs.


### PR DESCRIPTION
`MoveFiles` decides whether to write out an extracted file based only on whether *something* with that name already exists:

```go
if exists && !overwrite {
    x.config.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
    continue
}
```

Anything holding the name is kept, so a short file left behind by an interrupted or out-of-band extraction becomes permanent. It occupies the destination, every later extraction of the same archive refuses identically, and `DeleteFiles(fromPath)` then discards the copy that was just extracted. The refusal sets no error, so the run reports `Extraction Finished` and nothing surfaces it.

I hit this with a 1117954092-byte remnant sitting where a 3568204620-byte file belonged. It had survived four subsequent extractions, and only a manual delete let the correct file through.

## This PR

Whether an occupying file may be replaced is not a question this library can answer. It might be a remnant of a failed extraction, or it might have arrived with the download, in which case replacing it invalidates the download. Callers know which, so the decision is delegated rather than guessed:

```go
// ReplaceExisting reports whether a destination path already occupied by
// another file should be replaced by the freshly extracted copy.
// Nil, the default, always keeps the existing file.
ReplaceExisting func(check *ReplaceCheck) bool
```

`ReplaceCheck` carries both paths and both `FileInfo`s, so a caller can apply whatever comparison suits it. `nil` is the default and reproduces current behavior exactly, log line included. No policy of any kind ships enabled, and no assumption about whether a given decoder verified its output is baked in anywhere.

One policy is supplied for the common case:

```go
// ReplaceTruncated replaces a destination only when it is a truncated copy of
// the extracted file: shorter, and byte for byte identical to the leading
// bytes of it.
func ReplaceTruncated(check *ReplaceCheck) bool {
	if check.DestInfo.Size() >= check.SrcInfo.Size() {
		return false
	}

	prefix, err := samePrefix(check.Dest, check.Src, check.DestInfo.Size())

	return err == nil && prefix
}
```

Extractor output is written in order, so an interrupted extraction leaves exactly a prefix behind. Requiring one identifies that case positively rather than inferring it from length: anything that is not a prefix did not come from this archive and is kept. A file that arrived with the download is therefore never replaced by a different file of the same name, and no file is ever shortened.

The comparison is streaming, in 64KiB chunks, and returns on the first chunk that differs. It never reads past the length of the destination, and it does not run at all unless the destination is shorter than the extracted copy, so an unrelated file costs one chunk and a complete one costs nothing.

Only regular files are offered to the policy. Both paths are `os.Lstat`'d, so a directory or a symlink at either end is always kept whatever the policy returns, and nothing can reach `Rename`'s copy fallback through a link.

## Tests

`movefiles_replace_internal_test.go` covers:

- a truncated prefix replaced; an empty destination replaced
- an identical destination kept, a longer one kept
- a shorter destination that is not a prefix kept, including one differing only at its final byte
- multi-chunk coverage, with differences in both the first and the last chunk
- `nil` reproducing the historical refusal
- a permissive policy still not touching a symlink destination, with the link target verified byte-identical afterwards
- a permissive policy still not touching a directory occupying a destination name
- a folder extracted from an archive moving intact

Verified end to end against a 72-volume multi-part RAR set: before the change the short file survived and the run reported success; after, the output was 3568204620 bytes with CRC 55486DBD, matching the archive header exactly.

golangci-lint v2.13 reports 0 issues, and `go test -race -covermode=atomic ./...` passes.

## Rebased onto #172

`moveFiles` now takes the policy alongside the logger and dir mode, and `XFile` carries it too, so `ExtractFile` honors the job's setting instead of ignoring it the way the old dummy-`Config` path ignored `DirMode`. The three existing `moveFiles` calls in `files_internal_test.go` gain a `nil` argument; no test behavior changes.

## Not included

A refusal still returns no error, so the run reports success either way. That is what made this hard to spot from the outside, but changing it affects every caller, so it did not belong here. Happy to look at it separately.
