### PR TITLE
Honor Close errors and verify 7z CRC32

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,8 +49,6 @@ linters:
         - os.RemoveAll
         - os.Remove
         - os.Chtimes
-        - (io.Closer).Close
-        - (*compress/gzip.Reader).Close
         - (*archive/zip.ReadCloser).Close
         - (*github.com/bodgit/sevenzip.ReadCloser).Close
         - (*github.com/nwaples/rardecode/v2.ReadCloser).Close

--- a/7z.go
+++ b/7z.go
@@ -186,11 +186,9 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (size uint64, path string, err er
 	}
 
 	if !x.pathWithinOutput(file.Path) {
-		closeNamed(zFile, &err)
+		_ = zFile.Close()
 		// The file being written is trying to write outside of our base path. Malicious archive?
-		err = fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
-
-		return 0, file.Path, err
+		return 0, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
 	}
 
 	if zipFile.FileInfo().IsDir() {

--- a/7z.go
+++ b/7z.go
@@ -188,7 +188,8 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (size uint64, path string, err er
 	if !x.pathWithinOutput(file.Path) {
 		_ = zFile.Close()
 		// The file being written is trying to write outside of our base path. Malicious archive?
-		return 0, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
+		return 0, file.Path, fmt.Errorf("%s: %w: %s (from: %s)",
+			zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
 	}
 
 	if zipFile.FileInfo().IsDir() {

--- a/7z.go
+++ b/7z.go
@@ -2,6 +2,8 @@ package xtractr
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/bodgit/sevenzip"
@@ -146,23 +148,21 @@ func (x *XFile) sevenZipPrepareEntries(sevenZip *sevenzip.ReadCloser) ([]sevenZi
 }
 
 // extract7zEntry extracts a single 7z file entry (used by parallel workers).
-func (x *XFile) extract7zEntry(entry sevenZipEntry) error {
+func (x *XFile) extract7zEntry(entry sevenZipEntry) (err error) {
 	zFile, err := entry.sevenZipFile.Open()
 	if err != nil {
 		return fmt.Errorf("%s: 7zFile.Open: %w", x.FilePath, err)
 	}
-	defer zFile.Close()
 
 	fileInfo := &file{
 		Path:     x.clean(entry.sevenZipFile.Name),
-		Data:     zFile,
 		FileMode: entry.sevenZipFile.Mode(),
 		DirMode:  x.DirMode,
 		Mtime:    entry.sevenZipFile.Modified,
 		Atime:    entry.sevenZipFile.Accessed,
 	}
 
-	_, err = x.writeParallel(fileInfo)
+	_, err = x.write7zFile(zFile, fileInfo, entry.sevenZipFile.CRC32, true)
 	if err != nil {
 		return fmt.Errorf("%s: %w: %s (from: %s)",
 			entry.sevenZipFile.FileInfo().Name(), err, fileInfo.Path, entry.sevenZipFile.Name)
@@ -171,16 +171,14 @@ func (x *XFile) extract7zEntry(entry sevenZipEntry) error {
 	return nil
 }
 
-func (x *XFile) un7zip(zipFile *sevenzip.File) (uint64, string, error) {
+func (x *XFile) un7zip(zipFile *sevenzip.File) (size uint64, path string, err error) {
 	zFile, err := zipFile.Open()
 	if err != nil {
 		return 0, zipFile.Name, fmt.Errorf("zipFile.Open: %w", err)
 	}
-	defer zFile.Close()
 
 	file := &file{
 		Path:     x.clean(zipFile.Name),
-		Data:     zFile,
 		FileMode: zipFile.Mode(),
 		DirMode:  x.DirMode,
 		Mtime:    zipFile.Modified,
@@ -188,15 +186,19 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (uint64, string, error) {
 	}
 
 	if !x.pathWithinOutput(file.Path) {
+		closeNamed(zFile, &err)
 		// The file being written is trying to write outside of our base path. Malicious archive?
-		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
+		err = fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, zipFile.Name)
+
 		return 0, file.Path, err
 	}
 
 	if zipFile.FileInfo().IsDir() {
 		x.Debugf("Writing archived directory: %s", file.Path)
 
-		err := x.mkDir(file.Path, zipFile.Mode(), zipFile.Modified)
+		err = x.mkDir(file.Path, zipFile.Mode(), zipFile.Modified)
+		closeNamed(zFile, &err)
+
 		if err != nil {
 			return 0, file.Path, fmt.Errorf("making zipFile dir: %w", err)
 		}
@@ -207,10 +209,34 @@ func (x *XFile) un7zip(zipFile *sevenzip.File) (uint64, string, error) {
 	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)",
 		file.Path, zipFile.FileInfo().Size(), zipFile.UncompressedSize)
 
-	s, err := x.write(file)
+	size, err = x.write7zFile(zFile, file, zipFile.CRC32, false)
 	if err != nil {
-		return s, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, zipFile.Name)
+		return size, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, zipFile.Name)
 	}
 
-	return s, file.Path, nil
+	return size, file.Path, nil
+}
+
+// write7zFile copies a 7z member while hashing it, then checks the header CRC.
+func (x *XFile) write7zFile(zFile io.ReadCloser, file *file, wantCRC uint32, parallel bool) (size uint64, err error) {
+	reader, hasher := teeCRC32(zFile)
+	file.Data = reader
+
+	if parallel {
+		size, err = x.writeParallel(file)
+	} else {
+		size, err = x.write(file)
+	}
+
+	closeNamed(zFile, &err)
+
+	if err != nil {
+		_ = os.Remove(file.Path)
+
+		return size, err
+	}
+
+	err = checkCRC32(file.Path, hasher.Sum32(), wantCRC)
+
+	return size, err
 }

--- a/ar.go
+++ b/ar.go
@@ -73,7 +73,7 @@ func (x *XFile) unAr(reader io.Reader) ([]string, error) {
 }
 
 // ar files are not compressed.
-func getUncompressedArSize(arFile io.ReadCloser) (total, compressed uint64, count int) {
+func getUncompressedArSize(arFile *os.File) (total, compressed uint64, count int) {
 	defer arFile.Close()
 
 	arReader := ar.NewReader(arFile)

--- a/close.go
+++ b/close.go
@@ -1,0 +1,43 @@
+package xtractr
+
+import (
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"io"
+	"os"
+)
+
+// closeNamed closes c and, if no error is already set, records the close error.
+// Used with named return values so decoder checksums that surface on Close
+// (gzip, zlib, zip members, 7z members) are not discarded by defer Close().
+func closeNamed(closer io.Closer, err *error) { //nolint:gocritic // named returns require a pointer to error.
+	if closer == nil || err == nil {
+		return
+	}
+
+	closeErr := closer.Close()
+	if closeErr != nil && *err == nil {
+		*err = fmt.Errorf("closing: %w", closeErr)
+	}
+}
+
+// checkCRC32 compares a running IEEE CRC against the value stored in an archive
+// header. want 0 means the archive did not provide a checksum. On mismatch the
+// written file is removed so a corrupt extract cannot look successful.
+func checkCRC32(path string, got, want uint32) error {
+	if want == 0 || got == want {
+		return nil
+	}
+
+	_ = os.Remove(path)
+
+	return fmt.Errorf("%s: %w (got %08x, want %08x)", path, ErrChecksum, got, want)
+}
+
+// teeCRC32 copies r into a CRC-32 IEEE hasher while the caller reads.
+func teeCRC32(reader io.Reader) (io.Reader, hash.Hash32) {
+	hasher := crc32.NewIEEE()
+
+	return io.TeeReader(reader, hasher), hasher
+}

--- a/close_internal_test.go
+++ b/close_internal_test.go
@@ -1,0 +1,82 @@
+package xtractr
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubCloser struct {
+	err error
+}
+
+func (s stubCloser) Close() error {
+	return s.err
+}
+
+func TestCloseNamed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records close error", func(t *testing.T) {
+		t.Parallel()
+
+		closeErr := errors.New("boom")
+
+		var err error
+
+		closeNamed(stubCloser{err: closeErr}, &err)
+		require.ErrorIs(t, err, closeErr)
+	})
+
+	t.Run("keeps existing error", func(t *testing.T) {
+		t.Parallel()
+
+		first := errors.New("write failed")
+		err := first
+
+		closeNamed(stubCloser{err: errors.New("close failed")}, &err)
+		assert.Equal(t, first, err)
+	})
+
+	t.Run("nil closer is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		var err error
+
+		closeNamed(nil, &err)
+		require.NoError(t, err)
+	})
+}
+
+func TestCheckCRC32(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skips when want is zero", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, checkCRC32("unused", 1, 0))
+	})
+
+	t.Run("accepts a match", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, checkCRC32("unused", 0xabcdef01, 0xabcdef01))
+	})
+
+	t.Run("removes dest on mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "corrupt.bin")
+		require.NoError(t, os.WriteFile(path, []byte("nope"), 0o600))
+
+		err := checkCRC32(path, 1, 2)
+		require.ErrorIs(t, err, ErrChecksum)
+
+		_, statErr := os.Stat(path)
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	})
+}

--- a/cpio.go
+++ b/cpio.go
@@ -24,9 +24,9 @@ func ExtractCPIOGzip(xFile *XFile) (size uint64, filesList []string, err error) 
 	if err != nil {
 		return 0, nil, fmt.Errorf("gzip.NewReader: %w", err)
 	}
-	defer zipStream.Close()
 
 	files, err := xFile.uncpio(zipStream)
+	closeNamed(zipStream, &err)
 
 	return xFile.prog.Wrote, files, err
 }

--- a/decompress.go
+++ b/decompress.go
@@ -4,6 +4,7 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"fmt"
+	"os"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/s2"
@@ -58,7 +59,6 @@ func ExtractZlib(xFile *XFile) (size uint64, filesList []string, err error) {
 	if err != nil {
 		return 0, nil, fmt.Errorf("zlib.NewReader: %w", err)
 	}
-	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.
 	file := &file{
@@ -69,6 +69,11 @@ func ExtractZlib(xFile *XFile) (size uint64, filesList []string, err error) {
 	}
 
 	size, err = xFile.write(file)
+	closeNamed(zipReader, &err)
+
+	if err != nil {
+		_ = os.Remove(file.Path)
+	}
 
 	return size, []string{file.Path}, err
 }
@@ -321,7 +326,6 @@ func ExtractGzip(xFile *XFile) (size uint64, filesList []string, err error) {
 	if err != nil {
 		return 0, nil, fmt.Errorf("gzip.NewReader: %w", err)
 	}
-	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.
 	file := &file{
@@ -333,6 +337,11 @@ func ExtractGzip(xFile *XFile) (size uint64, filesList []string, err error) {
 	}
 
 	size, err = xFile.write(file)
+	closeNamed(zipReader, &err)
+
+	if err != nil {
+		_ = os.Remove(file.Path)
+	}
 
 	return size, []string{file.Path}, err
 }

--- a/decompress.go
+++ b/decompress.go
@@ -32,6 +32,8 @@ func ExtractXZ(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("xz.NewReader: %w", err)
 	}
 
+	// xz.Reader has no Close; CRC64 is checked when Read hits EOF.
+
 	// Get the absolute path of the file being written.
 	file := &file{
 		Path:     xFile.clean(xFile.FilePath, ".xz"),
@@ -151,6 +153,7 @@ func ExtractZstandard(xFile *XFile) (size uint64, filesList []string, err error)
 	if err != nil {
 		return 0, nil, fmt.Errorf("zstd.NewReader: %w", err)
 	}
+	// Close releases the decoder pool. Frame checksums surface on Read as zstd.ErrCRCMismatch.
 	defer zipReader.Close()
 
 	// Get the absolute path of the file being written.

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -1,0 +1,85 @@
+package xtractr_test
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golift.io/xtractr"
+)
+
+func TestExtractGzipCorruptChecksum(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.txt.gz")
+	payload := []byte("hello checksum")
+
+	gzipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	writer := gzip.NewWriter(gzipFile)
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, gzipFile.Close())
+
+	raw, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 8)
+	raw[len(raw)-5] ^= 0xff
+
+	bad := filepath.Join(t.TempDir(), "payload.txt.gz")
+	require.NoError(t, os.WriteFile(bad, raw, 0o600)) //nolint:gosec
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	_, _, err = xtractr.ExtractGzip(&xtractr.XFile{
+		FilePath:  bad,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filepath.Join(out, "payload.txt"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestExtractGzip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.txt.gz")
+	payload := []byte("hello checksum")
+
+	gzipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	writer := gzip.NewWriter(gzipFile)
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, gzipFile.Close())
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	size, files, err := xtractr.ExtractGzip(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(len(payload)), size)
+	require.Len(t, files, 1)
+
+	got, err := os.ReadFile(files[0])
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	xzlib "github.com/ulikunitz/xz"
 	"golift.io/xtractr"
 )
 
@@ -82,4 +84,85 @@ func TestExtractGzip(t *testing.T) {
 	got, err := os.ReadFile(files[0])
 	require.NoError(t, err)
 	assert.Equal(t, payload, got)
+}
+
+func TestExtractZstandardCorruptChecksum(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.txt.zst")
+	payload := []byte("hello checksum")
+
+	zstdFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	writer, err := zstd.NewWriter(zstdFile)
+	require.NoError(t, err)
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, zstdFile.Close())
+
+	raw, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 4)
+	raw[len(raw)-1] ^= 0xff
+
+	bad := filepath.Join(t.TempDir(), "payload.txt.zst")
+	require.NoError(t, os.WriteFile(bad, raw, 0o600)) //nolint:gosec
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	_, _, err = xtractr.ExtractZstandard(&xtractr.XFile{
+		FilePath:  bad,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, zstd.ErrCRCMismatch)
+
+	_, statErr := os.Stat(filepath.Join(out, "payload.txt"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestExtractXZCorruptChecksum(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.txt.xz")
+	payload := []byte("hello checksum")
+
+	xzFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	writer, err := xzlib.NewWriter(xzFile)
+	require.NoError(t, err)
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, xzFile.Close())
+
+	raw, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 16)
+	raw[len(raw)/2] ^= 0xff
+
+	bad := filepath.Join(t.TempDir(), "payload.txt.xz")
+	require.NoError(t, os.WriteFile(bad, raw, 0o600)) //nolint:gosec
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	_, _, err = xtractr.ExtractXZ(&xtractr.XFile{
+		FilePath:  bad,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.Error(t, err)
+
+	_, statErr := os.Stat(filepath.Join(out, "payload.txt"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }

--- a/errors.go
+++ b/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrQueueStopped       = errors.New("extractor queue stopped, cannot extract")
 	ErrNoCompressedFiles  = errors.New("no compressed files found")
 	ErrUnknownArchiveType = errors.New("unknown archive file type")
+	ErrChecksum           = errors.New("archived file checksum mismatch")
 	ErrInvalidPath        = errors.New("archived file contains invalid path")
 	ErrInvalidHead        = errors.New("archived file contains invalid header file")
 	ErrSymlinkTooLong     = errors.New("archived symlink target exceeds maximum length")

--- a/files.go
+++ b/files.go
@@ -700,10 +700,14 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 	closeErr := newFile.Close()
 
 	if err != nil {
+		_ = os.Remove(pathUsed)
+
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("io.Copy(): %w", err)}}
 	}
 
 	if closeErr != nil {
+		_ = os.Remove(pathUsed)
+
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("closing dest: %w", closeErr)}}
 	}
 

--- a/files.go
+++ b/files.go
@@ -695,11 +695,16 @@ func (x *Xtractr) Rename(oldpath, newpath string) error {
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, err}}
 	}
-	defer newFile.Close()
 
 	_, err = io.Copy(newFile, oldFile)
+	closeErr := newFile.Close()
+
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("io.Copy(): %w", err)}}
+	}
+
+	if closeErr != nil {
+		return &ExtractError{Errs: []error{origErr, fmt.Errorf("closing dest: %w", closeErr)}}
 	}
 
 	// pathUsed may differ from newpath if the name had to be truncated.
@@ -914,7 +919,6 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer fout.Close()
 
 	file.Path = pathUsed
 
@@ -924,12 +928,22 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 	}
 
 	size, err := io.Copy(progWriter, file.Data)
+	closeErr := fout.Close()
+
 	if err != nil {
+		_ = os.Remove(file.Path)
+
 		return uint64(size), fmt.Errorf("copying archived file '%s' io: %w", file.Path, err)
 	}
 
+	if closeErr != nil {
+		_ = os.Remove(file.Path)
+
+		return uint64(size), fmt.Errorf("closing archived file '%s': %w", file.Path, closeErr)
+	}
+
 	// The error is ignored because it's not critical and pops up on OSes like Windows.
-	defer os.Chtimes(file.Path, file.Atime, file.Mtime)
+	_ = os.Chtimes(file.Path, file.Atime, file.Mtime)
 
 	return uint64(size), nil
 }
@@ -984,11 +998,20 @@ func writeExtractFile(path string, data []byte, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer fout.Close()
 
 	_, err = fout.Write(data)
+	closeErr := fout.Close()
+
 	if err != nil {
+		_ = os.Remove(usedPath)
+
 		return fmt.Errorf("writing file '%s': %w", usedPath, err)
+	}
+
+	if closeErr != nil {
+		_ = os.Remove(usedPath)
+
+		return fmt.Errorf("closing file '%s': %w", usedPath, closeErr)
 	}
 
 	return nil

--- a/rpm.go
+++ b/rpm.go
@@ -48,9 +48,11 @@ func (x *XFile) extractRPM(rpmFile io.Reader) (filesList []string, err error) { 
 		if err != nil {
 			return nil, fmt.Errorf("gzip.NewReader: %w", err)
 		}
-		defer zipReader.Close()
 
-		return x.unrpm(zipReader, pkg.PayloadFormat())
+		files, err := x.unrpm(zipReader, pkg.PayloadFormat())
+		closeNamed(zipReader, &err)
+
+		return files, err
 	case "bz2", "bzip2":
 		return x.unrpm(bzip2.NewReader(rpmFile), pkg.PayloadFormat())
 	case "zstd", "zstandard", "zst", "Zstandard":

--- a/tar.go
+++ b/tar.go
@@ -100,9 +100,9 @@ func ExtractTarGzip(xFile *XFile) (size uint64, filesList []string, err error) {
 	if err != nil {
 		return 0, nil, fmt.Errorf("gzip.NewReader: %w", err)
 	}
-	defer zipStream.Close()
 
 	files, err := xFile.untar(zipStream)
+	closeNamed(zipStream, &err)
 
 	return xFile.prog.Wrote, files, err
 }

--- a/zip.go
+++ b/zip.go
@@ -3,6 +3,7 @@ package xtractr
 import (
 	"archive/zip"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -120,12 +121,11 @@ func (x *XFile) zipPrepareEntries(
 }
 
 // extractZIPEntry extracts a single zip file entry (used by parallel workers).
-func (x *XFile) extractZIPEntry(entry zipFileEntry) error {
+func (x *XFile) extractZIPEntry(entry zipFileEntry) (err error) {
 	zFile, err := entry.zipFile.Open()
 	if err != nil {
 		return fmt.Errorf("%s: zipFile.Open: %w", x.FilePath, err)
 	}
-	defer zFile.Close()
 
 	fileInfo := &file{
 		Path:     x.clean(entry.decodedName),
@@ -137,7 +137,11 @@ func (x *XFile) extractZIPEntry(entry zipFileEntry) error {
 	}
 
 	_, err = x.writeParallel(fileInfo)
+	closeNamed(zFile, &err)
+
 	if err != nil {
+		_ = os.Remove(fileInfo.Path)
+
 		return fmt.Errorf("%s: %w: %s (from: %s)",
 			entry.zipFile.FileInfo().Name(), err, fileInfo.Path, entry.decodedName)
 	}
@@ -145,12 +149,11 @@ func (x *XFile) extractZIPEntry(entry zipFileEntry) error {
 	return nil
 }
 
-func (x *XFile) unzipWithName(zipFile *zip.File, name string) (uint64, string, error) {
+func (x *XFile) unzipWithName(zipFile *zip.File, name string) (size uint64, path string, err error) {
 	zFile, err := zipFile.Open()
 	if err != nil {
 		return 0, name, fmt.Errorf("zipFile.Open: %w", err)
 	}
-	defer zFile.Close()
 
 	file := &file{
 		Path:     x.clean(name),
@@ -162,15 +165,19 @@ func (x *XFile) unzipWithName(zipFile *zip.File, name string) (uint64, string, e
 	}
 
 	if !x.pathWithinOutput(file.Path) {
+		closeNamed(zFile, &err)
 		// The file being written is trying to write outside of our base path. Malicious archive?
-		err := fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, name)
+		err = fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, name)
+
 		return 0, file.Path, err
 	}
 
 	if zipFile.FileInfo().IsDir() {
 		x.Debugf("Writing archived directory: %s", file.Path)
 
-		err := x.mkDir(file.Path, zipFile.Mode(), zipFile.Modified)
+		err = x.mkDir(file.Path, zipFile.Mode(), zipFile.Modified)
+		closeNamed(zFile, &err)
+
 		if err != nil {
 			return 0, file.Path, fmt.Errorf("making zipFile dir: %w", err)
 		}
@@ -181,10 +188,14 @@ func (x *XFile) unzipWithName(zipFile *zip.File, name string) (uint64, string, e
 	x.Debugf("Writing archived file: %s (packed: %d, unpacked: %d)", file.Path,
 		zipFile.CompressedSize64, zipFile.UncompressedSize64)
 
-	s, err := x.write(file)
+	size, err = x.write(file)
+	closeNamed(zFile, &err)
+
 	if err != nil {
-		return s, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, name)
+		_ = os.Remove(file.Path)
+
+		return size, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), err, file.Path, name)
 	}
 
-	return s, file.Path, nil
+	return size, file.Path, nil
 }

--- a/zip.go
+++ b/zip.go
@@ -165,11 +165,9 @@ func (x *XFile) unzipWithName(zipFile *zip.File, name string) (size uint64, path
 	}
 
 	if !x.pathWithinOutput(file.Path) {
-		closeNamed(zFile, &err)
+		_ = zFile.Close()
 		// The file being written is trying to write outside of our base path. Malicious archive?
-		err = fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, name)
-
-		return 0, file.Path, err
+		return 0, file.Path, fmt.Errorf("%s: %w: %s (from: %s)", zipFile.FileInfo().Name(), ErrInvalidPath, file.Path, name)
 	}
 
 	if zipFile.FileInfo().IsDir() {


### PR DESCRIPTION
## Summary
- Check decoder `Close()` (gzip/zlib, zip members, 7z members) via named returns so checksum failures are not discarded.
- Check destination file `Close()` after writes (and on the `Rename` copy fallback); delete the dest on copy/close/CRC failure.
- Hash 7z members while extracting and compare against `File.CRC32` (`bodgit/sevenzip` does not verify on Read/Close). Stop excluding `(io.Closer).Close` / gzip `Close` from errcheck so this cannot regress.

## Test plan
- [x] `go test -race` for gzip checksum + `closeNamed` / `checkCRC32` helpers
- [x] `golangci-lint run ./...` (v2.13)
- [ ] CI `go test -race` on macos/windows/ubuntu
- [ ] Confirm a good `.gz` and `.7z` still extract; a gzip with a flipped trailer CRC errors and leaves no dest file


Made with [Cursor](https://cursor.com)