### PR TITLE
Stop building a dummy Config to borrow MoveFiles

### DIFF
--- a/files.go
+++ b/files.go
@@ -218,6 +218,10 @@ func (x *XFile) Printf(format string, v ...any) {
 // This is non-recursive and only returns files _in_ the base paths provided.
 // This is a helper method and only exposed for convenience. You do not have to call this.
 func (x *Xtractr) GetFileList(paths ...string) ([]string, error) {
+	return listFiles(paths...)
+}
+
+func listFiles(paths ...string) ([]string, error) {
 	files := []string{}
 
 	for _, path := range paths {
@@ -446,8 +450,7 @@ func (x *XFile) Extract() (size uint64, filesList, archiveList []string, err err
 // Returns size of extracted data, list of extracted files, list of archives processed, and/or error.
 func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, err error) {
 	sName := strings.ToLower(xFile.FilePath)
-	// just borrowing this... Has to go into an interface to avoid a cycle.
-	xFile.moveFiles = parseConfig(&Config{Logger: xFile.log}).MoveFiles
+	xFile.bindMoveFiles()
 
 	var extensionType string // archive type from matched extension, for error reporting when extraction fails
 
@@ -499,13 +502,43 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 // MoveFiles relocates files then removes the folder they were in.
 // Returns the new file paths.
 // This is a helper method and only exposed for convenience. You do not have to call this.
-func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) { //nolint:cyclop
+func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) {
+	return moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
+}
+
+// bindMoveFiles gives ExtractFile a MoveFiles implementation that uses this
+// job's logger and DirMode, instead of a throwaway Config (which would apply
+// DefaultDirMode).
+func (x *XFile) bindMoveFiles() { //nolint:funcorder // kept next to MoveFiles
+	if x.moveFiles != nil {
+		return
+	}
+
+	x.moveFiles = func(fromPath, toPath string, overwrite bool) ([]string, error) {
+		return moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
+	}
+}
+
+func moveFiles( //nolint:cyclop,funlen
+	log Logger,
+	dirMode os.FileMode,
+	fromPath, toPath string,
+	overwrite bool,
+) ([]string, error) {
+	if log == nil {
+		log = NoLogger()
+	}
+
+	if dirMode == 0 {
+		dirMode = DefaultDirMode
+	}
+
 	var (
 		newFiles = []string{}
 		keepErr  error
 	)
 
-	files, err := x.GetFileList(fromPath)
+	files, err := listFiles(fromPath)
 	if err != nil {
 		return nil, err
 	}
@@ -516,9 +549,9 @@ func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, 
 		toPath = strings.TrimSuffix(toPath, filepath.Ext(toPath))
 	}
 
-	x.config.Debugf("Moving files: %v (%d files) -> %v", fromPath, len(files), toPath)
+	log.Debugf("Moving files: %v (%d files) -> %v", fromPath, len(files), toPath)
 
-	err = os.MkdirAll(toPath, x.config.DirMode)
+	err = os.MkdirAll(toPath, dirMode)
 	if err != nil {
 		return nil, fmt.Errorf("making final dir: %w", err)
 	}
@@ -531,25 +564,25 @@ func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, 
 		)
 
 		if exists && !overwrite {
-			x.config.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
+			log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
 			// keep trying.
 			continue
 		}
 
-		switch err = x.Rename(file, newFile); {
+		switch err = renameFile(file, newFile); {
 		case err != nil:
 			keepErr = err
-			x.config.Printf("Error: Renaming Temp File: %v to %v: %v", file, newFile, err)
+			log.Printf("Error: Renaming Temp File: %v to %v: %v", file, newFile, err)
 		case exists:
 			newFiles = append(newFiles, newFile)
-			x.config.Debugf("Renamed Temp File: %v -> %v (overwrote existing file)", file, newFile)
+			log.Debugf("Renamed Temp File: %v -> %v (overwrote existing file)", file, newFile)
 		default:
 			newFiles = append(newFiles, newFile)
-			x.config.Debugf("Renamed Temp File: %v -> %v", file, newFile)
+			log.Debugf("Renamed Temp File: %v -> %v", file, newFile)
 		}
 	}
 
-	x.DeleteFiles(fromPath)
+	deleteFiles(log, fromPath)
 	// Since this is the last step, we tried to rename all the files, bubble the
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
@@ -558,15 +591,23 @@ func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, 
 
 // DeleteFiles obliterates things and logs. Use with caution.
 func (x *Xtractr) DeleteFiles(files ...string) {
+	deleteFiles(x.config, files...)
+}
+
+func deleteFiles(log Logger, files ...string) {
+	if log == nil {
+		log = NoLogger()
+	}
+
 	for _, file := range files {
 		err := os.RemoveAll(file)
 		if err != nil {
-			x.config.Printf("Error: Deleting %v: %v", file, err)
+			log.Printf("Error: Deleting %v: %v", file, err)
 
 			continue
 		}
 
-		x.config.Printf("Deleted (recursively): %s", file)
+		log.Printf("Deleted (recursively): %s", file)
 	}
 }
 
@@ -670,6 +711,10 @@ type file struct {
 
 // Rename is an attempt to deal with "invalid cross link device" on weird file systems.
 func (x *Xtractr) Rename(oldpath, newpath string) error {
+	return renameFile(oldpath, newpath)
+}
+
+func renameFile(oldpath, newpath string) error {
 	origErr := os.Rename(oldpath, newpath)
 	if origErr == nil {
 		return nil

--- a/files.go
+++ b/files.go
@@ -506,9 +506,10 @@ func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, 
 	return moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
 }
 
-// bindMoveFiles gives ExtractFile a MoveFiles implementation that uses this
-// job's logger and DirMode, instead of a throwaway Config (which would apply
-// DefaultDirMode).
+// bindMoveFiles wires ExtractFile to this job's logger and DirMode.
+// The old parseConfig(&Config{Logger: x.log}) path allocated a throwaway
+// Xtractr (and its done channel) per extract. A pre-set stub is left in
+// place so tests can inject one.
 func (x *XFile) bindMoveFiles() { //nolint:funcorder // kept next to MoveFiles
 	if x.moveFiles != nil {
 		return
@@ -557,11 +558,15 @@ func moveFiles( //nolint:cyclop,funlen
 	}
 
 	for _, file := range files {
-		var (
-			newFile = filepath.Join(toPath, filepath.Base(file))
-			_, err  = os.Stat(newFile)
-			exists  = !os.IsNotExist(err)
-		)
+		newFile := filepath.Join(toPath, filepath.Base(file))
+		if filepath.Clean(file) == filepath.Clean(newFile) {
+			// Already at the destination (squash of a lone top-level file).
+			newFiles = append(newFiles, newFile)
+			continue
+		}
+
+		_, err = os.Stat(newFile)
+		exists := !os.IsNotExist(err)
 
 		if exists && !overwrite {
 			log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
@@ -582,7 +587,11 @@ func moveFiles( //nolint:cyclop,funlen
 		}
 	}
 
-	deleteFiles(log, fromPath)
+	info, statErr := os.Stat(fromPath)
+	if statErr == nil && info.IsDir() {
+		deleteFiles(log, fromPath)
+	}
+
 	// Since this is the last step, we tried to rename all the files, bubble the
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
@@ -862,10 +871,25 @@ func (x *XFile) squashRoot(files []string) ([]string, error) {
 		roots[strings.SplitN(newRoot, string(filepath.Separator), 2)[0]] = struct{}{} //nolint:mnd
 	}
 
-	if len(roots) == 1 { // only 1 root folder...
-		for root := range roots { // ...move it's content up a level.
-			return x.moveFiles(filepath.Join(x.OutputDir, root), x.OutputDir, false)
+	if len(roots) != 1 {
+		return files, nil
+	}
+
+	for root := range roots {
+		from := filepath.Join(x.OutputDir, root)
+
+		info, err := os.Stat(from)
+		if err != nil {
+			return files, fmt.Errorf("stat squash root: %w", err)
 		}
+
+		if !info.IsDir() {
+			// A lone top-level file is already in OutputDir. Moving it onto
+			// itself used to skip the rename and then delete the extract.
+			return files, nil
+		}
+
+		return x.moveFiles(from, x.OutputDir, false)
 	}
 
 	return files, nil

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -223,7 +223,7 @@ func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	info, err := os.Stat(dest)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
-		"custom DirMode must reach MkdirAll; a dummy Config would have used DefaultDirMode")
+		"DirMode must reach MkdirAll when the dest does not already exist")
 }
 
 func TestBindMoveFilesUsesXFileDirMode(t *testing.T) {
@@ -268,4 +268,67 @@ func TestMoveFilesZeroDirModeUsesDefault(t *testing.T) {
 	info, err := os.Stat(dest)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(DefaultDirMode).Perm(), info.Mode().Perm())
+}
+
+func TestSquashRootLeavesSingleFile(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	path := filepath.Join(out, "a.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hi"), 0o600))
+
+	xFile := &XFile{
+		OutputDir:  out,
+		SquashRoot: true,
+		log:        NoLogger(),
+	}
+	xFile.bindMoveFiles()
+
+	got, err := xFile.squashRoot([]string{path})
+	require.NoError(t, err)
+	assert.Equal(t, []string{path}, got)
+
+	_, err = os.Stat(path)
+	require.NoError(t, err, "SquashRoot must not delete a lone extracted file")
+}
+
+func TestSquashRootMovesSingleDirectory(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	nested := filepath.Join(out, "root")
+	require.NoError(t, os.Mkdir(nested, 0o700))
+	inner := filepath.Join(nested, "a.txt")
+	require.NoError(t, os.WriteFile(inner, []byte("hi"), 0o600))
+
+	xFile := &XFile{
+		OutputDir:  out,
+		SquashRoot: true,
+		DirMode:    0o755,
+		log:        NoLogger(),
+	}
+	xFile.bindMoveFiles()
+
+	got, err := xFile.squashRoot([]string{inner})
+	require.NoError(t, err)
+
+	dest := filepath.Join(out, "a.txt")
+	assert.Equal(t, []string{dest}, got)
+	require.FileExists(t, dest)
+
+	_, err = os.Stat(nested)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestMoveFilesDoesNotDeleteSourceFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.txt")
+	require.NoError(t, os.WriteFile(src, []byte("hi"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, src, dir, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{src}, got)
+	require.FileExists(t, src)
 }

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -3,6 +3,7 @@ package xtractr
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -203,4 +204,68 @@ func TestWriteExtractFileNameTooLongDoesNotFollowTruncatedSymlink(t *testing.T) 
 	got, err := os.ReadFile(victim)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("secret"), got, "must not follow symlink at truncated path")
+}
+
+func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permission bits")
+	}
+
+	fromDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	_, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
+	require.NoError(t, err)
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"custom DirMode must reach MkdirAll; a dummy Config would have used DefaultDirMode")
+}
+
+func TestBindMoveFilesUsesXFileDirMode(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permission bits")
+	}
+
+	fromDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
+
+	xFile := &XFile{
+		DirMode: 0o700,
+		log:     NoLogger(),
+	}
+	xFile.bindMoveFiles()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	_, err := xFile.moveFiles(fromDir, dest, false)
+	require.NoError(t, err)
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+func TestMoveFilesZeroDirModeUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permission bits")
+	}
+
+	fromDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	_, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
+	require.NoError(t, err)
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(DefaultDirMode).Perm(), info.Mode().Perm())
 }

--- a/zip_test.go
+++ b/zip_test.go
@@ -35,6 +35,36 @@ func TestZip(t *testing.T) {
 	assert.Len(t, archives, zipFile.archiveCount)
 }
 
+func TestZipSquashRootSingleFileDoesNotDeleteExtract(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "one.zip")
+
+	zipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(zipFile)
+	writer, err := zipWriter.Create("a.txt")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("hi"))
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	out := filepath.Join(dir, "out")
+	_, files, _, err := xtractr.ExtractFile(&xtractr.XFile{
+		FilePath:   src,
+		OutputDir:  out,
+		FileMode:   0o600,
+		DirMode:    0o700,
+		SquashRoot: true,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(out, "a.txt"))
+	require.NotEmpty(t, files)
+}
+
 func makeZipFile(t *testing.T) testFilesInfo {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Lift `MoveFiles` / `GetFileList` / `Rename` / `DeleteFiles` internals to package functions that take a logger and dir mode.
- `ExtractFile` now binds `XFile.moveFiles` from the job's logger and `DirMode` instead of `parseConfig(&Config{Logger: ...}).MoveFiles`, which allocated a throwaway `Xtractr` (and its done channel) per extract.
- `SquashRoot` only hoists a single *directory* root. A lone top-level file is already in `OutputDir`; moving it onto itself used to skip the rename and then delete the extract.

`DirMode` on `MkdirAll` in `moveFiles` still applies when the dest does not already exist. The bound `squashRoot` call uses `OutputDir`, which `processArchive` already created with the job's `DirMode`, so that particular `MkdirAll` is a no-op.

## Test plan
- [x] `go test` for `moveFiles`/`bindMoveFiles` DirMode (`0o700` vs default `0o755`)
- [x] `go test` for SquashRoot of a single-file zip (file survives) and a single-dir archive (contents hoisted)
- [x] `golangci-lint run ./...`
- [x] CI