### PR TITLE
docs: fix archive name comment typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ func main() {
 	response := make(chan *xtractr.Response)
 	// This sends an item into the extraction queue (buffered channel).
 	q.Extract(&xtractr.Xtract{
-		Name:       "my archive",    // name is not import to this library.
+		Name:       "my archive",    // name is not important to this library.
 		SearchPath: "/tmp/archives", // can also be a direct file.
 		CBChannel:  response,        // queue responses are sent here.
 	})

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func (l *Logger) Debugf(msg string, v ...interface{}) {
 	l.debug.Printf(msg, v...)
 }
 
-// Infof printf an info line.
+// Infof prints an info line.
 func (l *Logger) Infof(msg string, v ...interface{}) {
 	l.info.Printf(msg, v...)
 }


### PR DESCRIPTION
Fixes a small typo in the README example comment.

This PR also serves as an end-to-end validation of the Shell GitHub App review automation.