### PR TITLE
Do not follow planted symlinks when writing extracted files

### DIFF
--- a/ape.go
+++ b/ape.go
@@ -158,6 +158,7 @@ func readAPESeekTable(file *os.File, info *apeInfo, junk int64) error {
 	if info.Header.TotalFrames > uint32(maxInt) {
 		return fmt.Errorf("%w: %d frames exceeds platform limits", ErrAPESeekTable, info.Header.TotalFrames)
 	}
+
 	numEntries := int(info.Header.TotalFrames)
 
 	declaredEntries := int64(info.Descriptor.SeekTableBytes) / bytesPerUint32
@@ -280,7 +281,7 @@ func id3v2TagSize(hdr []byte) int64 {
 func apeSkipNullPadding(file *os.File, junk int64) int64 {
 	var b [1]byte
 
-	for scanned := 0; scanned < apeMaxMagicScan; scanned++ {
+	for range apeMaxMagicScan {
 		n, err := file.Read(b[:])
 		if err != nil || n == 0 || b[0] != 0 {
 			return junk
@@ -500,15 +501,15 @@ func splitAPE(
 		outputName := formatTrackFilename(track, ".ape")
 		outputPath := filepath.Join(xFile.OutputDir, outputName)
 
-		size, writeErr := writeTrackAPE(outputPath, info, srcFile, fr.start, fr.end, xFile.FileMode)
+		size, usedPath, writeErr := writeTrackAPE(outputPath, info, srcFile, fr.start, fr.end, xFile.FileMode)
 		if writeErr != nil {
 			return totalSize, files, fmt.Errorf("writing ape track %d: %w", track.Number, writeErr)
 		}
 
 		totalSize += size
 
-		files = append(files, outputPath)
-		xFile.Debugf("Wrote APE track %d: %s (%d bytes)", track.Number, outputPath, size)
+		files = append(files, usedPath)
+		xFile.Debugf("Wrote APE track %d: %s (%d bytes)", track.Number, usedPath, size)
 	}
 
 	return totalSize, files, nil
@@ -523,10 +524,10 @@ func writeTrackAPE(
 	srcFile *os.File,
 	startFrame, endFrame int,
 	fileMode os.FileMode,
-) (uint64, error) {
-	outFile, err := os.OpenFile(outputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileMode)
+) (uint64, string, error) {
+	outFile, usedPath, err := openExtractFile(outputPath, fileMode)
 	if err != nil {
-		return 0, fmt.Errorf("creating output ape file: %w", err)
+		return 0, "", fmt.Errorf("creating output ape file: %w", err)
 	}
 
 	size, err := writeTrackAPEContents(outFile, info, srcFile, startFrame, endFrame)
@@ -537,11 +538,11 @@ func writeTrackAPE(
 	}
 
 	if err != nil {
-		_ = os.Remove(outputPath)
-		return 0, err
+		_ = os.Remove(usedPath)
+		return 0, usedPath, err
 	}
 
-	return size, nil
+	return size, usedPath, nil
 }
 
 // apeTrackContainer holds the serialized, ready-to-write container pieces for one split

--- a/ape_internal_test.go
+++ b/ape_internal_test.go
@@ -632,6 +632,43 @@ func TestSplitAPESingleTrack(t *testing.T) {
 	assert.Equal(t, uint32(3), info.Header.TotalFrames, "single track should contain every frame")
 }
 
+func TestSplitAPETrackReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	outDir := filepath.Join(tmp, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o750))
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	trackPath := filepath.Join(outDir, "01 - Only.ape")
+	require.NoError(t, os.Symlink(victim, trackPath))
+
+	frames := equalFrames(3)
+	srcPath := defaultSyntheticAPE(frames).writeTo(t)
+	xFile := &XFile{OutputDir: outDir, FileMode: 0o600, DirMode: 0o700}
+	cue := &CueSheet{Tracks: []CueTrack{{Number: 1, Title: "Only"}}}
+
+	_, files, err := splitAPE(xFile, srcPath, cue, []cueTimestamp{{}})
+	require.NoError(t, err)
+	require.Equal(t, []string{trackPath}, files)
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "must not follow planted track symlink")
+
+	info, err := os.Lstat(trackPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
 // writeTwoTrackAPECue writes a 4-frame synthetic .ape (named apeName) and an album.cue that
 // references fileLine into dir, then returns the .cue path. With the test fixture's sample
 // rate (100) the second track's INDEX 00:02:00 (200 samples) lands on frame 2.

--- a/cue.go
+++ b/cue.go
@@ -685,7 +685,7 @@ func (s *trackSplitter) openEncoder(idx int) (*trackEncoder, error) {
 		NSamples:      s.trackEnds[idx] - s.trackStarts[idx],
 	}
 
-	outFile, err := os.OpenFile(outputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, s.xFile.FileMode)
+	outFile, usedPath, err := openExtractFile(outputPath, s.xFile.FileMode)
 	if err != nil {
 		return nil, fmt.Errorf("creating output file for track %d: %w", track.Number, err)
 	}
@@ -693,12 +693,14 @@ func (s *trackSplitter) openEncoder(idx int) (*trackEncoder, error) {
 	enc, err := flac.NewEncoder(outFile, trackInfo, blocks...)
 	if err != nil {
 		_ = outFile.Close()
+		_ = os.Remove(usedPath)
+
 		return nil, fmt.Errorf("creating encoder for track %d: %w", track.Number, err)
 	}
 
 	return &trackEncoder{
 		enc:        enc,
-		outputPath: outputPath,
+		outputPath: usedPath,
 		number:     track.Number,
 		start:      s.trackStarts[idx],
 		end:        s.trackEnds[idx],

--- a/cue_test.go
+++ b/cue_test.go
@@ -266,6 +266,55 @@ func TestCueExtractCUE(t *testing.T) {
 	}
 }
 
+func TestCueExtractCUE_ReplacesTrackSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmpDir, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	outputDir := filepath.Join(tmpDir, "output")
+	require.NoError(t, os.MkdirAll(outputDir, 0o750))
+
+	victim := filepath.Join(tmpDir, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	trackPath := filepath.Join(outputDir, "01 - First Song.flac")
+	require.NoError(t, os.Symlink(victim, trackPath))
+
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	generateTestFLAC(t, flacPath, uint64(testBlockSize)*2)
+
+	cuePath := filepath.Join(tmpDir, "album.cue")
+	cueContent := strings.Join([]string{
+		`FILE "album.flac" WAVE`,
+		`  TRACK 01 AUDIO`,
+		`    TITLE "First Song"`,
+		`    INDEX 01 00:00:00`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0o600))
+
+	_, files, _, err := xtractr.ExtractCUE(&xtractr.XFile{
+		FilePath:  cuePath,
+		OutputDir: outputDir,
+		FileMode:  0o600,
+		DirMode:   0o755,
+	})
+	require.NoError(t, err)
+	require.Contains(t, files, trackPath)
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "must not follow planted track symlink")
+
+	info, err := os.Lstat(trackPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
 func TestCueExtractCUE_SplitFLAC_EmbeddedCover(t *testing.T) {
 	t.Parallel()
 

--- a/errors.go
+++ b/errors.go
@@ -23,6 +23,10 @@ var (
 	ErrNoConfig           = errors.New("call NewQueue() to initialize a queue")
 	ErrNoLogger           = errors.New("xtractr.Config.Logger must be non-nil")
 
+	// Extract open. Unix surfaces this as ELOOP (O_NOFOLLOW); Windows as a
+	// reparse point opened with FILE_FLAG_OPEN_REPARSE_POINT.
+	errExtractSymlink = errors.New("refusing to write through a symbolic link")
+
 	// CUE sheet.
 
 	ErrNoCueFile        = errors.New("cue sheet does not reference a FILE")

--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ var (
 	// reparse point opened with FILE_FLAG_OPEN_REPARSE_POINT.
 	errExtractSymlink    = errors.New("refusing to write through a symbolic link")
 	errExtractNotRegular = errors.New("refusing to extract onto a non-regular file")
-	errExtractConflict   = errors.New("too many races replacing a symbolic link at the extract path")
+	errExtractConflict   = errors.New("too many concurrent changes at the extract path")
 
 	// CUE sheet.
 

--- a/errors.go
+++ b/errors.go
@@ -25,7 +25,9 @@ var (
 
 	// Extract open. Unix surfaces this as ELOOP (O_NOFOLLOW); Windows as a
 	// reparse point opened with FILE_FLAG_OPEN_REPARSE_POINT.
-	errExtractSymlink = errors.New("refusing to write through a symbolic link")
+	errExtractSymlink    = errors.New("refusing to write through a symbolic link")
+	errExtractNotRegular = errors.New("refusing to extract onto a non-regular file")
+	errExtractConflict   = errors.New("too many races replacing a symbolic link at the extract path")
 
 	// CUE sheet.
 

--- a/files.go
+++ b/files.go
@@ -983,12 +983,7 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 		return 0, err
 	}
 
-	flags, usedPath, err := openFlagsForExtract(file.Path)
-	if err != nil {
-		return 0, err
-	}
-
-	fout, pathUsed, err := openFile(usedPath, flags, x.safeFileMode(file.FileMode))
+	fout, pathUsed, err := openExtractFile(file.Path, x.safeFileMode(file.FileMode))
 	if err != nil {
 		return 0, err
 	}
@@ -1058,16 +1053,23 @@ func openFlagsForExtract(path string) (int, string, error) {
 	}
 }
 
+// openExtractFile opens path for writing extracted data without following a
+// final-component symlink. The returned path is the one that was actually
+// opened (it may be truncated for NAME_MAX).
+func openExtractFile(path string, mode os.FileMode) (*os.File, string, error) {
+	flags, usedPath, err := openFlagsForExtract(path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return openFile(usedPath, flags, mode)
+}
+
 // writeExtractFile writes data to path without following a final-component
 // symlink. Used for non-archive output (CUE copy, embedded pictures) that
 // otherwise goes through os.WriteFile, which follows links.
 func writeExtractFile(path string, data []byte, mode os.FileMode) error {
-	flags, usedPath, err := openFlagsForExtract(path)
-	if err != nil {
-		return err
-	}
-
-	fout, _, err := openFile(usedPath, flags, mode)
+	fout, usedPath, err := openExtractFile(path, mode)
 	if err != nil {
 		return err
 	}

--- a/files.go
+++ b/files.go
@@ -1035,6 +1035,9 @@ type noFollowOpen func(path string, flags int, mode os.FileMode) (*os.File, erro
 // (ELOOP / reparse point) is unlinked and the exclusive create is retried.
 // Missing-file races retry the exclusive create. Nothing is written through a
 // link, device, pipe, or directory.
+//
+// A hard link to a file outside the output directory is indistinguishable from
+// a regular file after open and is still truncated; that matches os.OpenFile.
 func openExtractFile(path string, mode os.FileMode) (*os.File, string, error) {
 	return openExtractFileWith(openFileNoFollow, path, mode)
 }
@@ -1068,6 +1071,10 @@ func openExtractFileWith(open noFollowOpen, path string, mode os.FileMode) (*os.
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return nil, usedPath, fmt.Errorf("removing symlink at archived file path '%s': %w", usedPath, err)
 		}
+	}
+
+	if errors.Is(lastErr, os.ErrNotExist) {
+		return nil, usedPath, lastErr
 	}
 
 	return nil, usedPath, fmt.Errorf("%w: %w", errExtractConflict, lastErr)

--- a/files.go
+++ b/files.go
@@ -1032,7 +1032,8 @@ type noFollowOpen func(path string, flags int, mode os.FileMode) (*os.File, erro
 // O_NOFOLLOW (Unix) or CREATE_NEW + FILE_FLAG_OPEN_REPARSE_POINT (Windows). If
 // the name exists, the existing object is opened the same no-follow way and
 // truncated only after the fd is confirmed to be a regular disk file. A symlink
-// (ELOOP / reparse point) is unlinked and the exclusive create is retried.
+// or directory junction (ELOOP / reparse point) is unlinked and the exclusive
+// create is retried.
 // Missing-file races retry the exclusive create. Nothing is written through a
 // link, device, pipe, or directory.
 //
@@ -1086,7 +1087,11 @@ func tryOpenExtractFile(open noFollowOpen, path string, mode os.FileMode) (*os.F
 		return finishExtractOpen(file, used, false)
 	}
 
-	if errors.Is(err, errExtractSymlink) || !errors.Is(err, os.ErrExist) {
+	if errors.Is(err, errExtractSymlink) {
+		return nil, used, err
+	}
+
+	if !errors.Is(err, os.ErrExist) && !isDeniedExclusiveCreate(err) {
 		return nil, used, err
 	}
 

--- a/files.go
+++ b/files.go
@@ -1016,83 +1016,125 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 	return uint64(size), nil
 }
 
-// openFlagsForExtract returns OpenFile flags that will not follow a symlink at
-// path, plus the path those flags apply to. A symlink already sitting at the
-// write target is removed and the file is created with O_EXCL. O_EXCL is also
-// used when the path does not exist, so a symlink planted in the race window
-// cannot be followed either. The remaining O_TRUNC case (existing regular file)
-// is opened with O_NOFOLLOW / FILE_FLAG_OPEN_REPARSE_POINT in openExtractFile
-// so a symlink swapped in after Lstat is not followed.
-//
-// If Lstat fails with ENAMETOOLONG, the path is truncated first (via
-// TruncatePathForFS) and the symlink check runs against that shorter name.
-// Otherwise openFile would later truncate and OpenFile with O_TRUNC, following
-// a planted link at the truncated target.
-func openFlagsForExtract(path string) (int, string, error) {
-	info, statErr := os.Lstat(path)
-	if IsErrNameTooLong(statErr) {
-		shortPath, err := TruncatePathForFS(path)
-		if err != nil {
-			return 0, "", err
-		}
+// extractOpenAttempts bounds the create/replace loop so a tight symlink-plant
+// race cannot spin forever. Each pass either returns a regular file or fails closed.
+const extractOpenAttempts = 8
 
-		path = shortPath
-		info, statErr = os.Lstat(path)
-	}
-
-	switch {
-	case statErr == nil && info.Mode()&os.ModeSymlink != 0:
-		err := os.Remove(path)
-		if err != nil {
-			return 0, "", fmt.Errorf("removing symlink at archived file path '%s': %w", path, err)
-		}
-
-		return os.O_RDWR | os.O_CREATE | os.O_EXCL, path, nil
-	case errors.Is(statErr, os.ErrNotExist):
-		return os.O_RDWR | os.O_CREATE | os.O_EXCL, path, nil
-	default:
-		return os.O_RDWR | os.O_CREATE | os.O_TRUNC, path, nil
-	}
-}
-
-func isSymlinkOpenErr(err error) bool {
-	return errors.Is(err, errExtractSymlink)
-}
+// noFollowOpen opens a path for extract writes without following a final-component
+// symlink. Production uses openFileNoFollow; tests inject a fake to exercise races.
+type noFollowOpen func(path string, flags int, mode os.FileMode) (*os.File, error)
 
 // openExtractFile opens path for writing extracted data without following a
 // final-component symlink. The returned path is the one that was actually
 // opened (it may be truncated for NAME_MAX).
 //
-// Opening uses O_NOFOLLOW (Unix) or FILE_FLAG_OPEN_REPARSE_POINT (Windows) so a
-// symlink planted after lstat cannot be followed by O_TRUNC. If the open still
-// sees a symlink, it is removed and the file is created with O_EXCL.
+// There is no Lstat-then-open decision. Each attempt exclusively-creates with
+// O_NOFOLLOW (Unix) or CREATE_NEW + FILE_FLAG_OPEN_REPARSE_POINT (Windows). If
+// the name exists, the existing object is opened the same no-follow way and
+// truncated only after the fd is confirmed to be a regular disk file. A symlink
+// (ELOOP / reparse point) is unlinked and the exclusive create is retried.
+// Missing-file races retry the exclusive create. Nothing is written through a
+// link, device, pipe, or directory.
 func openExtractFile(path string, mode os.FileMode) (*os.File, string, error) {
-	flags, usedPath, err := openFlagsForExtract(path)
-	if err != nil {
-		return nil, "", err
+	return openExtractFileWith(openFileNoFollow, path, mode)
+}
+
+func openExtractFileWith(open noFollowOpen, path string, mode os.FileMode) (*os.File, string, error) {
+	usedPath := path
+
+	var lastErr error
+
+	for range extractOpenAttempts {
+		file, openedPath, err := tryOpenExtractFile(open, usedPath, mode)
+		if openedPath != "" {
+			usedPath = openedPath
+		}
+
+		if err == nil {
+			return file, usedPath, nil
+		}
+
+		lastErr = err
+
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+
+		if !errors.Is(err, errExtractSymlink) {
+			return nil, usedPath, err
+		}
+
+		err = os.Remove(usedPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, usedPath, fmt.Errorf("removing symlink at archived file path '%s': %w", usedPath, err)
+		}
 	}
 
-	fout, pathUsed, err := openFileNoFollowTrunc(usedPath, flags, mode)
+	return nil, usedPath, fmt.Errorf("%w: %w", errExtractConflict, lastErr)
+}
+
+func tryOpenExtractFile(open noFollowOpen, path string, mode os.FileMode) (*os.File, string, error) {
+	file, used, err := openFileNoFollowTrunc(open, path, os.O_RDWR|os.O_CREATE|os.O_EXCL, mode)
 	if err == nil {
-		return fout, pathUsed, nil
+		return finishExtractOpen(file, used, false)
 	}
 
-	if !isSymlinkOpenErr(err) {
-		return nil, "", err
+	if errors.Is(err, errExtractSymlink) || !errors.Is(err, os.ErrExist) {
+		return nil, used, err
 	}
 
-	err = os.Remove(pathUsed)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, "", fmt.Errorf("removing symlink at archived file path '%s': %w", pathUsed, err)
+	file, used, err = openFileNoFollowTrunc(open, used, os.O_RDWR, mode)
+	if err != nil {
+		return nil, used, err
 	}
 
-	return openFileNoFollowTrunc(pathUsed, os.O_RDWR|os.O_CREATE|os.O_EXCL, mode)
+	return finishExtractOpen(file, used, true)
+}
+
+func finishExtractOpen(file *os.File, used string, truncate bool) (*os.File, string, error) {
+	err := requireRegularFile(file)
+	if err != nil {
+		_ = file.Close()
+
+		return nil, used, err
+	}
+
+	if !truncate {
+		return file, used, nil
+	}
+
+	err = file.Truncate(0)
+	if err != nil {
+		_ = file.Close()
+
+		return nil, used, fmt.Errorf("truncating extract file '%s': %w", used, err)
+	}
+
+	return file, used, nil
+}
+
+func requireRegularFile(file *os.File) error {
+	err := requireDiskFile(file)
+	if err != nil {
+		return err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat extract file: %w", err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: %s", errExtractNotRegular, file.Name())
+	}
+
+	return nil
 }
 
 // openFileNoFollowTrunc opens path without following a final-component symlink.
 // If the path exceeds NAME_MAX, it is truncated and retried, same as openFile.
-func openFileNoFollowTrunc(path string, flags int, mode os.FileMode) (*os.File, string, error) {
-	file, err := openFileNoFollow(path, flags, mode)
+func openFileNoFollowTrunc(open noFollowOpen, path string, flags int, mode os.FileMode) (*os.File, string, error) {
+	file, err := open(path, flags, mode)
 	if err == nil {
 		return file, path, nil
 	}
@@ -1106,7 +1148,7 @@ func openFileNoFollowTrunc(path string, flags int, mode os.FileMode) (*os.File, 
 		return nil, "", truncErr
 	}
 
-	file, err = openFileNoFollow(shortPath, flags, mode)
+	file, err = open(shortPath, flags, mode)
 	if err != nil {
 		return nil, shortPath, err
 	}

--- a/files.go
+++ b/files.go
@@ -1018,9 +1018,11 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 
 // openFlagsForExtract returns OpenFile flags that will not follow a symlink at
 // path, plus the path those flags apply to. A symlink already sitting at the
-// write target is followed by O_TRUNC, so it is removed and the file is created
-// with O_EXCL. O_EXCL is also used when the path does not exist, so a symlink
-// planted in the race window cannot be followed either.
+// write target is removed and the file is created with O_EXCL. O_EXCL is also
+// used when the path does not exist, so a symlink planted in the race window
+// cannot be followed either. The remaining O_TRUNC case (existing regular file)
+// is opened with O_NOFOLLOW / FILE_FLAG_OPEN_REPARSE_POINT in openExtractFile
+// so a symlink swapped in after Lstat is not followed.
 //
 // If Lstat fails with ENAMETOOLONG, the path is truncated first (via
 // TruncatePathForFS) and the symlink check runs against that shorter name.
@@ -1053,16 +1055,63 @@ func openFlagsForExtract(path string) (int, string, error) {
 	}
 }
 
+func isSymlinkOpenErr(err error) bool {
+	return errors.Is(err, errExtractSymlink)
+}
+
 // openExtractFile opens path for writing extracted data without following a
 // final-component symlink. The returned path is the one that was actually
 // opened (it may be truncated for NAME_MAX).
+//
+// Opening uses O_NOFOLLOW (Unix) or FILE_FLAG_OPEN_REPARSE_POINT (Windows) so a
+// symlink planted after lstat cannot be followed by O_TRUNC. If the open still
+// sees a symlink, it is removed and the file is created with O_EXCL.
 func openExtractFile(path string, mode os.FileMode) (*os.File, string, error) {
 	flags, usedPath, err := openFlagsForExtract(path)
 	if err != nil {
 		return nil, "", err
 	}
 
-	return openFile(usedPath, flags, mode)
+	fout, pathUsed, err := openFileNoFollowTrunc(usedPath, flags, mode)
+	if err == nil {
+		return fout, pathUsed, nil
+	}
+
+	if !isSymlinkOpenErr(err) {
+		return nil, "", err
+	}
+
+	err = os.Remove(pathUsed)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, "", fmt.Errorf("removing symlink at archived file path '%s': %w", pathUsed, err)
+	}
+
+	return openFileNoFollowTrunc(pathUsed, os.O_RDWR|os.O_CREATE|os.O_EXCL, mode)
+}
+
+// openFileNoFollowTrunc opens path without following a final-component symlink.
+// If the path exceeds NAME_MAX, it is truncated and retried, same as openFile.
+func openFileNoFollowTrunc(path string, flags int, mode os.FileMode) (*os.File, string, error) {
+	file, err := openFileNoFollow(path, flags, mode)
+	if err == nil {
+		return file, path, nil
+	}
+
+	if !IsErrNameTooLong(err) {
+		return nil, path, err
+	}
+
+	shortPath, truncErr := TruncatePathForFS(path)
+	if truncErr != nil {
+		return nil, "", truncErr
+	}
+
+	file, err = openFileNoFollow(shortPath, flags, mode)
+	if err != nil {
+		return nil, shortPath, err
+	}
+
+	return file, shortPath, nil
 }
 
 // writeExtractFile writes data to path without following a final-component

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -356,6 +356,62 @@ func TestOpenExtractFileRetriesWhenOpenSeesSymlink(t *testing.T) {
 	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
 }
 
+func TestOpenExtractFileRetriesWhenFileVanishes(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "track.flac")
+	calls := 0
+	opener := func(path string, flags int, mode os.FileMode) (*os.File, error) {
+		calls++
+
+		if flags&os.O_EXCL != 0 && calls == 1 {
+			return nil, os.ErrExist
+		}
+
+		if flags&os.O_EXCL == 0 && calls == 2 {
+			return nil, os.ErrNotExist
+		}
+
+		return openFileNoFollow(path, flags, mode)
+	}
+
+	fout, usedPath, err := openExtractFileWith(opener, dest, 0o600)
+	require.NoError(t, err)
+	assert.Equal(t, dest, usedPath)
+	assert.GreaterOrEqual(t, calls, 3)
+	require.NoError(t, fout.Close())
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular())
+}
+
+func TestOpenExtractFileConflictExhaustion(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "track.flac")
+	opener := func(string, int, os.FileMode) (*os.File, error) {
+		return nil, errExtractSymlink
+	}
+
+	_, _, err := openExtractFileWith(opener, dest, 0o600)
+	require.ErrorIs(t, err, errExtractConflict)
+	require.ErrorIs(t, err, errExtractSymlink)
+}
+
+func TestOpenExtractFileNotExistExhaustion(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "track.flac")
+	opener := func(string, int, os.FileMode) (*os.File, error) {
+		return nil, os.ErrNotExist
+	}
+
+	_, _, err := openExtractFileWith(opener, dest, 0o600)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NotErrorIs(t, err, errExtractConflict)
+}
+
 func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	t.Parallel()
 

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -153,10 +153,10 @@ func TestMkDirRefusesPreExistingSymlinkDir(t *testing.T) {
 	assert.Equal(t, oldTime.Unix(), info.ModTime().Unix(), "rejected path must not be Chtimes'd")
 }
 
-// TestOpenFlagsForExtractNameTooLongUsesExcl is the Copilot finding: Lstat of a
-// too-long name fails with ENAMETOOLONG, which used to fall through to O_TRUNC.
-// openFile then truncates and OpenFile-follows a raced symlink at the short name.
-func TestOpenFlagsForExtractNameTooLongUsesExcl(t *testing.T) {
+// TestOpenExtractFileNameTooLongCreatesShortName is the Copilot finding: Lstat of a
+// too-long name used to fall through to O_TRUNC. The exclusive-create path now
+// retries the truncated name with O_EXCL / CREATE_NEW instead.
+func TestOpenExtractFileNameTooLongCreatesShortName(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
@@ -167,10 +167,15 @@ func TestOpenFlagsForExtractNameTooLongUsesExcl(t *testing.T) {
 		t.Skipf("filesystem accepted a 300-byte filename (got %v)", err)
 	}
 
-	flags, usedPath, err := openFlagsForExtract(long)
+	fout, usedPath, err := openExtractFile(long, 0o600)
 	require.NoError(t, err)
-	assert.Equal(t, os.O_RDWR|os.O_CREATE|os.O_EXCL, flags)
 	assert.LessOrEqual(t, len(filepath.Base(usedPath)), nameMax)
+	require.NoError(t, fout.Close())
+
+	info, err := os.Lstat(usedPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+	assert.True(t, info.Mode().IsRegular())
 }
 
 // TestWriteExtractFileNameTooLongDoesNotFollowTruncatedSymlink plants a symlink
@@ -289,6 +294,66 @@ func TestOpenExtractFileTruncatesRegularFile(t *testing.T) {
 	got, err := os.ReadFile(dest)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new"), got)
+}
+
+// TestOpenExtractFileRetriesWhenOpenSeesSymlink is the qwen finding: Lstat (or
+// exclusive-create EEXIST) can observe a regular file while the no-follow open
+// of that name sees a symlink planted in the window. The retry must unlink and
+// exclusive-create, never write through the link.
+func TestOpenExtractFileRetriesWhenOpenSeesSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	dest := filepath.Join(tmp, "track.flac")
+	require.NoError(t, os.WriteFile(dest, []byte("old"), 0o600))
+
+	calls := 0
+	opener := func(path string, flags int, mode os.FileMode) (*os.File, error) {
+		calls++
+
+		if flags&os.O_EXCL != 0 && calls == 1 {
+			return nil, os.ErrExist
+		}
+
+		if flags&os.O_EXCL == 0 && calls == 2 {
+			require.NoError(t, os.Remove(dest))
+			require.NoError(t, os.Symlink(victim, dest))
+
+			return nil, errExtractSymlink
+		}
+
+		return openFileNoFollow(path, flags, mode)
+	}
+
+	fout, usedPath, err := openExtractFileWith(opener, dest, 0o600)
+	require.NoError(t, err)
+	assert.Equal(t, dest, usedPath)
+	assert.GreaterOrEqual(t, calls, 3)
+
+	_, err = fout.WriteString("track")
+	require.NoError(t, err)
+	require.NoError(t, fout.Close())
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "retry must not follow the planted symlink")
+
+	written, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("track"), written)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
 }
 
 func TestMoveFilesUsesProvidedDirMode(t *testing.T) {

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -248,6 +248,60 @@ func TestOpenExtractFileReplacesSymlink(t *testing.T) {
 	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
 }
 
+func TestOpenExtractFileReplacesDirectorySymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	dir := filepath.Join(tmp, "dir")
+	require.NoError(t, os.Mkdir(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inside"), []byte("keep"), 0o600))
+
+	dest := filepath.Join(tmp, "member")
+	require.NoError(t, os.Symlink(dir, dest))
+
+	fout, usedPath, err := openExtractFile(dest, 0o600)
+	require.NoError(t, err)
+	assert.Equal(t, dest, usedPath)
+
+	_, err = fout.WriteString("payload")
+	require.NoError(t, err)
+	require.NoError(t, fout.Close())
+
+	got, err := os.ReadFile(filepath.Join(dir, "inside"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("keep"), got, "must not follow a directory symlink/junction")
+
+	written, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("payload"), written)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+	assert.True(t, info.Mode().IsRegular())
+}
+
+func TestOpenExtractFileRefusesDirectory(t *testing.T) {
+	t.Parallel()
+
+	dest := t.TempDir()
+	marker := filepath.Join(dest, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0o600))
+
+	_, _, err := openExtractFile(dest, 0o600)
+	require.Error(t, err)
+
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("keep"), got)
+}
+
 func TestOpenFileNoFollowDoesNotFollowSymlink(t *testing.T) {
 	t.Parallel()
 

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -243,6 +243,54 @@ func TestOpenExtractFileReplacesSymlink(t *testing.T) {
 	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
 }
 
+func TestOpenFileNoFollowDoesNotFollowSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	dest := filepath.Join(tmp, "track.flac")
+	require.NoError(t, os.Symlink(victim, dest))
+
+	_, err = openFileNoFollow(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errExtractSymlink)
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "O_TRUNC must not follow a final-component symlink")
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeSymlink, "symlink should still be present")
+}
+
+func TestOpenExtractFileTruncatesRegularFile(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "track.flac")
+	require.NoError(t, os.WriteFile(dest, []byte("old payload"), 0o600))
+
+	fout, usedPath, err := openExtractFile(dest, 0o600)
+	require.NoError(t, err)
+	assert.Equal(t, dest, usedPath)
+
+	_, err = fout.WriteString("new")
+	require.NoError(t, err)
+	require.NoError(t, fout.Close())
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), got)
+}
+
 func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	t.Parallel()
 

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -206,6 +206,43 @@ func TestWriteExtractFileNameTooLongDoesNotFollowTruncatedSymlink(t *testing.T) 
 	assert.Equal(t, []byte("secret"), got, "must not follow symlink at truncated path")
 }
 
+func TestOpenExtractFileReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	victim := filepath.Join(tmp, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+
+	dest := filepath.Join(tmp, "track.flac")
+	require.NoError(t, os.Symlink(victim, dest))
+
+	fout, usedPath, err := openExtractFile(dest, 0o600)
+	require.NoError(t, err)
+	assert.Equal(t, dest, usedPath)
+
+	_, err = fout.WriteString("track")
+	require.NoError(t, err)
+	require.NoError(t, fout.Close())
+
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), got, "must not follow destPath symlink")
+
+	written, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("track"), written)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
 func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	t.Parallel()
 

--- a/files_other.go
+++ b/files_other.go
@@ -1,0 +1,18 @@
+//go:build !unix && !windows
+
+package xtractr
+
+import (
+	"fmt"
+	"os"
+)
+
+// openFileNoFollow falls back to os.OpenFile on platforms without a no-follow open.
+func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
+	file, err := os.OpenFile(path, flags, mode)
+	if err != nil {
+		return nil, fmt.Errorf("os.OpenFile(): %w", err)
+	}
+
+	return file, nil
+}

--- a/files_other.go
+++ b/files_other.go
@@ -7,12 +7,12 @@ import (
 	"os"
 )
 
-// openFileNoFollow falls back to os.OpenFile on platforms without a no-follow open.
-// A pre-existing final-component symlink is refused; a symlink planted after this
-// Lstat can still be followed on these platforms.
+// openFileNoFollow cannot implement a true no-follow open on this platform.
+// Exclusive-create (O_EXCL) does not follow a final-component symlink.
+// Any other open is refused so the caller unlinks the name and retries with
+// O_EXCL, instead of os.OpenFile-following a symlink planted after Lstat.
 func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
-	info, err := os.Lstat(path)
-	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+	if flags&os.O_EXCL == 0 {
 		return nil, errExtractSymlink
 	}
 

--- a/files_other.go
+++ b/files_other.go
@@ -8,11 +8,22 @@ import (
 )
 
 // openFileNoFollow falls back to os.OpenFile on platforms without a no-follow open.
+// A pre-existing final-component symlink is refused; a symlink planted after this
+// Lstat can still be followed on these platforms.
 func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, errExtractSymlink
+	}
+
 	file, err := os.OpenFile(path, flags, mode)
 	if err != nil {
 		return nil, fmt.Errorf("os.OpenFile(): %w", err)
 	}
 
 	return file, nil
+}
+
+func requireDiskFile(*os.File) error {
+	return nil
 }

--- a/files_other.go
+++ b/files_other.go
@@ -24,6 +24,10 @@ func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error
 	return file, nil
 }
 
+func isDeniedExclusiveCreate(error) bool {
+	return false
+}
+
 func requireDiskFile(*os.File) error {
 	return nil
 }

--- a/files_unix.go
+++ b/files_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package xtractr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// openFileNoFollow is os.OpenFile plus O_NOFOLLOW so a final-component symlink
+// fails with ELOOP instead of writing through to the target.
+func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
+	file, err := os.OpenFile(path, flags|syscall.O_NOFOLLOW, mode)
+	if err == nil {
+		return file, nil
+	}
+
+	if errors.Is(err, syscall.ELOOP) {
+		return nil, fmt.Errorf("%w: %w", errExtractSymlink, err)
+	}
+
+	return nil, fmt.Errorf("os.OpenFile(): %w", err)
+}

--- a/files_unix.go
+++ b/files_unix.go
@@ -24,6 +24,10 @@ func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error
 	return nil, fmt.Errorf("os.OpenFile(): %w", err)
 }
 
+func isDeniedExclusiveCreate(error) bool {
+	return false
+}
+
 // requireDiskFile is a no-op on Unix; requireRegularFile uses fstat mode bits.
 func requireDiskFile(*os.File) error {
 	return nil

--- a/files_unix.go
+++ b/files_unix.go
@@ -23,3 +23,8 @@ func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error
 
 	return nil, fmt.Errorf("os.OpenFile(): %w", err)
 }
+
+// requireDiskFile is a no-op on Unix; requireRegularFile uses fstat mode bits.
+func requireDiskFile(*os.File) error {
+	return nil
+}

--- a/files_unix_internal_test.go
+++ b/files_unix_internal_test.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package xtractr
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenExtractFileRefusesFifo(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "member")
+	require.NoError(t, syscall.Mkfifo(dest, 0o600))
+
+	_, _, err := openExtractFile(dest, 0o600)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errExtractNotRegular)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	require.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeNamedPipe)
+}

--- a/files_windows.go
+++ b/files_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package xtractr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// FILE_FLAG_OPEN_REPARSE_POINT: open the reparse point itself, do not follow it.
+const fileFlagOpenReparsePoint = 0x00200000
+
+// openFileNoFollow opens path for extract writes without following a final-component
+// symlink. A reparse point is reported as errExtractSymlink so the caller can
+// replace it with O_EXCL rather than writing through it.
+//
+// OPEN_EXISTING is used instead of CREATE_ALWAYS so a planted reparse point is
+// inspected rather than replaced-or-followed before we can refuse it.
+func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
+	handle, createdNew, err := createNoFollowHandle(path, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	if !createdNew {
+		err = refuseReparsePoint(handle)
+		if err != nil {
+			_ = syscall.CloseHandle(handle)
+
+			return nil, &os.PathError{Op: "open", Path: path, Err: err}
+		}
+	}
+
+	if flags&os.O_TRUNC != 0 {
+		err = syscall.SetEndOfFile(handle)
+		if err != nil {
+			_ = syscall.CloseHandle(handle)
+
+			return nil, &os.PathError{Op: "truncate", Path: path, Err: err}
+		}
+	}
+
+	file := os.NewFile(uintptr(handle), path)
+	_ = file.Chmod(mode)
+
+	return file, nil
+}
+
+func createNoFollowHandle(path string, flags int) (syscall.Handle, bool, error) {
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return syscall.InvalidHandle, false, fmt.Errorf("path: %w", err)
+	}
+
+	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
+	share := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+	attrs := uint32(syscall.FILE_ATTRIBUTE_NORMAL) | fileFlagOpenReparsePoint
+	createdNew := flags&os.O_EXCL != 0
+	createmode := uint32(syscall.OPEN_EXISTING)
+
+	if createdNew {
+		createmode = syscall.CREATE_NEW
+	}
+
+	handle, err := syscall.CreateFile(pathp, access, share, nil, createmode, attrs, 0)
+	if err != nil && !createdNew && flags&os.O_CREATE != 0 && errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+		handle, err = syscall.CreateFile(pathp, access, share, nil, syscall.CREATE_NEW, attrs, 0)
+		createdNew = true
+	}
+
+	if err != nil {
+		return syscall.InvalidHandle, false, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+
+	return handle, createdNew, nil
+}
+
+func refuseReparsePoint(handle syscall.Handle) error {
+	var info syscall.ByHandleFileInformation
+
+	err := syscall.GetFileInformationByHandle(handle, &info)
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+
+	if info.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return errExtractSymlink
+	}
+
+	return nil
+}

--- a/files_windows.go
+++ b/files_windows.go
@@ -24,17 +24,17 @@ func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error
 		return nil, err
 	}
 
-	if !createdNew {
-		err = refuseReparsePoint(handle)
-		if err != nil {
-			_ = syscall.CloseHandle(handle)
+	err = inspectExtractHandle(handle, createdNew)
+	if err != nil {
+		_ = syscall.CloseHandle(handle)
 
-			return nil, &os.PathError{Op: "open", Path: path, Err: err}
-		}
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
 
 	file := os.NewFile(uintptr(handle), path)
-	_ = file.Chmod(mode)
+	if createdNew {
+		_ = file.Chmod(mode)
+	}
 
 	return file, nil
 }
@@ -63,6 +63,35 @@ func createNoFollowHandle(path string, flags int) (syscall.Handle, bool, error) 
 	return handle, createdNew, nil
 }
 
+// inspectExtractHandle rejects devices/pipes before querying reparse attributes.
+// GetFileInformationByHandle is unsupported for NUL/CON/pipes and would hide
+// errExtractNotRegular behind a generic stat error.
+func inspectExtractHandle(handle syscall.Handle, createdNew bool) error {
+	err := refuseNonDiskHandle(handle)
+	if err != nil {
+		return err
+	}
+
+	if createdNew {
+		return nil
+	}
+
+	return refuseReparsePoint(handle)
+}
+
+func refuseNonDiskHandle(handle syscall.Handle) error {
+	kind, err := syscall.GetFileType(handle)
+	if err != nil {
+		return fmt.Errorf("file type: %w", err)
+	}
+
+	if kind != syscall.FILE_TYPE_DISK {
+		return errExtractNotRegular
+	}
+
+	return nil
+}
+
 func refuseReparsePoint(handle syscall.Handle) error {
 	var info syscall.ByHandleFileInformation
 
@@ -81,14 +110,5 @@ func refuseReparsePoint(handle syscall.Handle) error {
 // requireDiskFile rejects Windows devices and pipes (NUL, CON, COM1, named pipes).
 // os.File.Stat on those handles can look like a regular file.
 func requireDiskFile(file *os.File) error {
-	kind, err := syscall.GetFileType(syscall.Handle(file.Fd()))
-	if err != nil {
-		return fmt.Errorf("file type: %w", err)
-	}
-
-	if kind != syscall.FILE_TYPE_DISK {
-		return fmt.Errorf("%w: %s", errExtractNotRegular, file.Name())
-	}
-
-	return nil
+	return refuseNonDiskHandle(syscall.Handle(file.Fd()))
 }

--- a/files_windows.go
+++ b/files_windows.go
@@ -3,7 +3,6 @@
 package xtractr
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -14,10 +13,11 @@ const fileFlagOpenReparsePoint = 0x00200000
 
 // openFileNoFollow opens path for extract writes without following a final-component
 // symlink. A reparse point is reported as errExtractSymlink so the caller can
-// replace it with O_EXCL rather than writing through it.
+// unlink it and retry with CREATE_NEW rather than writing through it.
 //
-// OPEN_EXISTING is used instead of CREATE_ALWAYS so a planted reparse point is
-// inspected rather than replaced-or-followed before we can refuse it.
+// CREATE_NEW (O_EXCL) or OPEN_EXISTING (everything else). There is no
+// CREATE_ALWAYS / OPEN_ALWAYS fallback: those can follow or smash a reparse
+// point before we inspect it. A missing-file race is retried by openExtractFile.
 func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
 	handle, createdNew, err := createNoFollowHandle(path, flags)
 	if err != nil {
@@ -30,15 +30,6 @@ func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error
 			_ = syscall.CloseHandle(handle)
 
 			return nil, &os.PathError{Op: "open", Path: path, Err: err}
-		}
-	}
-
-	if flags&os.O_TRUNC != 0 {
-		err = syscall.SetEndOfFile(handle)
-		if err != nil {
-			_ = syscall.CloseHandle(handle)
-
-			return nil, &os.PathError{Op: "truncate", Path: path, Err: err}
 		}
 	}
 
@@ -65,11 +56,6 @@ func createNoFollowHandle(path string, flags int) (syscall.Handle, bool, error) 
 	}
 
 	handle, err := syscall.CreateFile(pathp, access, share, nil, createmode, attrs, 0)
-	if err != nil && !createdNew && flags&os.O_CREATE != 0 && errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
-		handle, err = syscall.CreateFile(pathp, access, share, nil, syscall.CREATE_NEW, attrs, 0)
-		createdNew = true
-	}
-
 	if err != nil {
 		return syscall.InvalidHandle, false, &os.PathError{Op: "open", Path: path, Err: err}
 	}
@@ -87,6 +73,21 @@ func refuseReparsePoint(handle syscall.Handle) error {
 
 	if info.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
 		return errExtractSymlink
+	}
+
+	return nil
+}
+
+// requireDiskFile rejects Windows devices and pipes (NUL, CON, COM1, named pipes).
+// os.File.Stat on those handles can look like a regular file.
+func requireDiskFile(file *os.File) error {
+	kind, err := syscall.GetFileType(syscall.Handle(file.Fd()))
+	if err != nil {
+		return fmt.Errorf("file type: %w", err)
+	}
+
+	if kind != syscall.FILE_TYPE_DISK {
+		return fmt.Errorf("%w: %s", errExtractNotRegular, file.Name())
 	}
 
 	return nil

--- a/files_windows.go
+++ b/files_windows.go
@@ -3,6 +3,7 @@
 package xtractr
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -18,6 +19,10 @@ const fileFlagOpenReparsePoint = 0x00200000
 // CREATE_NEW (O_EXCL) or OPEN_EXISTING (everything else). There is no
 // CREATE_ALWAYS / OPEN_ALWAYS fallback: those can follow or smash a reparse
 // point before we inspect it. A missing-file race is retried by openExtractFile.
+//
+// FILE_FLAG_BACKUP_SEMANTICS is required to open a directory or directory
+// junction; without it OPEN_EXISTING fails before we can classify a planted
+// reparse point and replace it.
 func openFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
 	handle, createdNew, err := createNoFollowHandle(path, flags)
 	if err != nil {
@@ -45,17 +50,21 @@ func createNoFollowHandle(path string, flags int) (syscall.Handle, bool, error) 
 		return syscall.InvalidHandle, false, fmt.Errorf("path: %w", err)
 	}
 
-	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
 	share := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-	attrs := uint32(syscall.FILE_ATTRIBUTE_NORMAL) | fileFlagOpenReparsePoint
+	attrs := uint32(syscall.FILE_ATTRIBUTE_NORMAL) | fileFlagOpenReparsePoint | syscall.FILE_FLAG_BACKUP_SEMANTICS
 	createdNew := flags&os.O_EXCL != 0
 	createmode := uint32(syscall.OPEN_EXISTING)
+	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
 
 	if createdNew {
 		createmode = syscall.CREATE_NEW
 	}
 
 	handle, err := syscall.CreateFile(pathp, access, share, nil, createmode, attrs, 0)
+	if err != nil && !createdNew && errors.Is(err, syscall.ERROR_ACCESS_DENIED) {
+		handle, err = syscall.CreateFile(pathp, syscall.GENERIC_READ, share, nil, createmode, attrs, 0)
+	}
+
 	if err != nil {
 		return syscall.InvalidHandle, false, &os.PathError{Op: "open", Path: path, Err: err}
 	}
@@ -105,6 +114,10 @@ func refuseReparsePoint(handle syscall.Handle) error {
 	}
 
 	return nil
+}
+
+func isDeniedExclusiveCreate(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 }
 
 // requireDiskFile rejects Windows devices and pipes (NUL, CON, COM1, named pipes).

--- a/files_windows_internal_test.go
+++ b/files_windows_internal_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package xtractr
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenExtractFileRefusesNULDevice(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "NUL")
+
+	_, _, err := openExtractFile(dest, 0o600)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errExtractNotRegular)
+}


### PR DESCRIPTION
## Summary
- Extracted **archive members** (zip, rar, 7z, tar and friends, cpio, ar, iso, udf, gzip/xz/zstd/etc.) already went through `writeFile`. That helper now opens with `openExtractFile` instead of `os.OpenFile`, so a planted final-component symlink, directory junction, FIFO, or Windows device is not written through.
- **CUE/APE** track writers (and CUE-sheet copy / embedded pictures) used raw `OpenFile`/`WriteFile` and skipped that path. They now use the same helper.
- Open is a bounded no-follow create-or-replace loop: exclusive-create first; if the name exists, open it no-follow and truncate only after the fd is a regular disk file; if it is a symlink/reparse point, unlink and retry.
- Windows does not use `CREATE_ALWAYS` / `OPEN_ALWAYS`. Devices and pipes (`NUL`, `CON`, named pipes) are rejected via `GetFileType`; Unix fifos/devices via fstat.
- On `flac.NewEncoder` failure the output file is now removed (previously left truncated). Same cleanup as APE / archive `writeFile`.

Still uses the older `openFile` (follows) only for the cross-device `Rename` copy fallback and the extract log `.txt` from `os.WriteFile`.

## Test plan
- [x] `TestOpenExtractFileReplacesSymlink`
- [x] `TestOpenExtractFileReplacesDirectorySymlink`
- [x] `TestOpenExtractFileRefusesDirectory`
- [x] `TestOpenExtractFileRetriesWhenOpenSeesSymlink`
- [x] `TestOpenFileNoFollowDoesNotFollowSymlink`
- [x] `TestOpenExtractFileTruncatesRegularFile`
- [x] `TestOpenExtractFileRefusesFifo` (Unix)
- [x] `TestOpenExtractFileRefusesNULDevice` (Windows)
- [x] `TestCueExtractCUE_ReplacesTrackSymlink`
- [x] `TestSplitAPETrackReplacesSymlink`
- [x] `TestCopyCueToOutputReplacesSymlink`
- [ ] CI gotest + golangci on this PR

Made with [Cursor](https://cursor.com)