### PR TITLE
Abort extracts that exceed MaxBytes, MaxFiles, or MaxRatio

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -47,7 +47,7 @@ func extract7z(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("%s: os.Open: %w", xFile.FilePath, err)
 	}
 
-	defer xFile.newProgress(getUncompressed7zSize(sevenZip)).done() // this closes sevenZip
+	defer xFile.newArchiveProgress(getUncompressed7zSize(sevenZip)).done() // this closes sevenZip
 
 	sevenZip, err = sevenzip.OpenReaderWithPassword(xFile.FilePath, xFile.Password)
 	if err != nil {

--- a/7z.go
+++ b/7z.go
@@ -30,10 +30,13 @@ func Extract7z(xFile *XFile) (size uint64, filesList, archiveList []string, err 
 		attempt.Password = password
 
 		size, files, archives, err := extract7z(&attempt)
-		if err != nil && idx == len(passwords)-1 {
-			return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)
-		} else if err == nil {
+		switch {
+		case err == nil:
 			return size, files, archives, nil
+		case isLimitError(err):
+			return size, files, archives, err
+		case idx == len(passwords)-1:
+			return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)
 		}
 	}
 
@@ -47,7 +50,7 @@ func extract7z(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("%s: os.Open: %w", xFile.FilePath, err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressed7zSize(sevenZip)).done() // this closes sevenZip
+	defer xFile.newArchiveProgress(getUncompressed7zSize(sevenZip, xFile.FilePath)).done() // this closes sevenZip
 
 	sevenZip, err = sevenzip.OpenReaderWithPassword(xFile.FilePath, xFile.Password)
 	if err != nil {
@@ -80,16 +83,17 @@ func extract7z(xFile *XFile) (uint64, []string, []string, error) {
 	return xFile.prog.Wrote, files, normalizeVolumes(sevenZip.Volumes(), xFile.FilePath), err
 }
 
-func getUncompressed7zSize(reader *sevenzip.ReadCloser) (total, compressed uint64, count int) {
+func getUncompressed7zSize(reader *sevenzip.ReadCloser, filePath string) (total, compressed uint64, count int) {
 	defer reader.Close()
 
 	for _, zipFile := range reader.File {
 		total += zipFile.UncompressedSize
-		// compressed += uint64(zipFile.FileInfo().Size())
 		count++
 	}
 
-	return total, 0, count
+	compressed = archiveFileSizes(normalizeVolumes(reader.Volumes(), filePath)...)
+
+	return total, compressed, count
 }
 
 // sevenZipEntry holds a 7z file entry for the parallel dispatch pass.

--- a/7z.go
+++ b/7z.go
@@ -30,6 +30,8 @@ func Extract7z(xFile *XFile) (size uint64, filesList, archiveList []string, err 
 		attempt.Password = password
 
 		size, files, archives, err := extract7z(&attempt)
+		xFile.prog = attempt.prog
+
 		switch {
 		case err == nil:
 			return size, files, archives, nil
@@ -50,7 +52,12 @@ func extract7z(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("%s: os.Open: %w", xFile.FilePath, err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressed7zSize(sevenZip, xFile.FilePath)).done() // this closes sevenZip
+	tracker, headerErr := xFile.archiveProgress(getUncompressed7zSize(sevenZip, xFile.FilePath))
+	defer tracker.done() // getUncompressed7zSize closed sevenZip
+
+	if headerErr != nil {
+		return 0, nil, nil, headerErr
+	}
 
 	sevenZip, err = sevenzip.OpenReaderWithPassword(xFile.FilePath, xFile.Password)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Can also be used ad-hoc for direct decompression and extraction. See docs.
 -   Splits FLAC+CUE sheets into individual tracks.
 -   Detects non-UTF8 zip filenames automatically.
 
+Optional extraction caps on `XFile`, `Xtract`, and `Config` (`0` means unlimited):
+
+-   `MaxBytes` — uncompressed bytes written for one archive
+-   `MaxFiles` — files, directories, and symlinks created for one archive
+-   `MaxRatio` — `bytesWritten / archiveFileSize`
+
+Exceeding a cap returns `ErrMaxBytes`, `ErrMaxFiles`, or `ErrMaxRatio` and stops the extract. Queue jobs inherit `Config` values when the `Xtract` field is `0`.
+
 # Interface
 
 This library provides a queue, and a common interface to extract files.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Optional extraction caps on `XFile`, `Xtract`, and `Config` (`0` means unlimited
 
 Exceeding a cap returns `ErrMaxBytes`, `ErrMaxFiles`, or `ErrMaxRatio` and stops the extract. Queue jobs inherit `Config` values when the `Xtract` field is `0`.
 
+`MaxFiles` counts claimed-plus-created entries, not just created. An archive whose header claims more entries than `MaxFiles` fails fast with `ErrMaxFiles` even when every entry already exists on disk and nothing new would be created. This fail-closed default is intentional for a security cap: headers can understate, so the runtime write path always re-checks regardless of what the header claimed.
+
 # Interface
 
 This library provides a queue, and a common interface to extract files.

--- a/ape.go
+++ b/ape.go
@@ -481,8 +481,6 @@ func splitAPE(
 		return 0, nil, fmt.Errorf("creating output directory: %w", err)
 	}
 
-	defer xFile.newProgress(0, archiveFileSize(audioPath), len(cue.Tracks)).done()
-
 	srcFile, err := os.Open(audioPath)
 	if err != nil {
 		return 0, nil, fmt.Errorf("opening ape file for splitting: %w", err)
@@ -652,17 +650,17 @@ func writeTrackAPEContents(
 		return 0, err
 	}
 
-	err = binary.Write(outFile, binary.LittleEndian, &con.descriptor)
+	err = binary.Write(counted, binary.LittleEndian, &con.descriptor)
 	if err != nil {
 		return 0, fmt.Errorf("writing ape descriptor: %w", err)
 	}
 
-	_, err = outFile.Write(con.headerBytes)
+	_, err = counted.Write(con.headerBytes)
 	if err != nil {
 		return 0, fmt.Errorf("writing ape header: %w", err)
 	}
 
-	_, err = outFile.Write(con.seekTableBytes)
+	_, err = counted.Write(con.seekTableBytes)
 	if err != nil {
 		return 0, fmt.Errorf("writing ape seek table: %w", err)
 	}

--- a/ape.go
+++ b/ape.go
@@ -481,7 +481,7 @@ func splitAPE(
 		return 0, nil, fmt.Errorf("creating output directory: %w", err)
 	}
 
-	defer xFile.newProgress(0, 0, len(cue.Tracks)).done()
+	defer xFile.newProgress(0, archiveFileSize(audioPath), len(cue.Tracks)).done()
 
 	srcFile, err := os.Open(audioPath)
 	if err != nil {
@@ -501,7 +501,7 @@ func splitAPE(
 		outputName := formatTrackFilename(track, ".ape")
 		outputPath := filepath.Join(xFile.OutputDir, outputName)
 
-		size, usedPath, writeErr := writeTrackAPE(outputPath, info, srcFile, fr.start, fr.end, xFile.FileMode)
+		size, usedPath, writeErr := writeTrackAPE(xFile, outputPath, info, srcFile, fr.start, fr.end, xFile.FileMode)
 		if writeErr != nil {
 			return totalSize, files, fmt.Errorf("writing ape track %d: %w", track.Number, writeErr)
 		}
@@ -519,6 +519,7 @@ func splitAPE(
 // from the source file. Compressed frame data is copied verbatim. On error the partial
 // output file is removed so a failed split never leaves a half-written track behind.
 func writeTrackAPE(
+	xFile *XFile,
 	outputPath string,
 	info *apeInfo,
 	srcFile *os.File,
@@ -530,7 +531,15 @@ func writeTrackAPE(
 		return 0, "", fmt.Errorf("creating output ape file: %w", err)
 	}
 
-	size, err := writeTrackAPEContents(outFile, info, srcFile, startFrame, endFrame)
+	counted, err := xFile.extractWriter(outFile)
+	if err != nil {
+		_ = outFile.Close()
+		_ = os.Remove(usedPath)
+
+		return 0, usedPath, err
+	}
+
+	size, err := writeTrackAPEContents(outFile, counted, info, srcFile, startFrame, endFrame)
 
 	closeErr := outFile.Close()
 	if err == nil && closeErr != nil {
@@ -633,6 +642,7 @@ func buildAPETrackContainer(info *apeInfo, startFrame, endFrame int) (*apeTrackC
 // is computed and patched into the descriptor so the output passes full MAC verification.
 func writeTrackAPEContents(
 	outFile *os.File,
+	counted io.Writer,
 	info *apeInfo,
 	srcFile *os.File,
 	startFrame, endFrame int,
@@ -659,7 +669,7 @@ func writeTrackAPEContents(
 
 	// Tee the frame data into the MD5 as it's written so we never buffer a whole track.
 	hash := md5.New() //nolint:gosec // MD5 is the APE file integrity hash, not security.
-	dst := io.MultiWriter(outFile, hash)
+	dst := io.MultiWriter(counted, hash)
 
 	err = writeAPEFrameData(dst, srcFile, info, startFrame, endFrame, con.trackDataSize)
 	if err != nil {

--- a/ar.go
+++ b/ar.go
@@ -16,7 +16,12 @@ func ExtractAr(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressedArSize(arFile)).done() // this closes arFile
+	tracker, headerErr := xFile.archiveProgress(getUncompressedArSize(arFile))
+	defer tracker.done() // getUncompressedArSize closed arFile
+
+	if headerErr != nil {
+		return 0, nil, headerErr
+	}
 
 	arFile, err = os.Open(xFile.FilePath)
 	if err != nil {

--- a/ar.go
+++ b/ar.go
@@ -13,7 +13,7 @@ import (
 func ExtractAr(xFile *XFile) (size uint64, filesList []string, err error) {
 	arFile, err := os.Open(xFile.FilePath)
 	if err != nil {
-		return 0, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
+		return 0, nil, fmt.Errorf("os.Open: %w", err)
 	}
 
 	tracker, headerErr := xFile.archiveProgress(getUncompressedArSize(arFile))

--- a/ar.go
+++ b/ar.go
@@ -16,7 +16,7 @@ func ExtractAr(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 
-	defer xFile.newProgress(getUncompressedArSize(arFile)).done() // this closes arFile
+	defer xFile.newArchiveProgress(getUncompressedArSize(arFile)).done() // this closes arFile
 
 	arFile, err = os.Open(xFile.FilePath)
 	if err != nil {

--- a/cue.go
+++ b/cue.go
@@ -710,7 +710,7 @@ func (s *trackSplitter) openEncoder(idx int) (*trackEncoder, error) {
 		return nil, fmt.Errorf("creating output file for track %d: %w", track.Number, err)
 	}
 
-	enc, err := flac.NewEncoder(outFile, trackInfo, blocks...)
+	enc, err := flac.NewEncoder(s.xFile.countedWriteSeeker(outFile), trackInfo, blocks...)
 	if err != nil {
 		_ = outFile.Close()
 		_ = os.Remove(usedPath)
@@ -814,14 +814,6 @@ func (s *trackSplitter) finalize(encoder *trackEncoder) error {
 	}
 
 	size := uint64(stat.Size())
-
-	err = s.xFile.accountBytes(size)
-	if err != nil {
-		_ = os.Remove(encoder.outputPath)
-
-		return err
-	}
-
 	s.totalSize += size
 
 	s.xFile.Debugf("Wrote track %d: %s (%d bytes)", encoder.number, encoder.outputPath, size)

--- a/cue.go
+++ b/cue.go
@@ -562,7 +562,7 @@ type trackEncoder struct {
 }
 
 // minFLACBlockSize is the smallest block size (in samples) the FLAC format allows
-// for any frame except the final frame of a stream (RFC 9639, section 9.1).
+// for any frame except the final frame of a stream (RFC 9639, section 4.1).
 // maxFLACBlockSize is the largest block size a FLAC frame can hold.
 const (
 	minFLACBlockSize = 16
@@ -891,9 +891,20 @@ func clipFrame(src *frame.Frame, offset, count int, prefix *frame.Frame) *frame.
 }
 
 // flushHeld writes the buffered frame, if any. Called when a track ends.
+// A track shorter than the FLAC minimum block size has nothing to balance
+// against, so the encoder would record a STREAMINFO minimum block size below
+// 16 and strict parsers would reject the file. Refuse instead of writing a
+// corrupt track.
 func (e *trackEncoder) flushHeld() error {
 	if e.held == nil {
 		return nil
+	}
+
+	if e.held.Subframes[0].NSamples < minFLACBlockSize {
+		samples := e.held.Subframes[0].NSamples
+		e.held = nil
+
+		return fmt.Errorf("%w (%d samples)", ErrTrackTooShort, samples)
 	}
 
 	err := e.enc.WriteFrame(e.held)

--- a/cue.go
+++ b/cue.go
@@ -773,7 +773,7 @@ func (s *trackSplitter) writeFrame(parsed *frame.Frame, frameStart, frameEnd uin
 
 // writeClip builds an output frame from a clip of the source frame and writes it to
 // the track. One frame is held back so a clip smaller than the FLAC minimum block
-// size fuses with its neighbor instead of becoming a spec-invalid tiny frame: a CUE
+// size merges with its neighbor instead of becoming a spec-invalid tiny frame: a CUE
 // boundary that falls near a source frame's edge otherwise produces a track whose
 // first or last clip is under 16 samples, and the encoder records the smallest
 // written frame as STREAMINFO's minimum block size, which strict parsers reject.
@@ -785,37 +785,56 @@ func (e *trackEncoder) writeClip(src *frame.Frame, offset, count int) error {
 		return nil
 	}
 
-	if fused, ok := fuseFrames(e.held, newFrame); ok {
-		e.held = fused
-		return nil
+	write, hold := balanceFrames(e.held, newFrame)
+	e.held = hold
+
+	if write == nil {
+		return nil // the clips were concatenated into the held frame
 	}
 
-	err := e.enc.WriteFrame(e.held)
+	err := e.enc.WriteFrame(write)
 	if err != nil {
 		return fmt.Errorf("encoding flac frame: %w", err)
 	}
 
-	e.held = newFrame
-
 	return nil
 }
 
-// fuseFrames concatenates two adjacent output frames when at least one is smaller
-// than the minimum block size the FLAC format allows for a non-final frame, and the
-// combined frame still fits in a FLAC frame. It reports whether fusion happened.
-func fuseFrames(held, next *frame.Frame) (*frame.Frame, bool) {
+// balanceFrames returns the frame to write now and the frame to hold for the next
+// clip, sized so neither is smaller than the FLAC minimum block size. When the two
+// fit in one frame it concatenates them (write is nil); otherwise it moves the
+// smallest possible tail of the larger frame onto the smaller one. Total samples
+// and their order are always preserved.
+func balanceFrames(held, next *frame.Frame) (write, hold *frame.Frame) {
 	heldSamples := held.Subframes[0].NSamples
 	nextSamples := next.Subframes[0].NSamples
-
-	if heldSamples >= minFLACBlockSize && nextSamples >= minFLACBlockSize {
-		return nil, false
-	}
-
 	combined := heldSamples + nextSamples
-	if combined > maxFLACBlockSize {
-		return nil, false
-	}
 
+	switch {
+	case heldSamples >= minFLACBlockSize && nextSamples >= minFLACBlockSize:
+		// Both already valid; write the earlier frame and hold the later one.
+		return held, next
+	case combined <= maxFLACBlockSize:
+		// Fits in one frame; write nothing and hold the concatenation.
+		return nil, concatFrames(held, next)
+	default:
+		// Too large to concatenate. Move the tail of the larger frame onto the
+		// smaller one so both meet the minimum block size.
+		move := minFLACBlockSize - min(heldSamples, nextSamples)
+
+		if heldSamples >= nextSamples {
+			// held is larger: shrink held by its tail, prepend that tail to next.
+			return clipFrame(held, 0, heldSamples-move, nil), clipFrame(next, 0, nextSamples, tailFrame(held, move))
+		}
+
+		// next is larger: shrink next by its tail, append held before next's head.
+		return concatFrames(held, clipFrame(next, 0, move, nil)), clipFrame(next, move, nextSamples-move, nil)
+	}
+}
+
+// concatFrames returns one frame holding held's samples followed by next's.
+func concatFrames(held, next *frame.Frame) *frame.Frame {
+	combined := held.Subframes[0].NSamples + next.Subframes[0].NSamples
 	merged := &frame.Frame{Header: held.Header}
 	merged.BlockSize = uint16(combined)
 	merged.Subframes = make([]*frame.Subframe, len(held.Subframes))
@@ -832,7 +851,43 @@ func fuseFrames(held, next *frame.Frame) (*frame.Frame, bool) {
 		}
 	}
 
-	return merged, true
+	return merged
+}
+
+// tailFrame returns a frame holding the last count samples of src.
+func tailFrame(src *frame.Frame, count int) *frame.Frame {
+	return clipFrame(src, src.Subframes[0].NSamples-count, count, nil)
+}
+
+// clipFrame returns a frame of count samples starting at offset. When prefix is
+// non-nil, that many samples from the end of prefix are prepended first (used to
+// move an earlier frame's tail onto the start of the next frame).
+func clipFrame(src *frame.Frame, offset, count int, prefix *frame.Frame) *frame.Frame {
+	total := count
+	if prefix != nil {
+		total += prefix.Subframes[0].NSamples
+	}
+
+	out := &frame.Frame{Header: src.Header}
+	out.BlockSize = uint16(total)
+	out.Subframes = make([]*frame.Subframe, len(src.Subframes))
+
+	for channel := range src.Subframes {
+		var samples []int32
+		if prefix != nil {
+			samples = append(samples, prefix.Subframes[channel].Samples...)
+		}
+
+		samples = append(samples, src.Subframes[channel].Samples[offset:offset+count]...)
+
+		out.Subframes[channel] = &frame.Subframe{
+			SubHeader: src.Subframes[channel].SubHeader,
+			Samples:   samples,
+			NSamples:  total,
+		}
+	}
+
+	return out
 }
 
 // flushHeld writes the buffered frame, if any. Called when a track ends.
@@ -894,6 +949,9 @@ func (s *trackSplitter) finishAll() error {
 func (s *trackSplitter) finalize(encoder *trackEncoder) error {
 	err := encoder.flushHeld()
 	if err != nil {
+		// The encoder is removed from s.open by the caller, so closeOpen cannot
+		// reach it; close it here to avoid leaking the output descriptor.
+		_ = encoder.enc.Close()
 		return fmt.Errorf("writing final frame to track %d (%s): %w", encoder.number, encoder.outputPath, err)
 	}
 

--- a/cue.go
+++ b/cue.go
@@ -554,11 +554,20 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 // trackEncoder holds an open encoder for a single output track during streaming.
 type trackEncoder struct {
 	enc        *flac.Encoder
+	held       *frame.Frame // last built frame, not yet written (see writeClip)
 	outputPath string
 	number     int
 	start      uint64
 	end        uint64
 }
+
+// minFLACBlockSize is the smallest block size (in samples) the FLAC format allows
+// for any frame except the final frame of a stream (RFC 9639, section 9.1).
+// maxFLACBlockSize is the largest block size a FLAC frame can hold.
+const (
+	minFLACBlockSize = 16
+	maxFLACBlockSize = 65535
+)
 
 // trackSplitter streams source FLAC frames into per-track encoders. It opens a track
 // encoder only when the stream reaches that track and closes it as soon as the stream
@@ -753,10 +762,90 @@ func (s *trackSplitter) writeFrame(parsed *frame.Frame, frameStart, frameEnd uin
 			continue
 		}
 
-		err := encoder.enc.WriteFrame(buildOutputFrame(parsed, offsetInFrame, samplesToTake))
+		err := encoder.writeClip(parsed, offsetInFrame, samplesToTake)
 		if err != nil {
 			return fmt.Errorf("writing frame to track %d (%s): %w", encoder.number, encoder.outputPath, err)
 		}
+	}
+
+	return nil
+}
+
+// writeClip builds an output frame from a clip of the source frame and writes it to
+// the track. One frame is held back so a clip smaller than the FLAC minimum block
+// size fuses with its neighbor instead of becoming a spec-invalid tiny frame: a CUE
+// boundary that falls near a source frame's edge otherwise produces a track whose
+// first or last clip is under 16 samples, and the encoder records the smallest
+// written frame as STREAMINFO's minimum block size, which strict parsers reject.
+func (e *trackEncoder) writeClip(src *frame.Frame, offset, count int) error {
+	newFrame := buildOutputFrame(src, offset, count)
+
+	if e.held == nil {
+		e.held = newFrame
+		return nil
+	}
+
+	if fused, ok := fuseFrames(e.held, newFrame); ok {
+		e.held = fused
+		return nil
+	}
+
+	err := e.enc.WriteFrame(e.held)
+	if err != nil {
+		return fmt.Errorf("encoding flac frame: %w", err)
+	}
+
+	e.held = newFrame
+
+	return nil
+}
+
+// fuseFrames concatenates two adjacent output frames when at least one is smaller
+// than the minimum block size the FLAC format allows for a non-final frame, and the
+// combined frame still fits in a FLAC frame. It reports whether fusion happened.
+func fuseFrames(held, next *frame.Frame) (*frame.Frame, bool) {
+	heldSamples := held.Subframes[0].NSamples
+	nextSamples := next.Subframes[0].NSamples
+
+	if heldSamples >= minFLACBlockSize && nextSamples >= minFLACBlockSize {
+		return nil, false
+	}
+
+	combined := heldSamples + nextSamples
+	if combined > maxFLACBlockSize {
+		return nil, false
+	}
+
+	merged := &frame.Frame{Header: held.Header}
+	merged.BlockSize = uint16(combined)
+	merged.Subframes = make([]*frame.Subframe, len(held.Subframes))
+
+	for channel := range held.Subframes {
+		samples := make([]int32, 0, combined)
+		samples = append(samples, held.Subframes[channel].Samples...)
+		samples = append(samples, next.Subframes[channel].Samples...)
+
+		merged.Subframes[channel] = &frame.Subframe{
+			SubHeader: held.Subframes[channel].SubHeader,
+			Samples:   samples,
+			NSamples:  combined,
+		}
+	}
+
+	return merged, true
+}
+
+// flushHeld writes the buffered frame, if any. Called when a track ends.
+func (e *trackEncoder) flushHeld() error {
+	if e.held == nil {
+		return nil
+	}
+
+	err := e.enc.WriteFrame(e.held)
+	e.held = nil
+
+	if err != nil {
+		return fmt.Errorf("encoding flac frame: %w", err)
 	}
 
 	return nil
@@ -803,7 +892,12 @@ func (s *trackSplitter) finishAll() error {
 
 // finalize closes a track encoder (flushing the FLAC stream) and records its size.
 func (s *trackSplitter) finalize(encoder *trackEncoder) error {
-	err := encoder.enc.Close()
+	err := encoder.flushHeld()
+	if err != nil {
+		return fmt.Errorf("writing final frame to track %d (%s): %w", encoder.number, encoder.outputPath, err)
+	}
+
+	err = encoder.enc.Close()
 	if err != nil {
 		return fmt.Errorf("closing track %d encoder (%s): %w", encoder.number, encoder.outputPath, err)
 	}

--- a/cue.go
+++ b/cue.go
@@ -626,7 +626,12 @@ func streamTracksFLAC(
 
 	err = splitter.run(stream)
 	if err != nil {
-		return splitter.totalSize, splitter.files, err
+		// Close before unlink so Windows can remove the files; ExtractCUE
+		// discards the file list on error, so leftovers would otherwise stay.
+		splitter.closeOpen()
+		splitter.removeFiles()
+
+		return 0, nil, err
 	}
 
 	return splitter.totalSize, splitter.files, nil
@@ -963,11 +968,15 @@ func (s *trackSplitter) finalize(encoder *trackEncoder) error {
 		// The encoder is removed from s.open by the caller, so closeOpen cannot
 		// reach it; close it here to avoid leaking the output descriptor.
 		_ = encoder.enc.Close()
+		_ = os.Remove(encoder.outputPath)
+
 		return fmt.Errorf("writing final frame to track %d (%s): %w", encoder.number, encoder.outputPath, err)
 	}
 
 	err = encoder.enc.Close()
 	if err != nil {
+		_ = os.Remove(encoder.outputPath)
+
 		return fmt.Errorf("closing track %d encoder (%s): %w", encoder.number, encoder.outputPath, err)
 	}
 
@@ -993,6 +1002,12 @@ func (s *trackSplitter) closeOpen() {
 	}
 
 	s.open = nil
+}
+
+func (s *trackSplitter) removeFiles() {
+	for _, path := range s.files {
+		_ = os.Remove(path)
+	}
 }
 
 // flacMetadata holds metadata read from a FLAC file for use when splitting by CUE.

--- a/cue.go
+++ b/cue.go
@@ -89,6 +89,8 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 		return 0, nil, nil, err
 	}
 
+	defer xFile.newProgress(0, archiveFileSize(audioPath), len(cue.Tracks)).done()
+
 	ext := strings.ToLower(filepath.Ext(audioPath))
 
 	switch ext {
@@ -115,19 +117,36 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 		return 0, nil, nil, fmt.Errorf("%s: %w: %s", xFile.FilePath, ErrInvalidPath, cueDest)
 	}
 
-	writeErr := copyCueToOutput(xFile.FilePath, cueDest, xFile.FileMode)
-	if writeErr != nil {
-		xFile.Debugf("Copying CUE sheet to output: %s", writeErr)
-	} else {
-		files = append(files, cueDest)
-		// Mark so recursion does not try to extract this copied CUE again.
-		xFile.SkipOnRecursion = append(xFile.SkipOnRecursion, cueDest)
+	files, err = copyCueSheetToOutput(xFile, cueDest, files)
+	if err != nil {
+		return size, files, nil, err
 	}
 
 	// The archive list includes both the CUE file and the FLAC file.
 	archives = []string{xFile.FilePath, audioPath}
 
 	return size, files, archives, nil
+}
+
+// copyCueSheetToOutput writes the source CUE into the extract folder. Limit
+// errors abort the extract; other copy failures are logged and ignored.
+func copyCueSheetToOutput(xFile *XFile, cueDest string, files []string) ([]string, error) {
+	writeErr := copyCueToOutput(xFile, xFile.FilePath, cueDest, xFile.FileMode)
+	if isLimitError(writeErr) {
+		return files, writeErr
+	}
+
+	if writeErr != nil {
+		xFile.Debugf("Copying CUE sheet to output: %s", writeErr)
+
+		return files, nil
+	}
+
+	files = append(files, cueDest)
+	// Mark so recursion does not try to extract this copied CUE again.
+	xFile.SkipOnRecursion = append(xFile.SkipOnRecursion, cueDest)
+
+	return files, nil
 }
 
 // parseCueSheetFile parses a CUE sheet from a file path and returns the sheet plus raw timestamps.
@@ -506,8 +525,11 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 	)
 
 	if len(pictures) > 0 {
-		picturePaths, pictureBytes, err = writePicturesToFiles(xFile.OutputDir, pictures, xFile.FileMode)
-		if err != nil {
+		picturePaths, pictureBytes, err = writePicturesToFiles(xFile, xFile.OutputDir, pictures, xFile.FileMode)
+		switch {
+		case isLimitError(err):
+			return 0, nil, err
+		case err != nil:
 			xFile.Debugf("Error writing album art files: %s", err)
 		}
 
@@ -515,8 +537,6 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 			xFile.Debugf("Wrote album art: %s", p)
 		}
 	}
-
-	defer xFile.newProgress(0, 0, len(cue.Tracks)).done()
 
 	// Stream frames one at a time, writing each to the appropriate track encoder.
 	totalSize, files, err := streamTracksFLAC(xFile, audioPath, cue, trackStarts, trackEnds, streamInfo, flacMeta)
@@ -698,6 +718,14 @@ func (s *trackSplitter) openEncoder(idx int) (*trackEncoder, error) {
 		return nil, fmt.Errorf("creating encoder for track %d: %w", track.Number, err)
 	}
 
+	err = s.xFile.countExtracted()
+	if err != nil {
+		_ = enc.Close()
+		_ = os.Remove(usedPath)
+
+		return nil, err
+	}
+
 	return &trackEncoder{
 		enc:        enc,
 		outputPath: usedPath,
@@ -786,6 +814,14 @@ func (s *trackSplitter) finalize(encoder *trackEncoder) error {
 	}
 
 	size := uint64(stat.Size())
+
+	err = s.xFile.accountBytes(size)
+	if err != nil {
+		_ = os.Remove(encoder.outputPath)
+
+		return err
+	}
+
 	s.totalSize += size
 
 	s.xFile.Debugf("Wrote track %d: %s (%d bytes)", encoder.number, encoder.outputPath, size)
@@ -974,7 +1010,12 @@ func pictureTypeNames() map[uint32]string {
 // writePicturesToFiles writes all picture blocks to files in outputDir. Front cover
 // (type 3) is named cover.<ext>; others use the picture type (e.g. cover_back.png).
 // Returns written paths, total bytes written, and any error from the first failed write.
-func writePicturesToFiles(outputDir string, pictures []*meta.Picture, fileMode os.FileMode) ([]string, uint64, error) {
+func writePicturesToFiles(
+	xFile *XFile,
+	outputDir string,
+	pictures []*meta.Picture,
+	fileMode os.FileMode,
+) ([]string, uint64, error) {
 	typeCount := make(map[string]int)
 	paths := make([]string, 0, len(pictures))
 	totalBytes := uint64(0)
@@ -1004,7 +1045,7 @@ func writePicturesToFiles(outputDir string, pictures []*meta.Picture, fileMode o
 		name += "." + ext
 		path := filepath.Join(outputDir, name)
 
-		err := writeExtractFile(path, pic.Data, fileMode)
+		err := xFile.writeExtractFile(path, pic.Data, fileMode)
 		if err != nil {
 			return paths, totalBytes, fmt.Errorf("writing %s: %w", name, err)
 		}
@@ -1018,13 +1059,13 @@ func writePicturesToFiles(outputDir string, pictures []*meta.Picture, fileMode o
 
 // copyCueToOutput copies the CUE sheet file into the output directory so the
 // extracted folder contains tracks, album art, and the CUE for verification/archival.
-func copyCueToOutput(srcPath, destPath string, fileMode os.FileMode) error {
+func copyCueToOutput(xFile *XFile, srcPath, destPath string, fileMode os.FileMode) error {
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
 		return fmt.Errorf("reading cue sheet: %w", err)
 	}
 
-	err = writeExtractFile(destPath, data, fileMode)
+	err = xFile.writeExtractFile(destPath, data, fileMode)
 	if err != nil {
 		return fmt.Errorf("writing cue sheet: %w", err)
 	}

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -254,6 +254,10 @@ func TestStreamTracksFLACSubMinimumTrack(t *testing.T) {
 
 	_, _, err = streamTracksFLAC(xFile, flacPath, cue, trackStarts, trackEnds, info, &flacMetadata{Info: info})
 	require.ErrorIs(t, err, ErrTrackTooShort)
+	require.NoFileExists(t, filepath.Join(tmpDir, "01 - Track 1.flac"),
+		"failed track must be removed")
+	require.NoFileExists(t, filepath.Join(tmpDir, "02 - Track 2.flac"),
+		"sibling tracks opened in the same frame must be removed on error")
 }
 
 // TestBalanceFrames covers the frame-pair sizing rules: both-valid pairs pass

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -124,10 +124,15 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 
 	for written := 0; written < totalSamples; written += blockSize {
 		subframes := make([]*frame.Subframe, 2)
-		for ch := range subframes {
-			subframes[ch] = &frame.Subframe{
+		for channel := range subframes {
+			samples := make([]int32, blockSize)
+			for i := range samples {
+				samples[i] = int32(written + i)
+			}
+
+			subframes[channel] = &frame.Subframe{
 				SubHeader: frame.SubHeader{Pred: frame.PredVerbatim},
-				Samples:   make([]int32, blockSize),
+				Samples:   samples,
 				NSamples:  blockSize,
 			}
 		}
@@ -148,8 +153,8 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 
 	// Track 1 ends 8 samples into a source frame; track 3 starts 8 samples
 	// before a source frame ends. Both edges produce an 8-sample clip.
-	trackStarts := []uint64{0, 4104, 12280}
-	trackEnds := []uint64{4104, 12280, totalSamples}
+	trackStarts := []uint64{0, blockSize + 8, 3*blockSize - 8}
+	trackEnds := []uint64{blockSize + 8, 3*blockSize - 8, totalSamples}
 	cue := &CueSheet{Tracks: []CueTrack{{Number: 1}, {Number: 2}, {Number: 3}}}
 	xFile := &XFile{OutputDir: tmpDir, FileMode: 0o600}
 
@@ -157,7 +162,7 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, files, 3)
 
-	expected := []uint64{4104, 12280 - 4104, totalSamples - 12280}
+	expected := []uint64{blockSize + 8, 2*blockSize - 16, 2*blockSize + 8}
 
 	for idx, path := range files {
 		trackFile, err := os.Open(path)
@@ -166,6 +171,11 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 		stream, err := flac.New(trackFile)
 		require.NoError(t, err, "track %d STREAMINFO must parse", idx+1)
 		assert.Equal(t, expected[idx], stream.Info.NSamples, "track %d sample count", idx+1)
+
+		// The source sample value equals its absolute position, so each track must
+		// decode to a contiguous run starting at its track start sample. This catches
+		// a fusion/redistribution that drops, duplicates, or reorders samples.
+		position := trackStarts[idx]
 
 		for frameIdx := 0; ; frameIdx++ {
 			frm, err := stream.ParseNext()
@@ -177,8 +187,75 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 			assert.False(t, frm.HasFixedBlockSize, "track %d frame %d", idx+1, frameIdx)
 			assert.GreaterOrEqual(t, frm.Subframes[0].NSamples, minFLACBlockSize,
 				"track %d frame %d below minimum block size", idx+1, frameIdx)
+
+			for _, sample := range frm.Subframes[0].Samples {
+				require.Equal(t, int32(position), sample,
+					"track %d frame %d sample out of sequence", idx+1, frameIdx)
+				position++
+			}
 		}
 
+		assert.Equal(t, trackEnds[idx], position, "track %d decoded sample count", idx+1)
 		require.NoError(t, trackFile.Close())
 	}
+}
+
+// TestBalanceFrames covers the frame-pair sizing rules: both-valid pairs pass
+// through, small pairs concatenate, and a tiny clip next to a maximum-size frame
+// redistributes samples so neither output frame is below the minimum block size.
+func TestBalanceFrames(t *testing.T) {
+	t.Parallel()
+
+	mkFrame := func(samples int) *frame.Frame {
+		subs := make([]*frame.Subframe, 2)
+		for channel := range subs {
+			subs[channel] = &frame.Subframe{
+				SubHeader: frame.SubHeader{Pred: frame.PredVerbatim},
+				Samples:   make([]int32, samples),
+				NSamples:  samples,
+			}
+		}
+
+		header := frame.Header{
+			BlockSize:     uint16(samples),
+			SampleRate:    44100,
+			Channels:      frame.ChannelsLR,
+			BitsPerSample: 16,
+		}
+
+		return &frame.Frame{Header: header, Subframes: subs}
+	}
+
+	// Both frames already valid: write held, hold next, unchanged.
+	write, hold := balanceFrames(mkFrame(4096), mkFrame(4096))
+	require.NotNil(t, write)
+	require.NotNil(t, hold)
+	assert.Equal(t, 4096, write.Subframes[0].NSamples)
+	assert.Equal(t, 4096, hold.Subframes[0].NSamples)
+
+	// Small pair: concatenate into the held frame, nothing to write yet.
+	write, hold = balanceFrames(mkFrame(8), mkFrame(4096))
+	assert.Nil(t, write)
+	require.NotNil(t, hold)
+	assert.Equal(t, 8+4096, hold.Subframes[0].NSamples)
+
+	// Tiny clip before a maximum-size frame: too large to concatenate, so move
+	// samples from the tiny clip onto the next frame; both meet the minimum.
+	write, hold = balanceFrames(mkFrame(8), mkFrame(maxFLACBlockSize))
+	require.NotNil(t, write)
+	require.NotNil(t, hold)
+	assert.Equal(t, minFLACBlockSize, write.Subframes[0].NSamples)
+	assert.Equal(t, maxFLACBlockSize-8, hold.Subframes[0].NSamples)
+	assert.Equal(t, 8+maxFLACBlockSize, write.Subframes[0].NSamples+hold.Subframes[0].NSamples,
+		"total samples must be preserved")
+
+	// Tiny clip after a maximum-size frame: move the tail of the large frame
+	// forward so both meet the minimum.
+	write, hold = balanceFrames(mkFrame(maxFLACBlockSize), mkFrame(8))
+	require.NotNil(t, write)
+	require.NotNil(t, hold)
+	assert.Equal(t, maxFLACBlockSize-8, write.Subframes[0].NSamples)
+	assert.Equal(t, minFLACBlockSize, hold.Subframes[0].NSamples)
+	assert.Equal(t, maxFLACBlockSize+8, write.Subframes[0].NSamples+hold.Subframes[0].NSamples,
+		"total samples must be preserved")
 }

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -200,6 +200,62 @@ func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
 	}
 }
 
+// A CUE track shorter than the FLAC minimum block size cannot be encoded
+// without producing a spec-invalid STREAMINFO; the splitter must refuse it
+// with ErrTrackTooShort instead of writing a corrupt file.
+func TestStreamTracksFLACSubMinimumTrack(t *testing.T) {
+	t.Parallel()
+
+	const blockSize = 4096
+
+	tmpDir := t.TempDir()
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	info := &meta.StreamInfo{
+		BlockSizeMin:  blockSize,
+		BlockSizeMax:  blockSize,
+		SampleRate:    44100,
+		NChannels:     2,
+		BitsPerSample: 16,
+		NSamples:      blockSize,
+	}
+
+	outFile, err := os.Create(flacPath)
+	require.NoError(t, err)
+
+	enc, err := flac.NewEncoder(outFile, info)
+	require.NoError(t, err)
+
+	subframes := make([]*frame.Subframe, 2)
+	for channel := range subframes {
+		subframes[channel] = &frame.Subframe{
+			SubHeader: frame.SubHeader{Pred: frame.PredVerbatim},
+			Samples:   make([]int32, blockSize),
+			NSamples:  blockSize,
+		}
+	}
+
+	require.NoError(t, enc.WriteFrame(&frame.Frame{
+		Header: frame.Header{
+			HasFixedBlockSize: true,
+			BlockSize:         blockSize,
+			SampleRate:        44100,
+			Channels:          frame.ChannelsLR,
+			BitsPerSample:     16,
+		},
+		Subframes: subframes,
+	}))
+	require.NoError(t, enc.Close())
+
+	// Track 1 is 8 samples long; track 2 is the rest. Track 1 is degenerate.
+	trackStarts := []uint64{0, 8}
+	trackEnds := []uint64{8, blockSize}
+	cue := &CueSheet{Tracks: []CueTrack{{Number: 1}, {Number: 2}}}
+	xFile := &XFile{OutputDir: tmpDir, FileMode: 0o600}
+
+	_, _, err = streamTracksFLAC(xFile, flacPath, cue, trackStarts, trackEnds, info, &flacMetadata{Info: info})
+	require.ErrorIs(t, err, ErrTrackTooShort)
+}
+
 // TestBalanceFrames covers the frame-pair sizing rules: both-valid pairs pass
 // through, small pairs concatenate, and a tiny clip next to a maximum-size frame
 // redistributes samples so neither output frame is below the minimum block size.

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -1,10 +1,15 @@
 package xtractr
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/mewkiz/flac"
+	"github.com/mewkiz/flac/frame"
+	"github.com/mewkiz/flac/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,4 +89,96 @@ func TestCopyCueToOutputReplacesSymlink(t *testing.T) {
 	info, err := os.Lstat(dest)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
+// TestStreamTracksFLACTinyBoundaryClips splits a fixed-blocksize FLAC at sample
+// positions that land 8 samples into and 8 samples before the end of a source
+// frame. Those boundary clips are smaller than the minimum block size the FLAC
+// format allows for a non-final frame (16 samples), so they must fuse with the
+// neighboring frame; written as-is, the encoder records a STREAMINFO minimum
+// block size of 8 and strict parsers (including go-flac itself) reject the track.
+func TestStreamTracksFLACTinyBoundaryClips(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockSize    = 4096
+		totalSamples = 5 * blockSize
+	)
+
+	tmpDir := t.TempDir()
+	flacPath := filepath.Join(tmpDir, "album.flac")
+	info := &meta.StreamInfo{
+		BlockSizeMin:  blockSize,
+		BlockSizeMax:  blockSize,
+		SampleRate:    44100,
+		NChannels:     2,
+		BitsPerSample: 16,
+		NSamples:      totalSamples,
+	}
+
+	outFile, err := os.Create(flacPath)
+	require.NoError(t, err)
+
+	enc, err := flac.NewEncoder(outFile, info)
+	require.NoError(t, err)
+
+	for written := 0; written < totalSamples; written += blockSize {
+		subframes := make([]*frame.Subframe, 2)
+		for ch := range subframes {
+			subframes[ch] = &frame.Subframe{
+				SubHeader: frame.SubHeader{Pred: frame.PredVerbatim},
+				Samples:   make([]int32, blockSize),
+				NSamples:  blockSize,
+			}
+		}
+
+		require.NoError(t, enc.WriteFrame(&frame.Frame{
+			Header: frame.Header{
+				HasFixedBlockSize: true,
+				BlockSize:         blockSize,
+				SampleRate:        44100,
+				Channels:          frame.ChannelsLR,
+				BitsPerSample:     16,
+			},
+			Subframes: subframes,
+		}))
+	}
+
+	require.NoError(t, enc.Close())
+
+	// Track 1 ends 8 samples into a source frame; track 3 starts 8 samples
+	// before a source frame ends. Both edges produce an 8-sample clip.
+	trackStarts := []uint64{0, 4104, 12280}
+	trackEnds := []uint64{4104, 12280, totalSamples}
+	cue := &CueSheet{Tracks: []CueTrack{{Number: 1}, {Number: 2}, {Number: 3}}}
+	xFile := &XFile{OutputDir: tmpDir, FileMode: 0o600}
+
+	_, files, err := streamTracksFLAC(xFile, flacPath, cue, trackStarts, trackEnds, info, &flacMetadata{Info: info})
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+
+	expected := []uint64{4104, 12280 - 4104, totalSamples - 12280}
+
+	for idx, path := range files {
+		trackFile, err := os.Open(path)
+		require.NoError(t, err)
+
+		stream, err := flac.New(trackFile)
+		require.NoError(t, err, "track %d STREAMINFO must parse", idx+1)
+		assert.Equal(t, expected[idx], stream.Info.NSamples, "track %d sample count", idx+1)
+
+		for frameIdx := 0; ; frameIdx++ {
+			frm, err := stream.ParseNext()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			require.NoError(t, err)
+			assert.False(t, frm.HasFixedBlockSize, "track %d frame %d", idx+1, frameIdx)
+			assert.GreaterOrEqual(t, frm.Subframes[0].NSamples, minFLACBlockSize,
+				"track %d frame %d below minimum block size", idx+1, frameIdx)
+		}
+
+		require.NoError(t, trackFile.Close())
+	}
 }

--- a/cue_internal_test.go
+++ b/cue_internal_test.go
@@ -71,7 +71,7 @@ func TestCopyCueToOutputReplacesSymlink(t *testing.T) {
 	src := filepath.Join(tmp, "src.cue")
 	require.NoError(t, os.WriteFile(src, []byte("REM GENRE Test\n"), 0o600))
 
-	require.NoError(t, copyCueToOutput(src, dest, 0o600))
+	require.NoError(t, copyCueToOutput(&XFile{}, src, dest, 0o600))
 
 	got, err := os.ReadFile(victim)
 	require.NoError(t, err)

--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,7 @@ var (
 	errExtractSymlink    = errors.New("refusing to write through a symbolic link")
 	errExtractNotRegular = errors.New("refusing to extract onto a non-regular file")
 	errExtractConflict   = errors.New("too many concurrent changes at the extract path")
+	errNotDirectory      = errors.New("path exists and is not a directory")
 
 	// ErrMaxBytes is returned when uncompressed bytes written exceed MaxBytes (0 is unlimited).
 	ErrMaxBytes = errors.New("extracted size exceeds maximum bytes")

--- a/errors.go
+++ b/errors.go
@@ -43,6 +43,9 @@ var (
 	ErrNoTracks         = errors.New("cue sheet contains no tracks")
 	ErrAudioNotFound    = errors.New("audio file referenced by cue sheet not found")
 	ErrUnsupportedAudio = errors.New("cue sheet references unsupported audio format (only FLAC and APE are supported)")
+	// ErrTrackTooShort is returned when a CUE track holds fewer samples than the
+	// FLAC minimum block size; encoding it would record an invalid STREAMINFO.
+	ErrTrackTooShort = errors.New("cue track is shorter than the minimum FLAC block size")
 
 	// RPM.
 

--- a/errors.go
+++ b/errors.go
@@ -49,6 +49,10 @@ var (
 	ErrUnsupportedRPMArchiveFmt  = errors.New("unsupported rpm archive format")
 )
 
+func isLimitError(err error) bool {
+	return errors.Is(err, ErrMaxBytes) || errors.Is(err, ErrMaxFiles) || errors.Is(err, ErrMaxRatio)
+}
+
 // ExtractError is a rich error type that can carry multiple errors and warnings
 // from an extraction attempt. Consumers can use errors.As to retrieve it.
 type ExtractError struct {

--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,13 @@ var (
 	errExtractNotRegular = errors.New("refusing to extract onto a non-regular file")
 	errExtractConflict   = errors.New("too many concurrent changes at the extract path")
 
+	// ErrMaxBytes is returned when uncompressed bytes written exceed MaxBytes (0 is unlimited).
+	ErrMaxBytes = errors.New("extracted size exceeds maximum bytes")
+	// ErrMaxFiles is returned when files, directories, and symlinks created exceed MaxFiles (0 is unlimited).
+	ErrMaxFiles = errors.New("extracted file count exceeds maximum")
+	// ErrMaxRatio is returned when bytesWritten / archiveFileSize exceeds MaxRatio (0 is unlimited).
+	ErrMaxRatio = errors.New("extracted size exceeds maximum compression ratio")
+
 	// CUE sheet.
 
 	ErrNoCueFile        = errors.New("cue sheet does not reference a FILE")

--- a/files.go
+++ b/files.go
@@ -164,6 +164,14 @@ type XFile struct {
 	// Streaming formats ignore this. 0 or 1 = sequential (current behavior).
 	// Total concurrent I/O when using the queue = Config.Parallel * FileWorkers.
 	FileWorkers int
+	// MaxBytes is the maximum uncompressed bytes written for this archive.
+	// 0 means unlimited.
+	MaxBytes uint64
+	// MaxFiles is the maximum files, directories, and symlinks created for this
+	// archive. 0 means unlimited.
+	MaxFiles int
+	// MaxRatio is the maximum bytesWritten / archiveFileSize. 0 means unlimited.
+	MaxRatio float64
 	// Progress is called periodically during file extraction.
 	// Contains info about the progress of the extraction.
 	// This is not called if an Updates channel is also provided.
@@ -939,6 +947,9 @@ func (x *XFile) mkDir(path string, mode os.FileMode, mtime time.Time) error {
 		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
 	}
 
+	_, statErr := os.Lstat(path)
+	existed := statErr == nil
+
 	err := os.MkdirAll(path, x.safeDirMode(mode))
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -948,6 +959,13 @@ func (x *XFile) mkDir(path string, mode os.FileMode, mtime time.Time) error {
 	// land the new folder outside OutputDir.
 	if !x.resolvedWithinOutput(path) {
 		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
+	}
+
+	if !existed && filepath.Clean(path) != filepath.Clean(x.OutputDir) {
+		err = x.countExtracted()
+		if err != nil {
+			return err
+		}
 	}
 
 	_ = os.Chtimes(path, time.Time{}, mtime)
@@ -990,9 +1008,12 @@ func (x *XFile) writeFile(file *file, parallel bool) (uint64, error) {
 
 	file.Path = pathUsed
 
-	progWriter := x.prog.writer(fout)
-	if parallel {
-		progWriter = x.prog.parallelWriter(fout)
+	progWriter, err := x.wrapExtractWriter(fout, parallel)
+	if err != nil {
+		_ = fout.Close()
+		_ = os.Remove(file.Path)
+
+		return 0, err
 	}
 
 	size, err := io.Copy(progWriter, file.Data)
@@ -1349,7 +1370,7 @@ func (x *XFile) createSymlink(path, linkName string) error {
 		return fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, linkName)
 	}
 
-	return nil
+	return x.countExtracted()
 }
 
 func (x *XFile) createHardLink(path, linkName string) error {
@@ -1373,7 +1394,7 @@ func (x *XFile) createHardLink(path, linkName string) error {
 
 	err := os.Link(target, path)
 	if err == nil {
-		return nil
+		return x.countExtracted()
 	}
 
 	linkErr := err

--- a/files.go
+++ b/files.go
@@ -977,28 +977,60 @@ func (x *XFile) mkdirAllCounted(path string, mode os.FileMode) error {
 	}
 
 	for _, dir := range dirComponentsUnder(base, path) {
-		err := os.Mkdir(dir, perm)
-		switch {
-		case err == nil:
-			if !x.resolvedWithinOutput(dir) {
-				_ = os.Remove(dir)
-
-				return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
-			}
-
-			countErr := x.countExtracted()
-			if countErr != nil {
-				_ = os.Remove(dir)
-
-				return countErr
-			}
-		case errors.Is(err, os.ErrExist):
-			if !x.resolvedWithinOutput(dir) {
-				return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
-			}
-		default:
-			return fmt.Errorf("creating directory %s: %w", dir, err)
+		err := x.mkdirComponent(dir, perm)
+		if err != nil {
+			return err
 		}
+	}
+
+	return nil
+}
+
+// mkdirComponent reserves a MaxFiles slot, then creates dir. Reservation is
+// rolled back on EEXIST (another worker or a pre-existing path) so parallel
+// ZIP/7z extracts cannot leave an over-limit directory that can no longer be
+// removed. A non-directory occupying the path is an error.
+func (x *XFile) mkdirComponent(dir string, perm os.FileMode) error {
+	err := x.countExtracted()
+	if err != nil {
+		return err
+	}
+
+	err = os.Mkdir(dir, perm)
+	switch {
+	case err == nil:
+		if !x.resolvedWithinOutput(dir) {
+			_ = os.Remove(dir)
+
+			x.uncountExtracted()
+
+			return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
+		}
+
+		return nil
+	case errors.Is(err, os.ErrExist):
+		x.uncountExtracted()
+
+		return x.existingDirOK(dir)
+	default:
+		x.uncountExtracted()
+
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+}
+
+func (x *XFile) existingDirOK(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat existing path %s: %w", dir, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s: %w: %s", x.FilePath, errNotDirectory, dir)
+	}
+
+	if !x.resolvedWithinOutput(dir) {
+		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
 	}
 
 	return nil

--- a/files.go
+++ b/files.go
@@ -941,36 +941,91 @@ func openStatFile(path string) (*os.File, os.FileInfo, error) {
 // mkDir creates a folder (and parents) with safe permissions.
 // It refuses to leave the output folder through a pre-existing symlink.
 func (x *XFile) mkDir(path string, mode os.FileMode, mtime time.Time) error {
-	// Check before MkdirAll so we do not create directories (or Chtimes them)
-	// through a symlink that already points outside OutputDir.
+	// Check before creating so we do not mkdir (or Chtimes) through a symlink
+	// that already points outside OutputDir.
 	if !x.resolvedWithinOutput(path) {
 		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
 	}
 
-	_, statErr := os.Lstat(path)
-	existed := statErr == nil
-
-	err := os.MkdirAll(path, x.safeDirMode(mode))
+	err := x.mkdirAllCounted(path, mode)
 	if err != nil {
-		return err //nolint:wrapcheck
+		return err
 	}
 
-	// Recheck after create: MkdirAll follows symlinks, so a race could still
-	// land the new folder outside OutputDir.
+	// Recheck after create: a race could still land the new folder outside OutputDir.
 	if !x.resolvedWithinOutput(path) {
 		return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, path)
-	}
-
-	if !existed && filepath.Clean(path) != filepath.Clean(x.OutputDir) {
-		err = x.countExtracted()
-		if err != nil {
-			return err
-		}
 	}
 
 	_ = os.Chtimes(path, time.Time{}, mtime)
 
 	return nil
+}
+
+// mkdirAllCounted creates each missing component under OutputDir with os.Mkdir
+// so MaxFiles charges one slot per new directory. EEXIST from a parallel worker
+// is not counted. The caller-provided OutputDir itself is created if needed
+// but is not charged.
+func (x *XFile) mkdirAllCounted(path string, mode os.FileMode) error {
+	path = filepath.Clean(path)
+	base := filepath.Clean(x.OutputDir)
+	perm := x.safeDirMode(mode)
+
+	err := os.MkdirAll(base, perm)
+	if err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	for _, dir := range dirComponentsUnder(base, path) {
+		err := os.Mkdir(dir, perm)
+		switch {
+		case err == nil:
+			if !x.resolvedWithinOutput(dir) {
+				_ = os.Remove(dir)
+
+				return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
+			}
+
+			countErr := x.countExtracted()
+			if countErr != nil {
+				_ = os.Remove(dir)
+
+				return countErr
+			}
+		case errors.Is(err, os.ErrExist):
+			if !x.resolvedWithinOutput(dir) {
+				return fmt.Errorf("%s: %w: %s resolves outside the output folder", x.FilePath, ErrInvalidPath, dir)
+			}
+		default:
+			return fmt.Errorf("creating directory %s: %w", dir, err)
+		}
+	}
+
+	return nil
+}
+
+// dirComponentsUnder returns cleaned descendants of base on the path from base
+// to path, parents first. path must be base or a descendant (see pathWithin).
+func dirComponentsUnder(base, path string) []string {
+	if !pathWithin(base, path) || path == base {
+		return nil
+	}
+
+	var stack []string
+
+	for path != base {
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+
+		stack = append(stack, path)
+		path = parent
+	}
+
+	slices.Reverse(stack)
+
+	return stack
 }
 
 // write a file from an io reader, making sure all parent directories exist.
@@ -1193,12 +1248,24 @@ func openFileNoFollowTrunc(open noFollowOpen, path string, flags int, mode os.Fi
 // symlink. Used for non-archive output (CUE copy, embedded pictures) that
 // otherwise goes through os.WriteFile, which follows links.
 func writeExtractFile(path string, data []byte, mode os.FileMode) error {
+	return (&XFile{}).writeExtractFile(path, data, mode)
+}
+
+func (x *XFile) writeExtractFile(path string, data []byte, mode os.FileMode) error {
 	fout, usedPath, err := openExtractFile(path, mode)
 	if err != nil {
 		return err
 	}
 
-	_, err = fout.Write(data)
+	writer, err := x.extractWriter(fout)
+	if err != nil {
+		_ = fout.Close()
+		_ = os.Remove(usedPath)
+
+		return err
+	}
+
+	_, err = writer.Write(data)
 	closeErr := fout.Close()
 
 	if err != nil {
@@ -1370,7 +1437,13 @@ func (x *XFile) createSymlink(path, linkName string) error {
 		return fmt.Errorf("%s: creating symlink: %w: %s -> %s", x.FilePath, err, path, linkName)
 	}
 
-	return x.countExtracted()
+	err = x.countExtracted()
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+
+	return nil
 }
 
 func (x *XFile) createHardLink(path, linkName string) error {
@@ -1394,7 +1467,13 @@ func (x *XFile) createHardLink(path, linkName string) error {
 
 	err := os.Link(target, path)
 	if err == nil {
-		return x.countExtracted()
+		countErr := x.countExtracted()
+		if countErr != nil {
+			_ = os.Remove(path)
+			return countErr
+		}
+
+		return nil
 	}
 
 	linkErr := err

--- a/files.go
+++ b/files.go
@@ -463,16 +463,24 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 	var extensionType string // archive type from matched extension, for error reporting when extraction fails
 
 	for _, ext := range extension2function {
-		if strings.HasSuffix(sName, ext.Ext) {
-			size, filesList, archiveList, err = ext.Fn(xFile)
-			if err == nil {
-				return size, filesList, archiveList, nil
-			}
-
-			extensionType = ext.Type // preserve for error reporting before fallback
-			// Extension matched but extraction failed; try signature detection as fallback.
-			break
+		if !strings.HasSuffix(sName, ext.Ext) {
+			continue
 		}
+
+		size, filesList, archiveList, err = ext.Fn(xFile)
+		if err == nil {
+			return size, filesList, archiveList, nil
+		}
+
+		// A resource cap aborts the extraction; do not re-extract via signature
+		// detection, which would reset the counters and could even report success.
+		if isLimitError(err) {
+			return size, filesList, archiveList, err
+		}
+
+		extensionType = ext.Type // preserve for error reporting before fallback
+		// Extension matched but extraction failed; try signature detection as fallback.
+		break
 	}
 
 	// Fall back to file signature (magic number) detection.

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -1,6 +1,7 @@
 package xtractr
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -591,4 +592,63 @@ func TestMoveFilesDoesNotDeleteSourceFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{src}, got)
 	require.FileExists(t, src)
+}
+
+func TestMkDirCountsEachMissingComponent(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	xFile := &XFile{FilePath: "a.zip", OutputDir: out, MaxFiles: 2, DirMode: 0o755}
+	xFile.newProgress(0, 0, 0)
+
+	err := xFile.mkDir(filepath.Join(out, "a", "b", "c"), 0o755, time.Now())
+	require.ErrorIs(t, err, ErrMaxFiles)
+	require.DirExists(t, filepath.Join(out, "a"))
+	require.DirExists(t, filepath.Join(out, "a", "b"))
+	require.NoDirExists(t, filepath.Join(out, "a", "b", "c"))
+}
+
+func TestCreateSymlinkRemovesWhenMaxFilesExceeded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(dir, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	xFile := &XFile{FilePath: "a.zip", OutputDir: dir, MaxFiles: 1, DirMode: 0o755}
+	xFile.newProgress(0, 0, 0)
+	require.NoError(t, xFile.countExtracted())
+
+	link := filepath.Join(dir, "link")
+	err = xFile.createSymlink(link, "target")
+	require.ErrorIs(t, err, ErrMaxFiles)
+
+	_, statErr := os.Lstat(link)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestCreateHardLinkRemovesWhenMaxFilesExceeded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real"), []byte("x"), 0o600))
+
+	xFile := &XFile{FilePath: "a.zip", OutputDir: dir, MaxFiles: 1, DirMode: 0o755}
+	xFile.newProgress(0, 0, 0)
+	require.NoError(t, xFile.countExtracted())
+
+	link := filepath.Join(dir, "link")
+
+	err := xFile.createHardLink(link, "real")
+	if err != nil && !errors.Is(err, ErrMaxFiles) {
+		t.Skipf("hard links and symlink fallback unavailable: %v", err)
+	}
+
+	require.ErrorIs(t, err, ErrMaxFiles)
+
+	_, statErr := os.Lstat(link)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -608,6 +608,26 @@ func TestMkDirCountsEachMissingComponent(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(out, "a", "b", "c"))
 }
 
+func TestMkDirExistingFileIsNotDirectory(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	filePath := filepath.Join(out, "notdir")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	oldTime := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+	require.NoError(t, os.Chtimes(filePath, oldTime, oldTime))
+
+	xFile := &XFile{FilePath: "a.zip", OutputDir: out, DirMode: 0o755}
+	err := xFile.mkDir(filePath, 0o755, time.Now())
+	require.ErrorIs(t, err, errNotDirectory)
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, oldTime.Unix(), info.ModTime().Unix(), "rejected file must not be Chtimes'd")
+	assert.False(t, info.IsDir())
+}
+
 func TestCreateSymlinkRemovesWhenMaxFilesExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/iso.go
+++ b/iso.go
@@ -26,6 +26,10 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 	}
 
 	if isLimitError(udfErr) {
+		if xFile.prog != nil {
+			xFile.prog.done()
+		}
+
 		return size, filesList, udfErr
 	}
 
@@ -34,10 +38,14 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 	// Fall back to ISO9660 (now with Joliet support for full filenames).
 	image, isoErr := iso9660.OpenImage(openISO)
 	if isoErr != nil {
+		if xFile.prog != nil {
+			xFile.prog.done()
+		}
+
 		return 0, nil, fmt.Errorf("failed to open iso image: %s: %w", xFile.FilePath, isoErr)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressedIsoSize(image)).done()
+	defer xFile.continueArchiveProgress(getUncompressedIsoSize(image)).done()
 
 	iso, err := iso9660.OpenImage(xFile.prog.readAter(openISO))
 	if err != nil {

--- a/iso.go
+++ b/iso.go
@@ -33,7 +33,7 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("failed to open iso image: %s: %w", xFile.FilePath, isoErr)
 	}
 
-	defer xFile.newProgress(getUncompressedIsoSize(image)).done()
+	defer xFile.newArchiveProgress(getUncompressedIsoSize(image)).done()
 
 	iso, err := iso9660.OpenImage(xFile.prog.readAter(openISO))
 	if err != nil {

--- a/iso.go
+++ b/iso.go
@@ -25,6 +25,10 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 		return size, filesList, nil
 	}
 
+	if isLimitError(udfErr) {
+		return size, filesList, udfErr
+	}
+
 	xFile.Debugf("UDF extraction failed for %s, falling back to ISO9660: %v", xFile.FilePath, udfErr)
 
 	// Fall back to ISO9660 (now with Joliet support for full filenames).
@@ -63,16 +67,20 @@ func getUncompressedIsoSize(image *iso9660.Image) (total, _ uint64, count int) {
 	var loop func(isoFile *iso9660.File)
 
 	loop = func(isoFile *iso9660.File) {
-		count++
-
 		children, err := isoFile.GetChildren()
 		if err != nil {
 			return
 		}
 
 		for _, child := range children {
+			count++
+
+			if child.IsDir() {
+				loop(child)
+				continue
+			}
+
 			total += uint64(child.Size())
-			loop(child)
 		}
 	}
 

--- a/iso.go
+++ b/iso.go
@@ -35,7 +35,10 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 
 	xFile.Debugf("UDF extraction failed for %s, falling back to ISO9660: %v", xFile.FilePath, udfErr)
 
-	// Fall back to ISO9660 (now with Joliet support for full filenames).
+	return extractISO9660(xFile, openISO)
+}
+
+func extractISO9660(xFile *XFile, openISO *os.File) (uint64, []string, error) {
 	image, isoErr := iso9660.OpenImage(openISO)
 	if isoErr != nil {
 		if xFile.prog != nil {
@@ -45,7 +48,12 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("failed to open iso image: %s: %w", xFile.FilePath, isoErr)
 	}
 
-	defer xFile.continueArchiveProgress(getUncompressedIsoSize(image)).done()
+	tracker, headerErr := xFile.archiveProgress(getUncompressedIsoSize(image))
+	defer tracker.done()
+
+	if headerErr != nil {
+		return 0, nil, headerErr
+	}
 
 	iso, err := iso9660.OpenImage(xFile.prog.readAter(openISO))
 	if err != nil {
@@ -57,7 +65,6 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 		return 0, nil, fmt.Errorf("failed to open iso root: %s: %w", xFile.FilePath, err)
 	}
 
-	// Extract directly to output directory (no ISO-name subfolder).
 	size, files, err := xFile.uniso(root, "")
 	if err != nil {
 		return size, files, fmt.Errorf("%s: %w", xFile.FilePath, err)

--- a/limits_test.go
+++ b/limits_test.go
@@ -160,6 +160,27 @@ func TestExtractGzipUnlimited(t *testing.T) {
 	require.Len(t, files, 1)
 }
 
+// TestExtractFileLimitErrorSkipsSignatureFallback ensures a resource cap reached by
+// the extension-matched extractor aborts the archive instead of falling through to
+// signature detection, which would re-extract with fresh counters (and for a .tar.gz
+// could even report success leaving an unextracted .tar).
+func TestExtractFileLimitErrorSkipsSignatureFallback(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeGzipOfZeros(t)
+
+	xFile := &xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxBytes:  100,
+	}
+
+	_, _, _, err := xtractr.ExtractFile(xFile) //nolint:dogsled // only the error matters here.
+	require.ErrorIs(t, err, xtractr.ErrMaxBytes)
+}
+
 func TestQueueInheritsConfigMaxBytes(t *testing.T) {
 	t.Parallel()
 

--- a/limits_test.go
+++ b/limits_test.go
@@ -68,6 +68,24 @@ func TestExtractZipMaxFiles(t *testing.T) {
 	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
 }
 
+func TestExtractZipHeaderMaxFilesExistingDirs(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeEmptyDirsZip(t, limitZipFiles)
+	for idx := range limitZipFiles {
+		require.NoError(t, os.MkdirAll(filepath.Join(out, fmt.Sprintf("dir_%d", idx)), 0o700))
+	}
+
+	_, _, err := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxFiles:  limitZipFiles - 1,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
+}
+
 func TestExtractTarMaxFilesRuntime(t *testing.T) {
 	t.Parallel()
 
@@ -250,6 +268,32 @@ func makeEmptyFilesZip(t *testing.T, count int) (src, out string) {
 	for idx := range count {
 		_, err = zipWriter.CreateHeader(&zip.FileHeader{
 			Name:   fmt.Sprintf("file_%d.txt", idx),
+			Method: zip.Store,
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	return src, out
+}
+
+func makeEmptyDirsZip(t *testing.T, count int) (src, out string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	src = filepath.Join(dir, "dirs.zip")
+	out = filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	zipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(zipFile)
+	for idx := range count {
+		_, err = zipWriter.CreateHeader(&zip.FileHeader{
+			Name:   fmt.Sprintf("dir_%d/", idx),
 			Method: zip.Store,
 		})
 		require.NoError(t, err)

--- a/limits_test.go
+++ b/limits_test.go
@@ -82,6 +82,49 @@ func TestExtractTarMaxFilesRuntime(t *testing.T) {
 	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
 }
 
+func TestExtractTarEmptyMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeEmptyFilesTar(t, 0)
+
+	size, files, err := xtractr.ExtractTar(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxBytes:  1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), size)
+	require.Empty(t, files)
+}
+
+func TestExtractTarNestedDirsMaxFiles(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeNestedFileTar(t, "a/b/c.txt")
+
+	_, _, err := xtractr.ExtractTar(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxFiles:  2,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
+
+	size, files, err := xtractr.ExtractTar(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: filepath.Join(out, "ok"),
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxFiles:  3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), size)
+	require.Len(t, files, 1)
+}
+
 func TestExtractGzipUnlimited(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +208,29 @@ func makeEmptyFilesTar(t *testing.T, count int) (src, out string) {
 		require.NoError(t, err)
 	}
 
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, tarFile.Close())
+
+	return src, out
+}
+
+func makeNestedFileTar(t *testing.T, name string) (src, out string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	src = filepath.Join(dir, "nested.tar")
+	out = filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	tarFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	tarWriter := tar.NewWriter(tarFile)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o600,
+		Size: 0,
+	}))
 	require.NoError(t, tarWriter.Close())
 	require.NoError(t, tarFile.Close())
 

--- a/limits_test.go
+++ b/limits_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golift.io/xtractr"
@@ -139,6 +140,79 @@ func TestExtractGzipUnlimited(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(limitPayloadBytes), size)
 	require.Len(t, files, 1)
+}
+
+func TestQueueInheritsConfigMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeGzipOfZeros(t)
+	dir := filepath.Dir(src)
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:   xtractr.NoLogger(),
+		MaxBytes: 100,
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:           xtractr.Filter{Path: dir},
+		TempFolder:       true,
+		DisableRecursion: true,
+		CBChannel:        make(chan *xtractr.Response, 2),
+	}
+
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+	require.ErrorIs(t, waitExtract(t, job.CBChannel).Error, xtractr.ErrMaxBytes)
+}
+
+func TestQueueJobMaxBytesOverridesConfig(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeGzipOfZeros(t)
+	dir := filepath.Dir(src)
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:   xtractr.NoLogger(),
+		MaxBytes: 100,
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:           xtractr.Filter{Path: dir},
+		TempFolder:       true,
+		DisableRecursion: true,
+		MaxBytes:         limitPayloadBytes,
+		CBChannel:        make(chan *xtractr.Response, 2),
+	}
+
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+	require.NoError(t, waitExtract(t, job.CBChannel).Error)
+}
+
+func waitExtract(t *testing.T, responses chan *xtractr.Response) *xtractr.Response {
+	t.Helper()
+
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case resp, ok := <-responses:
+			require.True(t, ok, "callback channel closed before extraction completed")
+
+			if resp.Done {
+				return resp
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for queued extraction")
+		}
+	}
 }
 
 func makeGzipOfZeros(t *testing.T) (src, out string) {

--- a/limits_test.go
+++ b/limits_test.go
@@ -1,0 +1,172 @@
+package xtractr_test
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golift.io/xtractr"
+)
+
+const (
+	limitPayloadBytes = 4096
+	limitZipFiles     = 4
+)
+
+func TestExtractGzipMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeGzipOfZeros(t)
+
+	_, _, err := xtractr.ExtractGzip(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxBytes:  100,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxBytes)
+}
+
+func TestExtractGzipMaxRatio(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeGzipOfZeros(t)
+
+	info, err := os.Stat(src)
+	require.NoError(t, err)
+	require.Greater(t, float64(limitPayloadBytes), float64(info.Size())*2)
+
+	_, _, err = xtractr.ExtractGzip(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxRatio:  2,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxRatio)
+}
+
+func TestExtractZipMaxFiles(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeEmptyFilesZip(t, limitZipFiles)
+
+	_, _, err := xtractr.ExtractZIP(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxFiles:  limitZipFiles - 1,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
+}
+
+func TestExtractTarMaxFilesRuntime(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeEmptyFilesTar(t, limitZipFiles)
+
+	_, _, err := xtractr.ExtractTar(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxFiles:  limitZipFiles - 1,
+	})
+	require.ErrorIs(t, err, xtractr.ErrMaxFiles)
+}
+
+func TestExtractGzipUnlimited(t *testing.T) {
+	t.Parallel()
+
+	src, out := makeGzipOfZeros(t)
+
+	size, files, err := xtractr.ExtractGzip(&xtractr.XFile{
+		FilePath:  src,
+		OutputDir: out,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(limitPayloadBytes), size)
+	require.Len(t, files, 1)
+}
+
+func makeGzipOfZeros(t *testing.T) (src, out string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	src = filepath.Join(dir, "payload.bin.gz")
+	out = filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	gzipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	writer := gzip.NewWriter(gzipFile)
+	_, err = writer.Write(make([]byte, limitPayloadBytes))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, gzipFile.Close())
+
+	return src, out
+}
+
+func makeEmptyFilesZip(t *testing.T, count int) (src, out string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	src = filepath.Join(dir, "empty.zip")
+	out = filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	zipFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(zipFile)
+	for idx := range count {
+		_, err = zipWriter.CreateHeader(&zip.FileHeader{
+			Name:   fmt.Sprintf("file_%d.txt", idx),
+			Method: zip.Store,
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	return src, out
+}
+
+func makeEmptyFilesTar(t *testing.T, count int) (src, out string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	src = filepath.Join(dir, "empty.tar")
+	out = filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o700))
+
+	tarFile, err := os.Create(src)
+	require.NoError(t, err)
+
+	tarWriter := tar.NewWriter(tarFile)
+	for idx := range count {
+		err = tarWriter.WriteHeader(&tar.Header{
+			Name: fmt.Sprintf("file_%d.txt", idx),
+			Mode: 0o600,
+			Size: 0,
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, tarFile.Close())
+
+	return src, out
+}

--- a/progress.go
+++ b/progress.go
@@ -145,6 +145,15 @@ func (x *XFile) newArchiveProgress(total, compressed uint64, count int) *progres
 	return tracker
 }
 
+// archiveProgress is continueArchiveProgress that returns a claimed-limit error
+// immediately so extractors can abort before walking members. Password retries
+// and the ISO UDF→ISO9660 fallback keep Wrote/Files through continue.
+func (x *XFile) archiveProgress(total, compressed uint64, count int) (*progressTracker, error) {
+	tracker := x.continueArchiveProgress(total, compressed, count)
+
+	return tracker, tracker.headerErr
+}
+
 // continueArchiveProgress is newArchiveProgress that keeps Wrote/Files from the
 // current tracker. Used when ISO9660 follows a partial UDF attempt so the same
 // MaxBytes/MaxFiles budget is not reset.
@@ -477,6 +486,19 @@ func (x *XFile) countExtracted() error {
 	defer x.prog.mu.Unlock()
 
 	return x.prog.addFileLocked()
+}
+
+func (x *XFile) uncountExtracted() {
+	if x == nil || x.prog == nil {
+		return
+	}
+
+	x.prog.mu.Lock()
+	defer x.prog.mu.Unlock()
+
+	if x.prog.Files > 0 {
+		x.prog.Files--
+	}
 }
 
 func (p *progressTracker) reader(reader io.Reader) io.Reader {

--- a/progress.go
+++ b/progress.go
@@ -110,7 +110,6 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 	tracker.Compressed = compressed
 	tracker.Count = count
 	tracker.XFile = x
-	tracker.headerErr = x.checkClaimedLimits(total, count, compressed)
 	tracker.send = func() {}
 	x.prog = tracker
 
@@ -129,10 +128,21 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 	return tracker
 }
 
-// newArchiveProgress is newProgress with Compressed set to the archive file size
+// newArchiveProgress is newProgress with Compressed set to the archive file
+// size (or the provided compressed size when non-zero, e.g. summed volumes)
 // so MaxRatio can be enforced even when member headers omit packed sizes.
-func (x *XFile) newArchiveProgress(total, _ uint64, count int) *progressTracker {
-	return x.newProgress(total, archiveFileSize(x.FilePath), count)
+// Claimed uncompressed size and entry counts from headers are checked here;
+// callers that pass the container size as Total for progress (tar, cpio) must
+// use newProgress instead so MaxBytes is not compared to the on-disk archive.
+func (x *XFile) newArchiveProgress(total, compressed uint64, count int) *progressTracker {
+	if compressed == 0 {
+		compressed = archiveFileSize(x.FilePath)
+	}
+
+	tracker := x.newProgress(total, compressed, count)
+	tracker.headerErr = x.checkClaimedLimits(total, count, compressed)
+
+	return tracker
 }
 
 // snapshot returns a copy of the Progress data, safe to send to callbacks/channels.
@@ -296,6 +306,16 @@ func archiveFileSize(path string) uint64 {
 	return uint64(info.Size())
 }
 
+func archiveFileSizes(paths ...string) uint64 {
+	var total uint64
+
+	for _, path := range paths {
+		total += archiveFileSize(path)
+	}
+
+	return total
+}
+
 // checkClaimedLimits fails closed when archive headers claim more than the
 // configured caps. Headers can understate, so this never replaces runtime
 // checks in Write / addFileLocked.
@@ -328,7 +348,7 @@ func (x *XFile) extractWriter(writer io.Writer) (io.Writer, error) {
 }
 
 func (x *XFile) wrapExtractWriter(writer io.Writer, parallel bool) (io.Writer, error) {
-	if x.prog == nil {
+	if x == nil || x.prog == nil {
 		return writer, nil
 	}
 
@@ -336,7 +356,7 @@ func (x *XFile) wrapExtractWriter(writer io.Writer, parallel bool) (io.Writer, e
 }
 
 func (x *XFile) countExtracted() error {
-	if x.prog == nil {
+	if x == nil || x.prog == nil {
 		return nil
 	}
 
@@ -344,6 +364,24 @@ func (x *XFile) countExtracted() error {
 	defer x.prog.mu.Unlock()
 
 	return x.prog.addFileLocked()
+}
+
+func (x *XFile) accountBytes(add uint64) error {
+	if x == nil || x.prog == nil {
+		return nil
+	}
+
+	x.prog.mu.Lock()
+	defer x.prog.mu.Unlock()
+
+	err := x.prog.checkWriteLocked(add)
+	if err != nil {
+		return err
+	}
+
+	x.prog.Wrote += add
+
+	return nil
 }
 
 func (p *progressTracker) reader(reader io.Reader) io.Reader {

--- a/progress.go
+++ b/progress.go
@@ -145,6 +145,28 @@ func (x *XFile) newArchiveProgress(total, compressed uint64, count int) *progres
 	return tracker
 }
 
+// continueArchiveProgress is newArchiveProgress that keeps Wrote/Files from the
+// current tracker. Used when ISO9660 follows a partial UDF attempt so the same
+// MaxBytes/MaxFiles budget is not reset.
+func (x *XFile) continueArchiveProgress(total, compressed uint64, count int) *progressTracker {
+	var wrote uint64
+
+	var files int
+
+	if x.prog != nil {
+		x.prog.mu.Lock()
+		wrote = x.prog.Wrote
+		files = x.prog.Files
+		x.prog.mu.Unlock()
+	}
+
+	tracker := x.newArchiveProgress(total, compressed, count)
+	tracker.Wrote = wrote
+	tracker.Files = files
+
+	return tracker
+}
+
 // snapshot returns a copy of the Progress data, safe to send to callbacks/channels.
 func (p *progressTracker) snapshot() Progress {
 	p.mu.Lock()
@@ -347,6 +369,97 @@ func (x *XFile) extractWriter(writer io.Writer) (io.Writer, error) {
 	return x.wrapExtractWriter(writer, false)
 }
 
+// countedWriteSeeker wraps a WriteSeeker so MaxBytes/MaxRatio apply to each
+// extending write. Overwrites (FLAC StreamInfo patch on Close) are not
+// counted again. The wrapper is an io.WriteSeeker (and io.Closer when the
+// inner type is) so flac.NewEncoder can still seek.
+func (x *XFile) countedWriteSeeker(writer io.WriteSeeker) *countedWriteSeeker {
+	var tracker *progressTracker
+	if x != nil {
+		tracker = x.prog
+	}
+
+	return &countedWriteSeeker{file: writer, progressTracker: tracker}
+}
+
+type countedWriteSeeker struct {
+	*progressTracker
+
+	file   io.WriteSeeker
+	offset int64
+	maxOff int64
+}
+
+func extraBytes(offset, wrote, maxOff int64) int64 {
+	end := offset + wrote
+	if end <= maxOff {
+		return 0
+	}
+
+	if offset >= maxOff {
+		return wrote
+	}
+
+	return end - maxOff
+}
+
+func (c *countedWriteSeeker) Write(data []byte) (int, error) {
+	want := extraBytes(c.offset, int64(len(data)), c.maxOff)
+	if want > 0 && c.progressTracker != nil {
+		c.mu.Lock()
+
+		err := c.checkWriteLocked(uint64(want))
+		if err != nil {
+			c.mu.Unlock()
+
+			return 0, err
+		}
+
+		c.Wrote += uint64(want)
+		c.mu.Unlock()
+	}
+
+	size, err := c.file.Write(data)
+	got := extraBytes(c.offset, int64(size), c.maxOff)
+
+	if got != want && c.progressTracker != nil {
+		c.mu.Lock()
+		c.Wrote -= uint64(want - got)
+		c.mu.Unlock()
+	}
+
+	c.offset += int64(size)
+	if c.offset > c.maxOff {
+		c.maxOff = c.offset
+	}
+
+	if c.progressTracker != nil {
+		c.send()
+	}
+
+	return size, err //nolint:wrapcheck
+}
+
+func (c *countedWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	pos, err := c.file.Seek(offset, whence)
+	if err != nil {
+		return pos, err //nolint:wrapcheck
+	}
+
+	c.offset = pos
+
+	return pos, nil
+}
+
+func (c *countedWriteSeeker) Close() error {
+	closer, ok := c.file.(io.Closer)
+	if !ok {
+		return nil
+	}
+
+	return closer.Close() //nolint:wrapcheck
+}
+
 func (x *XFile) wrapExtractWriter(writer io.Writer, parallel bool) (io.Writer, error) {
 	if x == nil || x.prog == nil {
 		return writer, nil
@@ -364,24 +477,6 @@ func (x *XFile) countExtracted() error {
 	defer x.prog.mu.Unlock()
 
 	return x.prog.addFileLocked()
-}
-
-func (x *XFile) accountBytes(add uint64) error {
-	if x == nil || x.prog == nil {
-		return nil
-	}
-
-	x.prog.mu.Lock()
-	defer x.prog.mu.Unlock()
-
-	err := x.prog.checkWriteLocked(add)
-	if err != nil {
-		return err
-	}
-
-	x.prog.Wrote += add
-
-	return nil
 }
 
 func (p *progressTracker) reader(reader io.Reader) io.Reader {

--- a/progress.go
+++ b/progress.go
@@ -3,6 +3,7 @@ package xtractr
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 )
 
@@ -37,7 +38,8 @@ type Progress struct {
 type progressTracker struct {
 	Progress
 
-	mu sync.Mutex
+	mu        sync.Mutex
+	headerErr error // optional fast-fail from claimed archive headers
 }
 
 // Percent returns the percent of bytes read or written.
@@ -108,6 +110,7 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 	tracker.Compressed = compressed
 	tracker.Count = count
 	tracker.XFile = x
+	tracker.headerErr = x.checkClaimedLimits(total, count, compressed)
 	tracker.send = func() {}
 	x.prog = tracker
 
@@ -124,6 +127,12 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 	}
 
 	return tracker
+}
+
+// newArchiveProgress is newProgress with Compressed set to the archive file size
+// so MaxRatio can be enforced even when member headers omit packed sizes.
+func (x *XFile) newArchiveProgress(total, _ uint64, count int) *progressTracker {
+	return x.newProgress(total, archiveFileSize(x.FilePath), count)
 }
 
 // snapshot returns a copy of the Progress data, safe to send to callbacks/channels.
@@ -155,11 +164,25 @@ type progressWrapper struct {
 }
 
 func (p *progressWrapper) Write(data []byte) (n int, err error) {
-	size, err := p.Writer.Write(data)
+	want := uint64(len(data))
 
 	p.mu.Lock()
-	p.Wrote += uint64(size)
+
+	err = p.checkWriteLocked(want)
+	if err != nil {
+		p.mu.Unlock()
+		return 0, err
+	}
+
+	p.Wrote += want
 	p.mu.Unlock()
+
+	size, err := p.Writer.Write(data)
+	if uint64(size) != want {
+		p.mu.Lock()
+		p.Wrote -= want - uint64(size)
+		p.mu.Unlock()
+	}
 
 	if p.parallel {
 		p.safeSend()
@@ -168,6 +191,15 @@ func (p *progressWrapper) Write(data []byte) (n int, err error) {
 	}
 
 	return size, err //nolint:wrapcheck
+}
+
+func (p *progressWrapper) Close() error {
+	closer, ok := p.Writer.(io.Closer)
+	if !ok {
+		return nil
+	}
+
+	return closer.Close() //nolint:wrapcheck
 }
 
 func (p *progressWrapper) Read(data []byte) (n int, err error) {
@@ -202,20 +234,116 @@ func (p *progressWrapper) ReadAt(data []byte, off int64) (n int, err error) {
 	return size, err //nolint:wrapcheck
 }
 
-func (p *progressTracker) writer(writer io.Writer) io.Writer {
+func (p *progressTracker) wrapWriter(writer io.Writer, parallel bool) (io.Writer, error) {
 	p.mu.Lock()
-	p.Files++
-	p.mu.Unlock()
+	defer p.mu.Unlock()
 
-	return &progressWrapper{Writer: writer, progressTracker: p}
+	err := p.addFileLocked()
+	if err != nil {
+		return nil, err
+	}
+
+	return &progressWrapper{Writer: writer, progressTracker: p, parallel: parallel}, nil
 }
 
-func (p *progressTracker) parallelWriter(writer io.Writer) io.Writer {
-	p.mu.Lock()
-	p.Files++
-	p.mu.Unlock()
+func (p *progressTracker) addFileLocked() error {
+	if p.headerErr != nil {
+		return p.headerErr
+	}
 
-	return &progressWrapper{Writer: writer, progressTracker: p, parallel: true}
+	xFile := p.XFile
+	if xFile != nil && xFile.MaxFiles > 0 && p.Files >= xFile.MaxFiles {
+		return ErrMaxFiles
+	}
+
+	p.Files++
+
+	return nil
+}
+
+func (p *progressTracker) checkWriteLocked(add uint64) error {
+	if p.headerErr != nil {
+		return p.headerErr
+	}
+
+	xFile := p.XFile
+	if xFile == nil {
+		return nil
+	}
+
+	if xFile.MaxBytes > 0 && p.Wrote+add > xFile.MaxBytes {
+		return ErrMaxBytes
+	}
+
+	if exceedsRatio(p.Wrote+add, p.Compressed, xFile.MaxRatio) {
+		return ErrMaxRatio
+	}
+
+	return nil
+}
+
+// archiveFileSize returns the size of path on disk, or 0 if it cannot be stat'd.
+func archiveFileSize(path string) uint64 {
+	if path == "" {
+		return 0
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= 0 {
+		return 0
+	}
+
+	return uint64(info.Size())
+}
+
+// checkClaimedLimits fails closed when archive headers claim more than the
+// configured caps. Headers can understate, so this never replaces runtime
+// checks in Write / addFileLocked.
+func (x *XFile) checkClaimedLimits(claimedBytes uint64, claimedFiles int, compressed uint64) error {
+	if x.MaxBytes > 0 && claimedBytes > x.MaxBytes {
+		return ErrMaxBytes
+	}
+
+	if x.MaxFiles > 0 && claimedFiles > x.MaxFiles {
+		return ErrMaxFiles
+	}
+
+	if claimedBytes > 0 && exceedsRatio(claimedBytes, compressed, x.MaxRatio) {
+		return ErrMaxRatio
+	}
+
+	return nil
+}
+
+func exceedsRatio(wrote, compressed uint64, ratio float64) bool {
+	if ratio <= 0 || compressed == 0 {
+		return false
+	}
+
+	return float64(wrote) > float64(compressed)*ratio
+}
+
+func (x *XFile) extractWriter(writer io.Writer) (io.Writer, error) {
+	return x.wrapExtractWriter(writer, false)
+}
+
+func (x *XFile) wrapExtractWriter(writer io.Writer, parallel bool) (io.Writer, error) {
+	if x.prog == nil {
+		return writer, nil
+	}
+
+	return x.prog.wrapWriter(writer, parallel)
+}
+
+func (x *XFile) countExtracted() error {
+	if x.prog == nil {
+		return nil
+	}
+
+	x.prog.mu.Lock()
+	defer x.prog.mu.Unlock()
+
+	return x.prog.addFileLocked()
 }
 
 func (p *progressTracker) reader(reader io.Reader) io.Reader {

--- a/progress.go
+++ b/progress.go
@@ -142,6 +142,12 @@ func (x *XFile) newArchiveProgress(total, compressed uint64, count int) *progres
 	tracker := x.newProgress(total, compressed, count)
 	tracker.headerErr = x.checkClaimedLimits(total, count, compressed)
 
+	// Fail closed: MaxRatio with no denominator would otherwise be treated as
+	// unlimited (exceedsRatio used to return false when compressed == 0).
+	if tracker.headerErr == nil && x.MaxRatio > 0 && compressed == 0 {
+		tracker.headerErr = fmt.Errorf("%w: compressed size unavailable", ErrMaxRatio)
+	}
+
 	return tracker
 }
 
@@ -367,8 +373,12 @@ func (x *XFile) checkClaimedLimits(claimedBytes uint64, claimedFiles int, compre
 }
 
 func exceedsRatio(wrote, compressed uint64, ratio float64) bool {
-	if ratio <= 0 || compressed == 0 {
+	if ratio <= 0 {
 		return false
+	}
+
+	if compressed == 0 {
+		return wrote > 0
 	}
 
 	return float64(wrote) > float64(compressed)*ratio

--- a/progress_internal_test.go
+++ b/progress_internal_test.go
@@ -1,0 +1,72 @@
+package xtractr
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountedWriteSeekerCountsGrowthOnly(t *testing.T) {
+	t.Parallel()
+
+	outFile, err := os.Create(filepath.Join(t.TempDir(), "out"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outFile.Close() })
+
+	xFile := &XFile{MaxBytes: 100}
+	xFile.newProgress(0, 100, 0)
+	writer := xFile.countedWriteSeeker(outFile)
+
+	_, err = writer.Write(make([]byte, 20))
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), xFile.prog.Wrote)
+
+	_, err = writer.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	_, err = writer.Write(make([]byte, 8))
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), xFile.prog.Wrote, "StreamInfo-style overwrite must not recount")
+
+	_, err = writer.Seek(0, io.SeekEnd)
+	require.NoError(t, err)
+
+	_, err = writer.Write(make([]byte, 5))
+	require.NoError(t, err)
+	require.Equal(t, uint64(25), xFile.prog.Wrote)
+}
+
+func TestCountedWriteSeekerStopsAtMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	outFile, err := os.Create(filepath.Join(t.TempDir(), "out"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outFile.Close() })
+
+	xFile := &XFile{MaxBytes: 10}
+	xFile.newProgress(0, 100, 0)
+	writer := xFile.countedWriteSeeker(outFile)
+
+	_, err = writer.Write(make([]byte, 8))
+	require.NoError(t, err)
+
+	_, err = writer.Write(make([]byte, 8))
+	require.ErrorIs(t, err, ErrMaxBytes)
+	require.Equal(t, uint64(8), xFile.prog.Wrote)
+}
+
+func TestContinueArchiveProgressKeepsCounts(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{FilePath: "a.iso", MaxBytes: 1000, MaxFiles: 20}
+	first := xFile.newArchiveProgress(0, 10, 0)
+	first.Wrote = 40
+	first.Files = 3
+
+	second := xFile.continueArchiveProgress(50, 10, 2)
+	require.Equal(t, uint64(40), second.Wrote)
+	require.Equal(t, 3, second.Files)
+}

--- a/progress_internal_test.go
+++ b/progress_internal_test.go
@@ -70,3 +70,26 @@ func TestContinueArchiveProgressKeepsCounts(t *testing.T) {
 	require.Equal(t, uint64(40), second.Wrote)
 	require.Equal(t, 3, second.Files)
 }
+
+func TestArchiveProgressReturnsClaimedMaxFiles(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{MaxFiles: 1}
+	_, err := xFile.archiveProgress(0, 10, 5)
+	require.ErrorIs(t, err, ErrMaxFiles)
+}
+
+func TestArchiveProgressKeepsCountsAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{MaxFiles: 100}
+	first, err := xFile.archiveProgress(0, 10, 1)
+	require.NoError(t, err)
+
+	first.Files = 7
+
+	attempt := *xFile
+	_, err = attempt.archiveProgress(0, 10, 1)
+	require.NoError(t, err)
+	require.Equal(t, 7, attempt.prog.Files)
+}

--- a/progress_internal_test.go
+++ b/progress_internal_test.go
@@ -93,3 +93,19 @@ func TestArchiveProgressKeepsCountsAcrossCalls(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 7, attempt.prog.Files)
 }
+
+func TestExceedsRatioFailsClosedWithoutCompressedSize(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, exceedsRatio(100, 0, 0), "MaxRatio 0 is unlimited")
+	require.False(t, exceedsRatio(0, 0, 2), "nothing written yet")
+	require.True(t, exceedsRatio(1, 0, 2), "any write without a denominator exceeds")
+}
+
+func TestArchiveProgressFailsClosedWithoutCompressedSize(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{MaxRatio: 2, FilePath: filepath.Join(t.TempDir(), "missing.zip")}
+	_, err := xFile.archiveProgress(0, 0, 0)
+	require.ErrorIs(t, err, ErrMaxRatio)
+}

--- a/queue.go
+++ b/queue.go
@@ -52,6 +52,15 @@ type Xtract struct {
 	// Contains info about the progress of the extraction.
 	// Shared by all archive file extractions that occur with this Xtract.
 	Updates chan Progress
+	// MaxBytes is the maximum uncompressed bytes written per archive.
+	// 0 means unlimited; when 0, Config.MaxBytes is used.
+	MaxBytes uint64
+	// MaxFiles is the maximum files, directories, and symlinks created per archive.
+	// 0 means unlimited; when 0, Config.MaxFiles is used.
+	MaxFiles int
+	// MaxRatio is the maximum bytesWritten / archiveFileSize per archive.
+	// 0 means unlimited; when 0, Config.MaxRatio is used.
+	MaxRatio float64
 }
 
 // Response is sent to the call-back function. The first CBFunction call is just
@@ -188,6 +197,9 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 				LogFile:          resp.X.LogFile,
 				Updates:          resp.X.Updates,
 				Progress:         resp.X.Progress,
+				MaxBytes:         resp.X.MaxBytes,
+				MaxFiles:         resp.X.MaxFiles,
+				MaxRatio:         resp.X.MaxRatio,
 			},
 			Started:  resp.Started,
 			Output:   output,
@@ -321,6 +333,9 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 			Passwords: resp.X.Passwords,
 			Progress:  resp.X.Progress,
 			Updates:   resp.X.Updates,
+			MaxBytes:  resp.X.MaxBytes,
+			MaxFiles:  resp.X.MaxFiles,
+			MaxRatio:  resp.X.MaxRatio,
 		},
 		Started:  resp.Started,
 		Output:   resp.Output,
@@ -389,6 +404,9 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		Passwords:   resp.X.Passwords,
 		Password:    resp.X.Password,
 		FileWorkers: x.config.FileWorkers,
+		MaxBytes:    pickUint64(resp.X.MaxBytes, x.config.MaxBytes),
+		MaxFiles:    pickInt(resp.X.MaxFiles, x.config.MaxFiles),
+		MaxRatio:    pickFloat64(resp.X.MaxRatio, x.config.MaxRatio),
 		log:         x.config.Logger,
 		Updates:     resp.X.Updates,
 		Progress:    resp.X.Progress,
@@ -405,6 +423,30 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	}
 
 	return bytes, files, archives, nil
+}
+
+func pickUint64(job, cfg uint64) uint64 {
+	if job != 0 {
+		return job
+	}
+
+	return cfg
+}
+
+func pickInt(job, cfg int) int {
+	if job != 0 {
+		return job
+	}
+
+	return cfg
+}
+
+func pickFloat64(job, cfg float64) float64 {
+	if job != 0 {
+		return job
+	}
+
+	return cfg
 }
 
 func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {

--- a/queue.go
+++ b/queue.go
@@ -404,9 +404,9 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		Passwords:   resp.X.Passwords,
 		Password:    resp.X.Password,
 		FileWorkers: x.config.FileWorkers,
-		MaxBytes:    pickUint64(resp.X.MaxBytes, x.config.MaxBytes),
-		MaxFiles:    pickInt(resp.X.MaxFiles, x.config.MaxFiles),
-		MaxRatio:    pickFloat64(resp.X.MaxRatio, x.config.MaxRatio),
+		MaxBytes:    pick(resp.X.MaxBytes, x.config.MaxBytes),
+		MaxFiles:    pick(resp.X.MaxFiles, x.config.MaxFiles),
+		MaxRatio:    pick(resp.X.MaxRatio, x.config.MaxRatio),
 		log:         x.config.Logger,
 		Updates:     resp.X.Updates,
 		Progress:    resp.X.Progress,
@@ -425,24 +425,9 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	return bytes, files, archives, nil
 }
 
-func pickUint64(job, cfg uint64) uint64 {
-	if job != 0 {
-		return job
-	}
-
-	return cfg
-}
-
-func pickInt(job, cfg int) int {
-	if job != 0 {
-		return job
-	}
-
-	return cfg
-}
-
-func pickFloat64(job, cfg float64) float64 {
-	if job != 0 {
+func pick[T uint64 | int | float64](job, cfg T) T { //nolint:ireturn // numeric union, not an interface.
+	var zero T
+	if job != zero {
 		return job
 	}
 

--- a/rar.go
+++ b/rar.go
@@ -32,16 +32,19 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 		attempt.Password = password
 
 		size, files, archives, err := extractRAR(&attempt)
-		if err == nil {
+		xFile.prog = attempt.prog
+
+		switch {
+		case err == nil:
 			return size, files, archives, nil
-		}
-
-		// https://github.com/nwaples/rardecode/issues/28
-		if strings.Contains(err.Error(), "incorrect password") {
+		case isLimitError(err):
+			return size, files, archives, err
+		case strings.Contains(err.Error(), "incorrect password"):
+			// https://github.com/nwaples/rardecode/issues/28
 			continue
+		default:
+			return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)
 		}
-
-		return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)
 	}
 
 	// No password worked, try without a password.
@@ -58,7 +61,12 @@ func extractRAR(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressedRarSize(rarReader, xFile.FilePath)).done() // this closes rarReader
+	tracker, headerErr := xFile.archiveProgress(getUncompressedRarSize(rarReader, xFile.FilePath))
+	defer tracker.done() // getUncompressedRarSize closed rarReader
+
+	if headerErr != nil {
+		return 0, nil, nil, headerErr
+	}
 
 	rarReader, err = rardecode.OpenReader(xFile.FilePath, rardecode.Password(xFile.Password)) // open it again.
 	if err != nil {

--- a/rar.go
+++ b/rar.go
@@ -58,7 +58,7 @@ func extractRAR(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 
-	defer xFile.newProgress(getUncompressedRarSize(rarReader)).done() // this closes rarReader
+	defer xFile.newArchiveProgress(getUncompressedRarSize(rarReader)).done() // this closes rarReader
 
 	rarReader, err = rardecode.OpenReader(xFile.FilePath, rardecode.Password(xFile.Password)) // open it again.
 	if err != nil {

--- a/rar.go
+++ b/rar.go
@@ -26,13 +26,7 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 	}
 
 	for idx, password := range passwords {
-		// Copy the input so the retry keeps the logger, progress callbacks,
-		// SquashRoot and the rest of the caller-provided configuration.
-		attempt := *xFile
-		attempt.Password = password
-
-		size, files, archives, err := extractRAR(&attempt)
-		xFile.prog = attempt.prog
+		size, files, archives, err := tryRAR(xFile, password)
 
 		switch {
 		case err == nil:
@@ -47,11 +41,21 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 		}
 	}
 
-	// No password worked, try without a password.
-	attempt := *xFile
-	attempt.Password = ""
+	// No password worked, try without a password. tryRAR copies the attempt
+	// tracker back so a later signature fallback keeps the same budget.
+	return tryRAR(xFile, "")
+}
 
-	return extractRAR(&attempt)
+// tryRAR runs one extractRAR attempt on a copy (so Password can change) and
+// writes the attempt's progress tracker back onto xFile.
+func tryRAR(xFile *XFile, password string) (uint64, []string, []string, error) {
+	attempt := *xFile
+	attempt.Password = password
+
+	size, files, archives, err := extractRAR(&attempt)
+	xFile.prog = attempt.prog
+
+	return size, files, archives, err
 }
 
 // extractRAR extracts a rar file. to a destination. This wraps github.com/nwaples/rardecode.

--- a/rar.go
+++ b/rar.go
@@ -58,7 +58,7 @@ func extractRAR(xFile *XFile) (uint64, []string, []string, error) {
 		return 0, nil, nil, fmt.Errorf("rardecode.OpenReader: %w", err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressedRarSize(rarReader)).done() // this closes rarReader
+	defer xFile.newArchiveProgress(getUncompressedRarSize(rarReader, xFile.FilePath)).done() // this closes rarReader
 
 	rarReader, err = rardecode.OpenReader(xFile.FilePath, rardecode.Password(xFile.Password)) // open it again.
 	if err != nil {
@@ -77,21 +77,18 @@ func extractRAR(xFile *XFile) (uint64, []string, []string, error) {
 	return xFile.prog.Wrote, files, normalizeVolumes(rarReader.Volumes(), xFile.FilePath), nil
 }
 
-func getUncompressedRarSize(rarReader *rardecode.ReadCloser) (total, compressed uint64, count int) {
+func getUncompressedRarSize(rarReader *rardecode.ReadCloser, filePath string) (total, compressed uint64, count int) {
 	defer rarReader.Close()
 
 	for {
 		header, err := rarReader.Next()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return total, 0, count
-			}
+			compressed = archiveFileSizes(normalizeVolumes(rarReader.Volumes(), filePath)...)
 
-			return total, 0, count
+			return total, compressed, count
 		}
 
 		total += uint64(header.UnPackedSize)
-		// compressed += uint64(header.PackedSize)
 		count++
 	}
 }

--- a/start.go
+++ b/start.go
@@ -40,6 +40,15 @@ type Config struct {
 	TryNames bool
 	// The suffix used for temporary folders.
 	Suffix string
+	// MaxBytes is the default maximum uncompressed bytes written per archive.
+	// 0 means unlimited. Copied onto each XFile when Xtract.MaxBytes is 0.
+	MaxBytes uint64
+	// MaxFiles is the default maximum files, directories, and symlinks created
+	// per archive. 0 means unlimited. Copied onto each XFile when Xtract.MaxFiles is 0.
+	MaxFiles int
+	// MaxRatio is the default maximum bytesWritten / archiveFileSize per archive.
+	// 0 means unlimited. Copied onto each XFile when Xtract.MaxRatio is 0.
+	MaxRatio float64
 }
 
 // Logger allows this library to write logs.

--- a/udf.go
+++ b/udf.go
@@ -15,12 +15,14 @@ func extractUDF(xFile *XFile, ra io.ReaderAt) (uint64, []string, error) {
 		return 0, nil, fmt.Errorf("failed to open UDF image: %s: %w", xFile.FilePath, err)
 	}
 
-	defer xFile.newArchiveProgress(getUncompressedUDFSize(udfImage)).done()
+	tracker := xFile.newArchiveProgress(getUncompressedUDFSize(udfImage))
 
 	size, files, err := xFile.unUDF(udfImage, nil, "")
 	if err != nil {
 		return size, files, fmt.Errorf("%s: %w", xFile.FilePath, err)
 	}
+
+	tracker.done()
 
 	return size, files, nil
 }

--- a/udf.go
+++ b/udf.go
@@ -15,7 +15,7 @@ func extractUDF(xFile *XFile, ra io.ReaderAt) (uint64, []string, error) {
 		return 0, nil, fmt.Errorf("failed to open UDF image: %s: %w", xFile.FilePath, err)
 	}
 
-	defer xFile.newProgress(getUncompressedUDFSize(udfImage)).done()
+	defer xFile.newArchiveProgress(getUncompressedUDFSize(udfImage)).done()
 
 	size, files, err := xFile.unUDF(udfImage, nil, "")
 	if err != nil {

--- a/udf.go
+++ b/udf.go
@@ -15,7 +15,10 @@ func extractUDF(xFile *XFile, ra io.ReaderAt) (uint64, []string, error) {
 		return 0, nil, fmt.Errorf("failed to open UDF image: %s: %w", xFile.FilePath, err)
 	}
 
-	tracker := xFile.newArchiveProgress(getUncompressedUDFSize(udfImage))
+	tracker, headerErr := xFile.archiveProgress(getUncompressedUDFSize(udfImage))
+	if headerErr != nil {
+		return 0, nil, headerErr
+	}
 
 	size, files, err := xFile.unUDF(udfImage, nil, "")
 	if err != nil {

--- a/zip.go
+++ b/zip.go
@@ -18,7 +18,7 @@ func ExtractZIP(xFile *XFile) (size uint64, filesList []string, err error) {
 	}
 	defer zipReader.Close()
 
-	defer xFile.newProgress(getUncompressedZipSize(zipReader)).done()
+	defer xFile.newArchiveProgress(getUncompressedZipSize(zipReader)).done()
 
 	// Detect encoding for non-UTF8 filenames in the archive.
 	decoder := detectZipEncoding(xFile, zipReader.File)

--- a/zip.go
+++ b/zip.go
@@ -18,7 +18,12 @@ func ExtractZIP(xFile *XFile) (size uint64, filesList []string, err error) {
 	}
 	defer zipReader.Close()
 
-	defer xFile.newArchiveProgress(getUncompressedZipSize(zipReader)).done()
+	tracker, headerErr := xFile.archiveProgress(getUncompressedZipSize(zipReader))
+	defer tracker.done()
+
+	if headerErr != nil {
+		return 0, nil, headerErr
+	}
 
 	// Detect encoding for non-UTF8 filenames in the archive.
 	decoder := detectZipEncoding(xFile, zipReader.File)


### PR DESCRIPTION
## Summary
- Add `MaxBytes`, `MaxFiles`, and `MaxRatio` on `XFile`, `Xtract`, and `Config`. `0` means unlimited (library default). Queue jobs inherit `Config` when the `Xtract` field is `0`.
- Enforce at runtime in the shared progress writer (and directory/symlink create): abort when bytes, file count, or `bytesWritten / archiveFileSize` exceed the cap. Return `ErrMaxBytes`, `ErrMaxFiles`, or `ErrMaxRatio` so `io.Copy` stops. Zip/7z/rar (and iso/udf/ar) also fast-fail from claimed header size/count; headers can understate, so that never replaces the write-path check.
- Nested extracts stay one extra pass gated by existing `DisableRecursion`. No `MaxRecursion`. CUE/APE track opens already go through `openExtractFile`; APE frame copies go through the progress writer so byte/file caps apply there too.
- CUE/FLAC splits now fuse boundary clips smaller than the FLAC minimum block size (16 samples) into the neighboring frame. A track cut near a source frame's edge previously wrote an 8-sample frame, and the encoder recorded that as STREAMINFO's minimum block size, so strict parsers (go-flac, GStreamer's flacparse) rejected the track.

## Test plan
- [x] `TestExtractGzipMaxBytes` — gzip of zeros with `MaxBytes` smaller than payload → `ErrMaxBytes`
- [x] `TestExtractGzipMaxRatio` — same with `MaxRatio=2` → `ErrMaxRatio`
- [x] `TestExtractZipMaxFiles` — zip with N empty files, `MaxFiles < N` → `ErrMaxFiles` (header fast-fail)
- [x] `TestExtractTarMaxFilesRuntime` — tar with N empty files, `MaxFiles < N` → `ErrMaxFiles` (runtime, tar reports count 0)
- [x] `TestExtractGzipUnlimited` — zeros still extract when all caps are 0
- [x] `TestStreamTracksFLACTinyBoundaryClips` — synthetic fixed-blocksize FLAC split 8 samples into / before a frame edge; every track parses and every frame is ≥ 16 samples
- [x] `TestCueSplitRealFLAC` — ffmpeg-encoded album split at 30s CUE marks produces readable tracks (skipped when ffmpeg is not in PATH)
- [x] CI gotest + golangci on this PR

Made with [Cursor](https://cursor.com)