### PR TITLE
Report refused files

### DIFF
--- a/files.go
+++ b/files.go
@@ -633,9 +633,15 @@ func moveFiles( //nolint:cyclop,funlen
 		}
 	}
 
-	info, statErr := os.Stat(fromPath)
-	if statErr == nil && info.IsDir() {
-		deleteFiles(log, fromPath)
+	// Only remove the temp source when every file moved. On a move or Lstat
+	// error (keepErr != nil) the destination holds a partial result, so the
+	// source must survive for recovery. Refusals are not errors; those files
+	// stay in the temp dir but the destination is otherwise complete.
+	if keepErr == nil {
+		info, statErr := os.Stat(fromPath)
+		if statErr == nil && info.IsDir() {
+			deleteFiles(log, fromPath)
+		}
 	}
 
 	// Since this is the last step, we tried to rename all the files, bubble the

--- a/files.go
+++ b/files.go
@@ -603,7 +603,15 @@ func moveFiles( //nolint:cyclop,funlen
 		}
 
 		_, err = os.Lstat(newFile)
-		exists := !os.IsNotExist(err)
+		exists := err == nil
+
+		if err != nil && !os.IsNotExist(err) {
+			// Permission or I/O error is not an occupied destination.
+			keepErr = err
+			log.Printf("Error: Checking Temp File Destination: %v to %v: %v", file, newFile, err)
+
+			continue
+		}
 
 		if exists && !overwrite {
 			log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
@@ -716,34 +724,6 @@ func truncateToBytes(str string, maxBytes int) string {
 	return string(raw)
 }
 
-// openFile opens path with the given flags and mode. If the path exceeds
-// filesystem name limits, the path is truncated via TruncatePathForFS and
-// retried. It returns the opened file and the path that was actually used
-// (the original or the truncated path), so the caller can update file.Path
-// for later use (e.g. os.Chtimes).
-func openFile(path string, flags int, mode os.FileMode) (*os.File, string, error) {
-	openFile, err := os.OpenFile(path, flags, mode)
-	if err == nil {
-		return openFile, path, nil
-	}
-
-	if !IsErrNameTooLong(err) {
-		return nil, "", fmt.Errorf("os.OpenFile(): %w", err)
-	}
-
-	shortPath, truncErr := TruncatePathForFS(path)
-	if truncErr != nil {
-		return nil, "", truncErr
-	}
-
-	openFile, err = os.OpenFile(shortPath, flags, mode)
-	if err != nil {
-		return nil, "", fmt.Errorf("os.OpenFile(): %w", err)
-	}
-
-	return openFile, shortPath, nil
-}
-
 type file struct {
 	Path     string
 	Data     io.Reader
@@ -771,16 +751,8 @@ func renameFile(oldpath, newpath string) error {
 
 	/* Rename failed, try copy. */
 
-	// O_TRUNC follows a dest symlink and would write through it. Replace the
-	// name instead, matching os.Rename on the same device.
-	destInfo, destErr := os.Lstat(newpath)
-	if destErr == nil && destInfo.Mode()&os.ModeSymlink != 0 {
-		destErr = os.Remove(newpath) // Delete the symlink.
-		if destErr != nil {
-			return &ExtractError{Errs: []error{origErr, fmt.Errorf("removing dest symlink: %w", destErr)}}
-		}
-	}
-
+	// Open the source first so a missing/unreadable source returns an error
+	// without touching the destination.
 	oldFileStat, err := os.Stat(oldpath)
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, fmt.Errorf("os.Stat(): %w", err)}}
@@ -793,7 +765,10 @@ func renameFile(oldpath, newpath string) error {
 
 	defer oldFile.Close() // also closed explicitly before the delete below.
 
-	newFile, pathUsed, err := openFile(newpath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, oldFileStat.Mode())
+	// os.OpenFile(O_TRUNC) follows a dest symlink and would write through it.
+	// openExtractFile opens the dest without following a final-component symlink,
+	// unlinking and retrying like the extract writers do.
+	newFile, pathUsed, err := openExtractFile(newpath, oldFileStat.Mode())
 	if err != nil {
 		return &ExtractError{Errs: []error{origErr, err}}
 	}

--- a/files.go
+++ b/files.go
@@ -502,13 +502,41 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 	return size, filesList, archiveList, nil
 }
 
-// MoveFiles relocates files then removes the folder they were in.
-// Returns the new file paths.
-// This is a helper method and only exposed for convenience. You do not have to call this.
-func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) {
-	newFiles, _, err := moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
+// Renamed is the result of RenameFiles.
+type Renamed struct {
+	// NewFiles is the list of paths that were moved into place.
+	NewFiles []string
+	// Refused lists files that were not moved because the destination was occupied.
+	Refused []RefusedFile
+}
 
-	return newFiles, err
+// RefusedFile describes an extracted file that was not moved into place
+// because the destination path was already occupied and overwrite was false.
+// The occupying file was left untouched; the extracted copy was deleted
+// with the temporary folder.
+type RefusedFile struct {
+	// Src is the extracted copy's path in the temporary folder.
+	Src string
+	// Dest is the occupied destination path that was kept.
+	Dest string
+}
+
+// MoveFiles relocates files then removes the folder they were in.
+// Returns the new file paths. Occupied destinations are skipped when overwrite
+// is false; use RenameFiles to learn which names were refused.
+// This is a helper method and only exposed for convenience. You do not have to call this.
+//
+// Deprecated: Use RenameFiles instead.
+func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) {
+	renamed, err := x.RenameFiles(fromPath, toPath, overwrite)
+	return renamed.NewFiles, err
+}
+
+// RenameFiles relocates files then removes the folder they were in.
+// Unlike MoveFiles, the result includes destinations that were already occupied.
+// This is a helper method and only exposed for convenience. You do not have to call this.
+func (x *Xtractr) RenameFiles(fromPath, toPath string, overwrite bool) (Renamed, error) {
+	return moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
 }
 
 // bindMoveFiles wires ExtractFile to this job's logger and DirMode.
@@ -521,10 +549,10 @@ func (x *XFile) bindMoveFiles() { //nolint:funcorder // kept next to MoveFiles
 	}
 
 	x.moveFiles = func(fromPath, toPath string, overwrite bool) ([]string, error) {
-		newFiles, refused, err := moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
-		x.refused = append(x.refused, refused...)
+		renamed, err := moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
+		x.refused = append(x.refused, renamed.Refused...)
 
-		return newFiles, err
+		return renamed.NewFiles, err
 	}
 }
 
@@ -533,7 +561,7 @@ func moveFiles( //nolint:cyclop,funlen
 	dirMode os.FileMode,
 	fromPath, toPath string,
 	overwrite bool,
-) ([]string, []RefusedFile, error) {
+) (Renamed, error) {
 	if log == nil {
 		log = NoLogger()
 	}
@@ -550,7 +578,7 @@ func moveFiles( //nolint:cyclop,funlen
 
 	files, err := listFiles(fromPath)
 	if err != nil {
-		return nil, nil, err
+		return Renamed{}, err
 	}
 
 	// If the "to path" is an existing archive file, remove the suffix to make a directory.
@@ -563,7 +591,7 @@ func moveFiles( //nolint:cyclop,funlen
 
 	err = os.MkdirAll(toPath, dirMode)
 	if err != nil {
-		return nil, nil, fmt.Errorf("making final dir: %w", err)
+		return Renamed{}, fmt.Errorf("making final dir: %w", err)
 	}
 
 	for _, file := range files {
@@ -574,7 +602,7 @@ func moveFiles( //nolint:cyclop,funlen
 			continue
 		}
 
-		_, err = os.Stat(newFile)
+		_, err = os.Lstat(newFile)
 		exists := !os.IsNotExist(err)
 
 		if exists && !overwrite {
@@ -605,18 +633,7 @@ func moveFiles( //nolint:cyclop,funlen
 	// Since this is the last step, we tried to rename all the files, bubble the
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
-	return newFiles, refused, keepErr
-}
-
-// RefusedFile describes an extracted file that was not moved into place
-// because the destination path was already occupied and overwrite was false.
-// The occupying file was left untouched; the extracted copy was deleted
-// with the temporary folder.
-type RefusedFile struct {
-	// Src is the extracted copy's path in the temporary folder.
-	Src string
-	// Dest is the occupied destination path that was kept.
-	Dest string
+	return Renamed{NewFiles: newFiles, Refused: refused}, keepErr
 }
 
 // DeleteFiles obliterates things and logs. Use with caution.
@@ -753,6 +770,16 @@ func renameFile(oldpath, newpath string) error {
 	origErr = fmt.Errorf("os.Rename(): %w", origErr)
 
 	/* Rename failed, try copy. */
+
+	// O_TRUNC follows a dest symlink and would write through it. Replace the
+	// name instead, matching os.Rename on the same device.
+	destInfo, destErr := os.Lstat(newpath)
+	if destErr == nil && destInfo.Mode()&os.ModeSymlink != 0 {
+		destErr = os.Remove(newpath) // Delete the symlink.
+		if destErr != nil {
+			return &ExtractError{Errs: []error{origErr, fmt.Errorf("removing dest symlink: %w", destErr)}}
+		}
+	}
 
 	oldFileStat, err := os.Stat(oldpath)
 	if err != nil {

--- a/files.go
+++ b/files.go
@@ -512,8 +512,8 @@ type Renamed struct {
 
 // RefusedFile describes an extracted file that was not moved into place
 // because the destination path was already occupied and overwrite was false.
-// The occupying file was left untouched; the extracted copy was deleted
-// with the temporary folder.
+// The occupying file was left untouched. The extracted copy is deleted when
+// the overall move succeeds, but may remain if another move fails.
 type RefusedFile struct {
 	// Src is the extracted copy's path in the temporary folder.
 	Src string

--- a/files.go
+++ b/files.go
@@ -182,6 +182,9 @@ type XFile struct {
 	log       Logger
 	moveFiles func(fromPath, toPath string, overwrite bool) ([]string, error)
 	prog      *progressTracker
+	// refused collects files not moved into place during Extract; it is
+	// copied into Response.Refused by processArchive.
+	refused []RefusedFile
 }
 
 // Filter is the input to find compressed files.
@@ -503,7 +506,9 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 // Returns the new file paths.
 // This is a helper method and only exposed for convenience. You do not have to call this.
 func (x *Xtractr) MoveFiles(fromPath, toPath string, overwrite bool) ([]string, error) {
-	return moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
+	newFiles, _, err := moveFiles(x.config, x.config.DirMode, fromPath, toPath, overwrite)
+
+	return newFiles, err
 }
 
 // bindMoveFiles wires ExtractFile to this job's logger and DirMode.
@@ -516,7 +521,10 @@ func (x *XFile) bindMoveFiles() { //nolint:funcorder // kept next to MoveFiles
 	}
 
 	x.moveFiles = func(fromPath, toPath string, overwrite bool) ([]string, error) {
-		return moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
+		newFiles, refused, err := moveFiles(x.log, x.DirMode, fromPath, toPath, overwrite)
+		x.refused = append(x.refused, refused...)
+
+		return newFiles, err
 	}
 }
 
@@ -525,7 +533,7 @@ func moveFiles( //nolint:cyclop,funlen
 	dirMode os.FileMode,
 	fromPath, toPath string,
 	overwrite bool,
-) ([]string, error) {
+) ([]string, []RefusedFile, error) {
 	if log == nil {
 		log = NoLogger()
 	}
@@ -536,12 +544,13 @@ func moveFiles( //nolint:cyclop,funlen
 
 	var (
 		newFiles = []string{}
+		refused  []RefusedFile
 		keepErr  error
 	)
 
 	files, err := listFiles(fromPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// If the "to path" is an existing archive file, remove the suffix to make a directory.
@@ -554,7 +563,7 @@ func moveFiles( //nolint:cyclop,funlen
 
 	err = os.MkdirAll(toPath, dirMode)
 	if err != nil {
-		return nil, fmt.Errorf("making final dir: %w", err)
+		return nil, nil, fmt.Errorf("making final dir: %w", err)
 	}
 
 	for _, file := range files {
@@ -570,6 +579,7 @@ func moveFiles( //nolint:cyclop,funlen
 
 		if exists && !overwrite {
 			log.Printf("Error: Renaming Temp File: %v to %v: (refusing to overwrite existing file)", file, newFile)
+			refused = append(refused, RefusedFile{Src: file, Dest: newFile})
 			// keep trying.
 			continue
 		}
@@ -595,7 +605,18 @@ func moveFiles( //nolint:cyclop,funlen
 	// Since this is the last step, we tried to rename all the files, bubble the
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
-	return newFiles, keepErr
+	return newFiles, refused, keepErr
+}
+
+// RefusedFile describes an extracted file that was not moved into place
+// because the destination path was already occupied and overwrite was false.
+// The occupying file was left untouched; the extracted copy was deleted
+// with the temporary folder.
+type RefusedFile struct {
+	// Src is the extracted copy's path in the temporary folder.
+	Src string
+	// Dest is the occupied destination path that was kept.
+	Dest string
 }
 
 // DeleteFiles obliterates things and logs. Use with caution.

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -477,7 +477,7 @@ func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, _, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
+	_, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -522,7 +522,7 @@ func TestMoveFilesZeroDirModeUsesDefault(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, _, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
+	_, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -587,8 +587,8 @@ func TestMoveFilesDoesNotDeleteSourceFile(t *testing.T) {
 	src := filepath.Join(dir, "a.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hi"), 0o600))
 
-	got, _, err := moveFiles(NoLogger(), 0o755, src, dir, false)
+	got, err := moveFiles(NoLogger(), 0o755, src, dir, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{src}, got)
+	assert.Equal(t, []string{src}, got.NewFiles)
 	require.FileExists(t, src)
 }

--- a/files_internal_test.go
+++ b/files_internal_test.go
@@ -477,7 +477,7 @@ func TestMoveFilesUsesProvidedDirMode(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
+	_, _, err := moveFiles(NoLogger(), 0o700, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -522,7 +522,7 @@ func TestMoveFilesZeroDirModeUsesDefault(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "a.txt"), []byte("hi"), 0o600))
 
 	dest := filepath.Join(t.TempDir(), "dest")
-	_, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
+	_, _, err := moveFiles(NoLogger(), 0, fromDir, dest, false)
 	require.NoError(t, err)
 
 	info, err := os.Stat(dest)
@@ -587,7 +587,7 @@ func TestMoveFilesDoesNotDeleteSourceFile(t *testing.T) {
 	src := filepath.Join(dir, "a.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hi"), 0o600))
 
-	got, err := moveFiles(NoLogger(), 0o755, src, dir, false)
+	got, _, err := moveFiles(NoLogger(), 0o755, src, dir, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{src}, got)
 	require.FileExists(t, src)

--- a/queue.go
+++ b/queue.go
@@ -77,6 +77,10 @@ type Response struct {
 	Archives ArchiveList
 	// Files written to final path.
 	NewFiles []string
+	// Refused lists files that were extracted but not moved into the final
+	// path because the destination was already occupied. The occupying file
+	// may have arrived with the download; it was kept. No error is set.
+	Refused []RefusedFile
 	// SkipOnRecursion lists paths that extractors copied into output (e.g. CUE sheet)
 	// and must not be re-extracted when recursing. Other files (e.g. CUE from a RAR) are still extracted.
 	SkipOnRecursion []string
@@ -196,6 +200,7 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 
 		err := x.decompressFiles(subResp)
 		resp.NewFiles = append(resp.NewFiles, subResp.NewFiles...)
+		resp.Refused = append(resp.Refused, subResp.Refused...)
 		resp.Size += subResp.Size
 
 		if err != nil {
@@ -330,6 +335,7 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 	// Combine the new Response with the existing response.
 	resp.Extras = nre.Archives
 	resp.Size += nre.Size
+	resp.Refused = append(resp.Refused, nre.Refused...)
 
 	if nre.NewFiles != nil {
 		resp.NewFiles = append(resp.NewFiles, nre.NewFiles...)
@@ -404,6 +410,8 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		resp.SkipOnRecursion = append(resp.SkipOnRecursion, xFile.SkipOnRecursion...)
 	}
 
+	resp.Refused = append(resp.Refused, xFile.refused...)
+
 	return bytes, files, archives, nil
 }
 
@@ -422,7 +430,10 @@ func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {
 	if !resp.X.TempFolder {
 		time.Sleep(fsSyncDelay) // Wait for file system to catch up/sync.
 		// If TempFolder is false then move the files back to the original location.
-		resp.NewFiles, err = x.MoveFiles(resp.Output, resp.X.Path, false)
+		var refused []RefusedFile
+
+		resp.NewFiles, refused, err = moveFiles(x.config, x.config.DirMode, resp.Output, resp.X.Path, false)
+		resp.Refused = append(resp.Refused, refused...)
 	}
 
 	if err != nil {
@@ -515,7 +526,9 @@ func (x *Xtractr) cleanTempFolder(resp *Response) {
 		return
 	}
 
-	newFiles, err := x.MoveFiles(resp.Output, newName, false)
+	newFiles, refused, err := moveFiles(x.config, x.config.DirMode, resp.Output, newName, false)
+	resp.Refused = append(resp.Refused, refused...)
+
 	if err != nil {
 		x.config.Printf("Error: Renaming Temporary Folder: %v", err)
 	} else {

--- a/queue.go
+++ b/queue.go
@@ -430,10 +430,11 @@ func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {
 	if !resp.X.TempFolder {
 		time.Sleep(fsSyncDelay) // Wait for file system to catch up/sync.
 		// If TempFolder is false then move the files back to the original location.
-		var refused []RefusedFile
+		var renamed Renamed
 
-		resp.NewFiles, refused, err = moveFiles(x.config, x.config.DirMode, resp.Output, resp.X.Path, false)
-		resp.Refused = append(resp.Refused, refused...)
+		renamed, err = x.RenameFiles(resp.Output, resp.X.Path, false)
+		resp.NewFiles = renamed.NewFiles
+		resp.Refused = append(resp.Refused, renamed.Refused...)
 	}
 
 	if err != nil {
@@ -526,15 +527,15 @@ func (x *Xtractr) cleanTempFolder(resp *Response) {
 		return
 	}
 
-	newFiles, refused, err := moveFiles(x.config, x.config.DirMode, resp.Output, newName, false)
-	resp.Refused = append(resp.Refused, refused...)
+	renamed, err := x.RenameFiles(resp.Output, newName, false)
+	resp.Refused = append(resp.Refused, renamed.Refused...)
 
 	if err != nil {
 		x.config.Printf("Error: Renaming Temporary Folder: %v", err)
 	} else {
 		x.config.Debugf("Renamed Temp Folder: %v -> %v", resp.Output, newName)
 		resp.Output = newName
-		resp.NewFiles = newFiles
+		resp.NewFiles = renamed.NewFiles
 	}
 
 	files, err := x.GetFileList(resp.X.Path)

--- a/queue.go
+++ b/queue.go
@@ -401,16 +401,18 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	}
 
 	bytes, files, archives, err := ExtractFile(xFile)
-	if err != nil {
-		x.DeleteFiles(resp.Output) // clean up the mess after an error and bail.
-		return bytes, files, archives, WrapExtractError(err, xFile, bytes, "")
-	}
 
 	if len(xFile.SkipOnRecursion) > 0 {
 		resp.SkipOnRecursion = append(resp.SkipOnRecursion, xFile.SkipOnRecursion...)
 	}
 
+	// Collect refusals before the error check so a failed extract still reports them.
 	resp.Refused = append(resp.Refused, xFile.refused...)
+
+	if err != nil {
+		x.DeleteFiles(resp.Output) // clean up the mess after an error and bail.
+		return bytes, files, archives, WrapExtractError(err, xFile, bytes, "")
+	}
 
 	return bytes, files, archives, nil
 }

--- a/queue.go
+++ b/queue.go
@@ -79,7 +79,10 @@ type Response struct {
 	NewFiles []string
 	// Refused lists files that were extracted but not moved into the final
 	// path because the destination was already occupied. The occupying file
-	// may have arrived with the download; it was kept. No error is set.
+	// may have arrived with the download; it was kept. A refusal alone does
+	// not set an error. The same logical file can appear twice (with different
+	// Src paths) if it is refused during the squash move and again during the
+	// final folder move; consumers should dedupe by Dest.
 	Refused []RefusedFile
 	// SkipOnRecursion lists paths that extractors copied into output (e.g. CUE sheet)
 	// and must not be re-extracted when recursing. Other files (e.g. CUE from a RAR) are still extracted.

--- a/queue_test.go
+++ b/queue_test.go
@@ -122,6 +122,68 @@ func TestNoTempFolder(t *testing.T) {
 	_ = os.RemoveAll(xFile.Path + xtractr.DefaultSuffix)
 }
 
+// TestRefusedExistingDestination is the reported bug, now observable: a file
+// already occupying the destination name is kept, the extracted copy is
+// discarded, the run reports success, and Response.Refused names the pair.
+func TestRefusedExistingDestination(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	testFileData, err := os.ReadFile(testFile)
+	require.NoError(t, err, "reading test data file failed")
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(dir, "archive.rar")))
+
+	const junk = "not from the archive"
+
+	blocker := filepath.Join(dir, "doc.go")
+	require.NoError(t, os.WriteFile(blocker, []byte(junk), 0o600))
+
+	queue := xtractr.NewQueue(&xtractr.Config{Logger: &testLogger{t: t}})
+	defer queue.Stop()
+
+	xFile := &xtractr.Xtract{
+		Name:       "Refused",
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: false,
+		DeleteOrig: false,
+		Password:   "some_password",
+		CBChannel:  make(chan *xtractr.Response),
+	}
+
+	_, err = queue.Extract(xFile)
+	require.NoError(t, err)
+
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+
+	var done *xtractr.Response
+
+loop:
+	for {
+		select {
+		case resp, ok := <-xFile.CBChannel:
+			require.True(t, ok, "callback channel closed before extraction completed")
+			require.NoError(t, resp.Error)
+
+			if resp.Done {
+				done = resp
+				break loop
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for extraction to complete")
+		}
+	}
+
+	require.Len(t, done.Refused, 1)
+	assert.Equal(t, filepath.Join(dir+xtractr.DefaultSuffix, "doc.go"), done.Refused[0].Src)
+	assert.Equal(t, blocker, done.Refused[0].Dest)
+
+	got, err := os.ReadFile(blocker)
+	require.NoError(t, err)
+	assert.Equal(t, junk, string(got))
+}
+
 // testSetupTestDir creates a temp directory with 4 copies of a rar archive in it.
 func testSetupTestDir(t *testing.T) string {
 	t.Helper()

--- a/refused_internal_test.go
+++ b/refused_internal_test.go
@@ -1,0 +1,286 @@
+package xtractr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testFileMover() *Xtractr {
+	return &Xtractr{config: &Config{Logger: NoLogger(), DirMode: 0o755}}
+}
+
+func TestMoveFilesRefusesOccupiedFile(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, false)
+	require.NoError(t, err)
+	assert.Empty(t, got.NewFiles)
+	require.Len(t, got.Refused, 1)
+	assert.Equal(t, src, got.Refused[0].Src)
+	assert.Equal(t, dest, got.Refused[0].Dest)
+
+	content, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("existing"), content)
+
+	_, err = os.Stat(fromDir)
+	require.ErrorIs(t, err, os.ErrNotExist, "temp folder must still be deleted after a refusal")
+}
+
+func TestMoveFilesRefusesOccupiedDirectory(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.Mkdir(dest, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "keep.txt"), []byte("still here"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, false)
+	require.NoError(t, err)
+	require.Len(t, got.Refused, 1)
+	assert.Equal(t, src, got.Refused[0].Src)
+	assert.Equal(t, dest, got.Refused[0].Dest)
+
+	content, err := os.ReadFile(filepath.Join(dest, "keep.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("still here"), content)
+}
+
+func TestMoveFilesOverwriteRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	dest := filepath.Join(toDir, "payload.bin")
+	src := filepath.Join(fromDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, true)
+	require.NoError(t, err)
+	assert.Empty(t, got.Refused)
+	require.Equal(t, []string{dest}, got.NewFiles)
+
+	content, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("extracted"), content)
+
+	_, err = os.Stat(src)
+	require.ErrorIs(t, err, os.ErrNotExist, "overwrite must still remove the temp copy")
+}
+
+func TestRenameFilesReportsRefused(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
+
+	renamed, err := testFileMover().RenameFiles(fromDir, toDir, false)
+	require.NoError(t, err)
+	assert.Empty(t, renamed.NewFiles)
+	require.Len(t, renamed.Refused, 1)
+	assert.Equal(t, src, renamed.Refused[0].Src)
+	assert.Equal(t, dest, renamed.Refused[0].Dest)
+}
+
+func TestMoveFilesOmitsRefused(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(fromDir, "payload.bin"), []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(toDir, "payload.bin"), []byte("existing"), 0o600))
+
+	files, err := testFileMover().MoveFiles(fromDir, toDir, false)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func skipWithoutSymlinks(t *testing.T) {
+	t.Helper()
+
+	err := os.Symlink("target", filepath.Join(t.TempDir(), "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+}
+
+func TestMoveFilesRefusesDanglingSymlink(t *testing.T) {
+	t.Parallel()
+	skipWithoutSymlinks(t)
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.Symlink(filepath.Join(toDir, "missing-target"), dest))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, false)
+	require.NoError(t, err)
+	assert.Empty(t, got.NewFiles)
+	require.Len(t, got.Refused, 1)
+	assert.Equal(t, dest, got.Refused[0].Dest)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
+func TestMoveFilesRefusesLiveSymlink(t *testing.T) {
+	t.Parallel()
+	skipWithoutSymlinks(t)
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+	victim := filepath.Join(toDir, "victim.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+	require.NoError(t, os.Symlink(victim, dest))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, false)
+	require.NoError(t, err)
+	require.Len(t, got.Refused, 1)
+
+	content, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), content)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+}
+
+func TestMoveFilesOverwriteReplacesDanglingSymlink(t *testing.T) {
+	t.Parallel()
+	skipWithoutSymlinks(t)
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.Symlink(filepath.Join(toDir, "missing-target"), dest))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, true)
+	require.NoError(t, err)
+	assert.Empty(t, got.Refused)
+	require.Equal(t, []string{dest}, got.NewFiles)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+
+	content, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("extracted"), content)
+}
+
+func TestMoveFilesOverwriteDoesNotFollowLiveSymlink(t *testing.T) {
+	t.Parallel()
+	skipWithoutSymlinks(t)
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+	victim := filepath.Join(toDir, "victim.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(victim, []byte("secret"), 0o600))
+	require.NoError(t, os.Symlink(victim, dest))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, true)
+	require.NoError(t, err)
+	assert.Empty(t, got.Refused)
+
+	content, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), content, "must not follow dest symlink")
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+
+	gotDest, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("extracted"), gotDest)
+}
+
+func TestMoveFilesStatErrorIsNotARefusal(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+
+	// Lstat of a path under a regular file fails with ENOTDIR, not ErrNotExist.
+	// With overwrite=false that must surface as an error, not a false refusal.
+	notADir := filepath.Join(toDir, "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("file"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, filepath.Join(notADir, "sub"), false)
+	require.Error(t, err)
+	assert.Empty(t, got.Refused, "a stat error is not an occupied destination")
+}
+
+func TestMoveFilesOverwriteDoesNotFollowDirSymlink(t *testing.T) {
+	t.Parallel()
+	skipWithoutSymlinks(t)
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+	realDir := filepath.Join(toDir, "real")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.Mkdir(realDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "keep.txt"), []byte("still here"), 0o600))
+	require.NoError(t, os.Symlink(realDir, dest))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, true)
+	require.NoError(t, err)
+	assert.Empty(t, got.Refused)
+
+	content, err := os.ReadFile(filepath.Join(realDir, "keep.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("still here"), content)
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
+
+	gotDest, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("extracted"), gotDest)
+}

--- a/refused_internal_test.go
+++ b/refused_internal_test.go
@@ -238,19 +238,34 @@ func TestMoveFilesOverwriteDoesNotFollowLiveSymlink(t *testing.T) {
 func TestMoveFilesStatErrorIsNotARefusal(t *testing.T) {
 	t.Parallel()
 
-	fromDir := t.TempDir()
-	toDir := t.TempDir()
-	src := filepath.Join(fromDir, "payload.bin")
-	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	// overwrite does not change the skip-and-error path: a non-NotExist Lstat
+	// failure is not occupancy, so the file is not renamed and not refused.
+	cases := []struct {
+		name      string
+		overwrite bool
+	}{
+		{name: "overwrite false", overwrite: false},
+		{name: "overwrite true", overwrite: true},
+	}
 
-	// Lstat of a path under a regular file fails with ENOTDIR, not ErrNotExist.
-	// With overwrite=false that must surface as an error, not a false refusal.
-	notADir := filepath.Join(toDir, "not-a-dir")
-	require.NoError(t, os.WriteFile(notADir, []byte("file"), 0o600))
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := moveFiles(NoLogger(), 0o755, fromDir, filepath.Join(notADir, "sub"), false)
-	require.Error(t, err)
-	assert.Empty(t, got.Refused, "a stat error is not an occupied destination")
+			fromDir := t.TempDir()
+			toDir := t.TempDir()
+			src := filepath.Join(fromDir, "payload.bin")
+			require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+
+			// Lstat of a path under a regular file fails with ENOTDIR, not ErrNotExist.
+			notADir := filepath.Join(toDir, "not-a-dir")
+			require.NoError(t, os.WriteFile(notADir, []byte("file"), 0o600))
+
+			got, err := moveFiles(NoLogger(), 0o755, fromDir, filepath.Join(notADir, "sub"), testCase.overwrite)
+			require.Error(t, err)
+			assert.Empty(t, got.Refused, "a stat error is not an occupied destination")
+		})
+	}
 }
 
 func TestMoveFilesOverwriteDoesNotFollowDirSymlink(t *testing.T) {

--- a/refused_internal_test.go
+++ b/refused_internal_test.go
@@ -284,3 +284,50 @@ func TestMoveFilesOverwriteDoesNotFollowDirSymlink(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("extracted"), gotDest)
 }
+
+// Copilot: a move failure must not delete the temp source. Before this fix,
+// the unconditional deleteFiles(fromPath) ran even when keepErr was set,
+// destroying the extracted data along with the partial destination result.
+func TestMoveFilesMoveErrorPreservesSource(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+
+	src := filepath.Join(fromDir, "payload.bin")
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+
+	// Dest is a non-empty directory. os.Rename(file, nonemptydir) fails, so
+	// keepErr is set in the loop while fromPath still holds the source.
+	dest := filepath.Join(toDir, "payload.bin")
+	require.NoError(t, os.Mkdir(dest, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "keep.txt"), []byte("keep"), 0o600))
+
+	_, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, true)
+	require.Error(t, err)
+
+	// The temp source must survive so the data is recoverable.
+	require.FileExists(t, src)
+	require.DirExists(t, fromDir)
+}
+
+// A refusal is not an error: the destination is complete (occupied), so the
+// temp source is still cleaned up. Only genuine move failures preserve it.
+func TestMoveFilesRefusalStillCleansSource(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+	src := filepath.Join(fromDir, "payload.bin")
+	dest := filepath.Join(toDir, "payload.bin")
+
+	require.NoError(t, os.WriteFile(src, []byte("extracted"), 0o600))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
+
+	got, err := moveFiles(NoLogger(), 0o755, fromDir, toDir, false)
+	require.NoError(t, err)
+	require.Len(t, got.Refused, 1)
+
+	// The moved (refused) file's temp copy is gone; fromPath itself is removed.
+	require.NoDirExists(t, fromDir)
+}


### PR DESCRIPTION
When a file, symlink or directory already exists at the destination, the extraction is always reported as successful — regardless of whether overwrite is true or false. This change at least tells the library consumer which files were refused. A consumer can make decisions, like deleting the occupying files, before starting a new extraction.

`MoveFiles` is deprecated in favor of `RenameFiles`, which returns a `Renamed` struct (`NewFiles` + `Refused`) so the result can grow without another signature break.

## Behavior changes

These are bundled with the reporting feature and are observable for consumers:

1. **Dangling destination symlink is occupied.** Occupancy is checked with `Lstat`, not `Stat`. With `overwrite=false`, a dangling symlink at the destination is refused (previously `Stat` followed it, reported not-exist, and `renameFile` replaced the symlink).
2. **Cross-device copy fallback does not follow a destination symlink.** The fallback used `openFile` with `O_TRUNC`, which followed a dest symlink and wrote through it. It now uses the no-follow `openExtractFile` from #175.
3. **Temp folder survives a failed move.** `moveFiles` no longer deletes the temp source when a move or destination `Lstat` fails, so a partial destination is recoverable. Refusals (occupied dest, not an error) still clean up the temp source.

A refusal alone does not set `Response.Error`. A failed extraction can still carry both `Error` and `Refused`. The same logical file can appear twice in `Refused` (different `Src` paths) if it is refused during the squash move and again during the final folder move; consumers should dedupe by `Dest`.