### PR TITLE
Report final move destinations on Response

### DIFF
--- a/files.go
+++ b/files.go
@@ -527,6 +527,9 @@ type Renamed struct {
 	NewFiles []string
 	// Refused lists files that were not moved because the destination was occupied.
 	Refused []RefusedFile
+	// Dest is the directory files were moved into (toPath, after any archive
+	// extension strip). It is "" when no files were moved.
+	Dest string
 }
 
 // RefusedFile describes an extracted file that was not moved into place
@@ -671,7 +674,16 @@ func moveFiles( //nolint:cyclop,funlen
 	// Since this is the last step, we tried to rename all the files, bubble the
 	// os.Rename error up, so it gets flagged as failed. It may have worked, but
 	// it should get attention.
-	return Renamed{NewFiles: newFiles, Refused: refused}, keepErr
+	//
+	// Dest is set whenever the move step completed (keepErr == nil): the
+	// destination is known even if NewFiles is empty (e.g. the lone top-level
+	// file was already in place, so nothing needed renaming).
+	dest := ""
+	if keepErr == nil {
+		dest = toPath
+	}
+
+	return Renamed{NewFiles: newFiles, Refused: refused, Dest: dest}, keepErr
 }
 
 // DeleteFiles obliterates things and logs. Use with caution.

--- a/files.go
+++ b/files.go
@@ -528,7 +528,9 @@ type Renamed struct {
 	// Refused lists files that were not moved because the destination was occupied.
 	Refused []RefusedFile
 	// Dest is the directory files were moved into (toPath, after any archive
-	// extension strip). It is "" when no files were moved.
+	// extension strip). It is "" when the move did not complete (err != nil).
+	// It is set whenever the move completes without error, even when NewFiles
+	// is empty (e.g. a squash where files were already in place).
 	Dest string
 }
 

--- a/queue.go
+++ b/queue.go
@@ -101,14 +101,16 @@ type Response struct {
 	// Src paths) if it is refused during the squash move and again during the
 	// final folder move; consumers should dedupe by Dest.
 	Refused []RefusedFile
-	// FinalDest is the directory extracted files were moved into. When
-	// TempFolder is false this is the (archive-extension-stripped) extraction
-	// path; when the temp folder is kept it is the final unsuffixed output
-	// folder. It is "" before the final move runs (in-progress callbacks) or
-	// when nothing was moved into place. Consumers use it to distinguish
-	// files that belong to the download from interrupted-extraction remnants
-	// without re-deriving the move destination.
-	FinalDest string
+	// FinalDests maps each input folder that produced a completed final move
+	// to the directory its files were moved into. The key is the per-folder
+	// X.Path (a key of Archives), so a caller can correlate each destination
+	// — and each Refused entry — back to the folder that produced it.
+	// A folder is omitted until its move completes without error (in-progress
+	// callbacks, and any move that returned an error). When TempFolder is true
+	// the whole output tree is renamed once, so this map has a single entry
+	// keyed by the original search Path. Dest is recorded even when NewFiles
+	// is empty (every destination already occupied, or a no-op squash).
+	FinalDests map[string]string
 	// SkipOnRecursion lists paths that extractors copied into output (e.g. CUE sheet)
 	// and must not be re-extracted when recursing. Other files (e.g. CUE from a RAR) are still extracted.
 	SkipOnRecursion []string
@@ -233,10 +235,7 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 		resp.NewFiles = append(resp.NewFiles, subResp.NewFiles...)
 		resp.Refused = append(resp.Refused, subResp.Refused...)
 		resp.Size += subResp.Size
-
-		if subResp.FinalDest != "" {
-			resp.FinalDest = subResp.FinalDest
-		}
+		mergeFinalDests(resp, subResp)
 
 		if err != nil {
 			return err
@@ -488,7 +487,7 @@ func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {
 		renamed, err = x.RenameFiles(resp.Output, resp.X.Path, false)
 		resp.NewFiles = renamed.NewFiles
 		resp.Refused = append(resp.Refused, renamed.Refused...)
-		resp.FinalDest = renamed.Dest
+		recordFinalDest(resp, resp.X.Path, renamed.Dest)
 	}
 
 	if err != nil {
@@ -590,7 +589,7 @@ func (x *Xtractr) cleanTempFolder(resp *Response) {
 		x.config.Debugf("Renamed Temp Folder: %v -> %v", resp.Output, newName)
 		resp.Output = newName
 		resp.NewFiles = renamed.NewFiles
-		resp.FinalDest = renamed.Dest
+		recordFinalDest(resp, resp.X.Path, renamed.Dest)
 	}
 
 	files, err := x.GetFileList(resp.X.Path)
@@ -602,5 +601,29 @@ func (x *Xtractr) cleanTempFolder(resp *Response) {
 	if len(files) == 0 {
 		// If the original path is empty, delete it.
 		x.DeleteFiles(resp.X.Path)
+	}
+}
+
+// recordFinalDest records a completed move. Empty dir or dest is ignored so a
+// failed move (Renamed.Dest == "") never occupies a map slot.
+func recordFinalDest(resp *Response, dir, dest string) {
+	if resp == nil || dir == "" || dest == "" {
+		return
+	}
+
+	if resp.FinalDests == nil {
+		resp.FinalDests = make(map[string]string)
+	}
+
+	resp.FinalDests[dir] = dest
+}
+
+func mergeFinalDests(dst, src *Response) {
+	if dst == nil || src == nil {
+		return
+	}
+
+	for dir, dest := range src.FinalDests {
+		recordFinalDest(dst, dir, dest)
 	}
 }

--- a/queue.go
+++ b/queue.go
@@ -68,23 +68,31 @@ type Xtract struct {
 // call by checking Response.Done. false = started, true = finished. When done=false
 // the only other meaningful data provided is the re.Archives, re.Output and re.Queue.
 type Response struct {
-	// Extract Started (false) or Finished (true).
+	// Done is false on the start notification and true on the single finished
+	// callback. Only the finished callback carries the full result below.
 	Done bool
-	// Size of data written.
+	// Size is the total uncompressed bytes written to disk across all archives,
+	// including Extras. Only set when Done is true.
 	Size uint64
-	// Temporary output folder.
+	// Output is the temporary folder files were extracted into (Path+Suffix,
+	// rebased onto ExtractTo when set). When TempFolder is true it is updated
+	// to the final renamed folder; when TempFolder is false its contents are
+	// moved out and the folder removed, so it is empty by the time Done is true.
 	Output string
-	// Items still in queue.
+	// Queued is how many extractions are still waiting in the queue at the
+	// moment this response is sent. Useful for progress display.
 	Queued int
-	// When this extract began.
+	// Started is when extraction of this item began.
 	Started time.Time
-	// Elapsed extraction duration. ie. How long it took.
+	// Elapsed is how long the extraction took. Only set when Done is true.
 	Elapsed time.Duration
-	// Extra archives extracted from within an archive.
+	// Extras are archives found inside an extracted archive and also extracted
+	// (skipped when DisableRecursion is true).
 	Extras ArchiveList
-	// Initial archives found and extracted.
+	// Archives are the archives found in the search path and extracted.
 	Archives ArchiveList
-	// Files written to final path.
+	// NewFiles lists the final paths of files that were moved into place.
+	// Only set when Done is true.
 	NewFiles []string
 	// Refused lists files that were extracted but not moved into the final
 	// path because the destination was already occupied. The occupying file
@@ -93,6 +101,14 @@ type Response struct {
 	// Src paths) if it is refused during the squash move and again during the
 	// final folder move; consumers should dedupe by Dest.
 	Refused []RefusedFile
+	// FinalDest is the directory extracted files were moved into. When
+	// TempFolder is false this is the (archive-extension-stripped) extraction
+	// path; when the temp folder is kept it is the final unsuffixed output
+	// folder. It is "" before the final move runs (in-progress callbacks) or
+	// when nothing was moved into place. Consumers use it to distinguish
+	// files that belong to the download from interrupted-extraction remnants
+	// without re-deriving the move destination.
+	FinalDest string
 	// SkipOnRecursion lists paths that extractors copied into output (e.g. CUE sheet)
 	// and must not be re-extracted when recursing. Other files (e.g. CUE from a RAR) are still extracted.
 	SkipOnRecursion []string
@@ -217,6 +233,10 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 		resp.NewFiles = append(resp.NewFiles, subResp.NewFiles...)
 		resp.Refused = append(resp.Refused, subResp.Refused...)
 		resp.Size += subResp.Size
+
+		if subResp.FinalDest != "" {
+			resp.FinalDest = subResp.FinalDest
+		}
 
 		if err != nil {
 			return err
@@ -468,6 +488,7 @@ func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {
 		renamed, err = x.RenameFiles(resp.Output, resp.X.Path, false)
 		resp.NewFiles = renamed.NewFiles
 		resp.Refused = append(resp.Refused, renamed.Refused...)
+		resp.FinalDest = renamed.Dest
 	}
 
 	if err != nil {
@@ -569,6 +590,7 @@ func (x *Xtractr) cleanTempFolder(resp *Response) {
 		x.config.Debugf("Renamed Temp Folder: %v -> %v", resp.Output, newName)
 		resp.Output = newName
 		resp.NewFiles = renamed.NewFiles
+		resp.FinalDest = renamed.Dest
 	}
 
 	files, err := x.GetFileList(resp.X.Path)

--- a/queue_test.go
+++ b/queue_test.go
@@ -184,6 +184,95 @@ loop:
 	assert.Equal(t, junk, string(got))
 }
 
+// TestFinalDestMovedBack reports the move destination when the temp folder is
+// moved back into the download path (TempFolder=false).
+func TestFinalDestMovedBack(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	testFileData, err := os.ReadFile(testFile)
+	require.NoError(t, err, "reading test data file failed")
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(dir, "archive.rar")))
+
+	queue := xtractr.NewQueue(&xtractr.Config{Logger: &testLogger{t: t}})
+	defer queue.Stop()
+
+	xFile := &xtractr.Xtract{
+		Name:       "FinalDest",
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: false,
+		DeleteOrig: false,
+		Password:   "some_password",
+		CBChannel:  make(chan *xtractr.Response),
+	}
+
+	_, err = queue.Extract(xFile)
+	require.NoError(t, err)
+
+	done := waitFinalResponse(t, xFile.CBChannel)
+	require.NoError(t, done.Error)
+	// Move-back writes into the search path itself; the archive-extension
+	// strip only applies to the kept temp folder's final name.
+	assert.Equal(t, dir, done.FinalDest)
+	assert.DirExists(t, done.FinalDest)
+	assert.FileExists(t, filepath.Join(dir, "doc.go"))
+}
+
+// TestFinalDestTempFolder reports the final unsuffixed output folder when the
+// temp folder is kept (TempFolder=true).
+func TestFinalDestTempFolder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	testFileData, err := os.ReadFile(testFile)
+	require.NoError(t, err, "reading test data file failed")
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(dir, "archive.rar")))
+
+	queue := xtractr.NewQueue(&xtractr.Config{Logger: &testLogger{t: t}, TryNames: true})
+	defer queue.Stop()
+
+	xFile := &xtractr.Xtract{
+		Name:       "FinalDestTmp",
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: true,
+		DeleteOrig: false,
+		Password:   "some_password",
+		CBChannel:  make(chan *xtractr.Response),
+	}
+
+	_, err = queue.Extract(xFile)
+	require.NoError(t, err)
+
+	done := waitFinalResponse(t, xFile.CBChannel)
+	require.NoError(t, done.Error)
+	require.NotEmpty(t, done.FinalDest, "FinalDest must name the moved output folder")
+	assert.NotContains(t, done.FinalDest, xtractr.DefaultSuffix)
+	assert.Equal(t, done.Output, done.FinalDest)
+	assert.DirExists(t, done.FinalDest)
+}
+
+func waitFinalResponse(t *testing.T, chResponse chan *xtractr.Response) *xtractr.Response {
+	t.Helper()
+
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case resp, ok := <-chResponse:
+			require.True(t, ok, "callback channel closed before extraction completed")
+
+			if resp.Done {
+				return resp
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for extraction to complete")
+		}
+	}
+}
+
 // testSetupTestDir creates a temp directory with 4 copies of a rar archive in it.
 func testSetupTestDir(t *testing.T) string {
 	t.Helper()

--- a/queue_test.go
+++ b/queue_test.go
@@ -214,8 +214,8 @@ func TestFinalDestMovedBack(t *testing.T) {
 	require.NoError(t, done.Error)
 	// Move-back writes into the search path itself; the archive-extension
 	// strip only applies to the kept temp folder's final name.
-	assert.Equal(t, dir, done.FinalDest)
-	assert.DirExists(t, done.FinalDest)
+	assert.Equal(t, map[string]string{dir: dir}, done.FinalDests)
+	assert.DirExists(t, done.FinalDests[dir])
 	assert.FileExists(t, filepath.Join(dir, "doc.go"))
 }
 
@@ -247,16 +247,100 @@ func TestFinalDestTempFolder(t *testing.T) {
 
 	done := waitFinalResponse(t, xFile.CBChannel)
 	require.NoError(t, done.Error)
-	require.NotEmpty(t, done.FinalDest, "FinalDest must name the moved output folder")
-	assert.NotContains(t, done.FinalDest, xtractr.DefaultSuffix)
-	assert.Equal(t, done.Output, done.FinalDest)
-	assert.DirExists(t, done.FinalDest)
+	require.NotEmpty(t, done.FinalDests, "FinalDests must name the moved output folder")
+	assert.Equal(t, map[string]string{dir: done.Output}, done.FinalDests)
+	assert.NotContains(t, done.FinalDests[dir], xtractr.DefaultSuffix)
+	assert.DirExists(t, done.FinalDests[dir])
+}
+
+// TestFinalDestsMultiFolder reports each per-folder destination when a search
+// path holds archives in more than one subfolder (a multi-key ArchiveList).
+func TestFinalDestsMultiFolder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	testFileData, err := os.ReadFile(testFile)
+	require.NoError(t, err, "reading test data file failed")
+
+	subA := filepath.Join(dir, "cd1")
+	subB := filepath.Join(dir, "cd2")
+
+	require.NoError(t, os.MkdirAll(subA, 0o750))
+	require.NoError(t, os.MkdirAll(subB, 0o750))
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(subA, "archive.rar")))
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(subB, "archive.rar")))
+
+	queue := xtractr.NewQueue(&xtractr.Config{Logger: &testLogger{t: t}})
+	defer queue.Stop()
+
+	xFile := &xtractr.Xtract{
+		Name:       "FinalDestMulti",
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: false,
+		DeleteOrig: false,
+		Password:   "some_password",
+		CBChannel:  make(chan *xtractr.Response),
+	}
+
+	_, err = queue.Extract(xFile)
+	require.NoError(t, err)
+
+	done := waitFinalResponse(t, xFile.CBChannel)
+	require.NoError(t, done.Error)
+	// Both per-folder destinations are reported, keyed by their input folder.
+	assert.Equal(t, map[string]string{subA: subA, subB: subB}, done.FinalDests)
+	assert.DirExists(t, done.FinalDests[subA])
+	assert.DirExists(t, done.FinalDests[subB])
+}
+
+// TestFinalDestsTempFolderMultiFolder keeps one destination for the renamed
+// output tree, keyed by the original search path (TempFolder=true does not
+// produce a per-subfolder entry).
+func TestFinalDestsTempFolderMultiFolder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	testFileData, err := os.ReadFile(testFile)
+	require.NoError(t, err, "reading test data file failed")
+
+	subA := filepath.Join(dir, "cd1")
+	subB := filepath.Join(dir, "cd2")
+
+	require.NoError(t, os.MkdirAll(subA, 0o750))
+	require.NoError(t, os.MkdirAll(subB, 0o750))
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(subA, "archive.rar")))
+	require.NoError(t, makeFile(t, testFileData, filepath.Join(subB, "archive.rar")))
+
+	queue := xtractr.NewQueue(&xtractr.Config{Logger: &testLogger{t: t}, TryNames: true})
+	defer queue.Stop()
+
+	xFile := &xtractr.Xtract{
+		Name:       "FinalDestTmpMulti",
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: true,
+		DeleteOrig: false,
+		Password:   "some_password",
+		CBChannel:  make(chan *xtractr.Response),
+	}
+
+	_, err = queue.Extract(xFile)
+	require.NoError(t, err)
+
+	done := waitFinalResponse(t, xFile.CBChannel)
+	require.NoError(t, done.Error)
+	require.Len(t, done.FinalDests, 1)
+	assert.Equal(t, done.Output, done.FinalDests[dir])
+	assert.NotContains(t, done.FinalDests[dir], xtractr.DefaultSuffix)
+	assert.DirExists(t, done.FinalDests[dir])
 }
 
 func waitFinalResponse(t *testing.T, chResponse chan *xtractr.Response) *xtractr.Response {
 	t.Helper()
 
-	timeout := time.NewTimer(20 * time.Second)
+	// Multi-folder move-back sleeps fsSyncDelay (10s) per folder.
+	timeout := time.NewTimer(60 * time.Second)
 	defer timeout.Stop()
 
 	for {

--- a/rar_internal_test.go
+++ b/rar_internal_test.go
@@ -1,0 +1,32 @@
+package xtractr
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// tryRAR copies the attempt tracker back onto the caller's XFile. Without that
+// assignment, ExtractRAR's passwordless fallback left prog on a stack copy, and
+// ExtractFile's signature retry resumed from the pre-final counters.
+func TestTryRARCopiesProgress(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{
+		FilePath:  filepath.Join("test_data", "symlink.rar"),
+		OutputDir: t.TempDir(),
+		FileMode:  DefaultFileMode,
+		DirMode:   DefaultDirMode,
+	}
+	stale := xFile.newProgress(0, 1, 0)
+	stale.Wrote = 99
+	stale.Files = 7
+
+	size, files, _, err := tryRAR(xFile, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+	require.NotNil(t, xFile.prog)
+	require.NotSame(t, stale, xFile.prog, "passwordless extract must install the attempt tracker")
+	require.Equal(t, size, xFile.prog.Wrote)
+}

--- a/rar_internal_test.go
+++ b/rar_internal_test.go
@@ -1,6 +1,7 @@
 package xtractr
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,6 +13,13 @@ import (
 // ExtractFile's signature retry resumed from the pre-final counters.
 func TestTryRARCopiesProgress(t *testing.T) {
 	t.Parallel()
+
+	tmp := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(tmp, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
 
 	xFile := &XFile{
 		FilePath:  filepath.Join("test_data", "symlink.rar"),

--- a/refused_internal_test.go
+++ b/refused_internal_test.go
@@ -103,6 +103,7 @@ func TestRenameFilesReportsRefused(t *testing.T) {
 	require.Len(t, renamed.Refused, 1)
 	assert.Equal(t, src, renamed.Refused[0].Src)
 	assert.Equal(t, dest, renamed.Refused[0].Dest)
+	assert.Equal(t, toDir, renamed.Dest, "Dest is set when the move completes even if every file was refused")
 }
 
 func TestMoveFilesOmitsRefused(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Renamed` gains `Dest`: the post-archive-extension-strip directory files were moved into. Set when the move completes without error (`keepErr == nil`), even if `NewFiles` is empty (every dest already occupied, or a no-op squash). Omitted (`""`) when the move errors.
- `Response` gains `FinalDests map[string]string`: input folder (`X.Path`, a key of `Archives`) → the directory that folder's files were moved into. A folder is omitted until its move completes without error. Move-back reports every parent directory; `TempFolder=true` collapses to one entry keyed by the original search path (the whole output tree is renamed once).
- Populated at the final-move sites (`cleanupProcessedArchives`, `cleanTempFolder`) and merged up from per-folder extracts in `decompressFolders`. Nested extras do not get their own destinations; they live in the parent's output until that move.
- Expanded the `Response` field docs to say which fields are only set when `Done` is true.
- Includes `rar_internal_test.go` (`TestTryRARCopiesProgress`): passwordless RAR fallback installs the attempt tracker on the caller's `XFile`. Skips when the platform cannot create symlinks.

Motivation: Unpackerr's interrupted-extraction recovery currently re-derives this destination (move-back path, kept temp folder's final name, `extract_path` rebase), forcing it to mirror `getTempFolderFinalName` and keep a dest-root allowlist. Reading `Response.FinalDests` removes that duplication and keeps multi-folder extracts correlated to the folder that produced each dest. Additive only; v0.5.0 consumers are unaffected.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run ./...` clean
- [x] `go test ./...` passes (full suite)
- [x] `TestFinalDestMovedBack` — move-back dest keyed by search path
- [x] `TestFinalDestTempFolder` — kept temp folder, `FinalDests[path] == Output` after rename (`TryNames`)
- [x] `TestFinalDestsMultiFolder` — two subfolders, move-back, both keys present
- [x] `TestFinalDestsTempFolderMultiFolder` — two subfolders, `TempFolder=true`, one dest keyed by search path
- [x] `TestRenameFilesReportsRefused` — `Dest` set when every file was refused
- [x] `TestTryRARCopiesProgress` passes (skips without symlink support)