### PR TITLE
Skip symlink archives and cap nested extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,17 @@
 
 Go Library for Queuing and Extracting ZIP, RAR, GZ, BZ2, TAR,
 TGZ, TBZ2, 7Z, ISO ([and other](https://github.com/golift/xtractr/issues/44)) compressed archive files.
-Can also be used ad-hoc for direct decompression and extraction. See docs.
+Can also be used ad-hoc for direct decompression and extraction. See [GoDoc](https://pkg.go.dev/golift.io/xtractr).
 
--   [GoDoc](https://pkg.go.dev/golift.io/xtractr)
--   Works on Linux, Windows, FreeBSD and macOS **without Cgo**.
--   Supports 32 and 64 bit architectures.
--   Decrypts RAR and 7-Zip archives with passwords.
--   Extracts ISO images (ISO9660 and UDF volumes).
--   Splits FLAC+CUE sheets into individual tracks.
--   Detects non-UTF8 zip filenames automatically.
+- [GoDoc](https://pkg.go.dev/golift.io/xtractr)
+- Works on Linux, Windows, FreeBSD and macOS **without Cgo**.
+- Supports 32 and 64 bit architectures.
+- Decrypts RAR and 7-Zip archives with passwords.
+- Extracts ISO images (ISO9660 and UDF volumes).
+- Splits FLAC+CUE sheets into individual tracks.
+- Detects non-UTF8 zip filenames automatically.
 
-Optional extraction caps on `XFile`, `Xtract`, and `Config` (`0` means unlimited):
-
--   `MaxBytes` — uncompressed bytes written for one archive
--   `MaxFiles` — files, directories, and symlinks created for one archive
--   `MaxRatio` — `bytesWritten / archiveFileSize`
-
-Exceeding a cap returns `ErrMaxBytes`, `ErrMaxFiles`, or `ErrMaxRatio` and stops the extract. Queue jobs inherit `Config` values when the `Xtract` field is `0`.
-
-`MaxFiles` counts claimed-plus-created entries, not just created. An archive whose header claims more entries than `MaxFiles` fails fast with `ErrMaxFiles` even when every entry already exists on disk and nothing new would be created. This fail-closed default is intentional for a security cap: headers can understate, so the runtime write path always re-checks regardless of what the header claimed.
-
-# Interface
+## Interface
 
 This library provides a queue, and a common interface to extract files.
 It does not do the heavy lifting, and relies on these libraries to extract files:
@@ -43,9 +33,9 @@ It does not do the heavy lifting, and relies on these libraries to extract files
 
 `Zip`, `Gzip`, `Tar` and `Bzip` are all handled by the standard Go library.
 
-# Examples
+## Examples
 
-## Example 1 - Queue
+### Example 1 - Queue
 
 ```golang
 package main
@@ -98,14 +88,14 @@ func main() {
 	response := make(chan *xtractr.Response)
 	// This sends an item into the extraction queue (buffered channel).
 	q.Extract(&xtractr.Xtract{
-		Name:       "my archive",    // name is not import to this library.
-		SearchPath: "/tmp/archives", // can also be a direct file.
-		CBChannel:  response,        // queue responses are sent here.
+		Name:      "my archive",    // unused by this library.
+		Path:      "/tmp/archives", // can also be a direct file.
+		CBChannel: response,        // queue responses are sent here.
 	})
 
 	// Queue always sends two responses. 1 on start and again when finished (error or not)
 	resp := <-response
-	log.Infof("Extraction started: %s", strings.Join(resp.Archives, ", "))
+	log.Infof("Extraction started: %s", strings.Join(resp.Archives.List(), ", "))
 
 	resp = <-response
 	if resp.Error != nil {
@@ -118,7 +108,7 @@ func main() {
 }
 ```
 
-## Example 2 - Direct
+### Example 2 - Direct
 
 This example shows `ExtractFile()` with a very simple `XFile`.
 You can choose output path, as well as file and dir modes.
@@ -126,16 +116,17 @@ Failing to provide `OutputDir` results in unexpected behavior.
 `ExtractFile()` attempts to identify the type of file. If you
 know the file type you may call the direct method instead:
 
- - `ExtractZIP(*XFile)`
- - `ExtractRAR(*XFile)`
- - `ExtractTar(*XFile)`
- - `ExtractGzip(*XFile)`
- - `ExtractBzip(*XFile)`
- - `ExtractTarGzip(*XFile)`
- - `ExtractTarBzip(*XFile)`
- - `Extract7z(*XFile)`
- - `ExtractISO(*XFile)`
- - `SplitCueFlac(*XFile)`
+- `ExtractZIP(*XFile)`
+- `ExtractRAR(*XFile)`
+- `ExtractTar(*XFile)`
+- `ExtractGzip(*XFile)`
+- `ExtractBzip(*XFile)`
+- `ExtractTarGzip(*XFile)`
+- `ExtractTarBzip(*XFile)`
+- `Extract7z(*XFile)`
+- `ExtractISO(*XFile)`
+- `SplitCueFlac(*XFile)`
+- etc.. there's more than this.
 
 ```golang
 package main
@@ -155,7 +146,7 @@ func main() {
 
 	// size is how many bytes were written.
 	// files may be nil, but will contain any files written (even with an error).
-	size, files, err := xtractr.ExtractFile(x)
+	size, files, _, err := xtractr.ExtractFile(x)
 	if err != nil || files == nil {
 		log.Fatal(size, files, err)
 	}
@@ -164,14 +155,81 @@ func main() {
 }
 ```
 
-This is what `XFile` looks like (today at least):
+## XFile Input
+
+This is what `XFile` looks like (yesterday at least):
+
 ```golang
 // XFile defines the data needed to extract an archive.
 type XFile struct {
-	FilePath  string      // Path to archive being extracted.
-	OutputDir string      // Folder to extract archive into.
-	FileMode  os.FileMode // Write files with this mode.
-	DirMode   os.FileMode // Write folders with this mode.
-	Password  string      // (RAR/7z) Archive password. Blank for none.
+	// Path to archive being extracted.
+	FilePath string
+	// Folder to extract archive into.
+	OutputDir string
+	// Write files with this mode.
+	FileMode os.FileMode
+	// Write folders with this mode.
+	DirMode os.FileMode
+	// Suffix brands cross-device copy siblings as a known extra extension
+	// (e.g. movie.mkv.xtractr_partial). Empty uses DefaultSuffix.
+	Suffix string
+	// (RAR/7z) Archive password. Blank for none. Gets prepended to Passwords, below.
+	Password string
+	// (RAR/7z) Archive passwords (to try multiple).
+	Passwords []string
+	// FileWorkers controls how many files within a single archive are extracted
+	// concurrently. Only effective for random-access formats (ZIP, 7z).
+	// Streaming formats ignore this. 0 or 1 = sequential (current behavior).
+	// Total concurrent I/O when using the queue = Config.Parallel * FileWorkers.
+	FileWorkers int
+	// MaxBytes is the maximum uncompressed bytes written for this archive.
+	// 0 means unlimited.
+	MaxBytes uint64
+	// MaxFiles is the maximum files, directories, and symlinks created for this
+	// archive. 0 means unlimited.
+	MaxFiles int
+	// MaxRatio is the maximum bytesWritten / archiveFileSize. 0 means unlimited.
+	MaxRatio float64
+	// AllowSymlinks allows FilePath to be a symbolic link to an archive.
+	AllowSymlinks bool
+	// Progress is called periodically during file extraction.
+	// Contains info about the progress of the extraction.
+	// This is not called if an Updates channel is also provided.
+	Progress func(Progress)
+	// If an Updates channel is provided, all Progress updates are sent to it.
+	// Contains info about the progress of the extraction.
+	Updates chan Progress
+	// If the archive only has one directory in the root, then setting
+	// this true will cause the extracted content to be moved into the
+	// output folder, and the root folder in the archive to be removed.
+	SquashRoot bool
+	// SkipOnRecursion, if set by an extractor, lists paths that were copied into
+	// the output (e.g. a CUE sheet) and must not be re-extracted when recursing.
+	SkipOnRecursion []string
 }
 ```
+
+### Input Safety
+
+Per-archive caps on `XFile`, `Xtract`, and `Config` (`0` means unlimited):
+
+- `MaxBytes` — uncompressed bytes written for one archive
+- `MaxFiles` — files, directories, and symlinks created for one archive
+- `MaxRatio` — `bytesWritten / archiveFileSize`
+
+Queue extras caps on `Xtract` and `Config` (`0` inherits `Config`, then unlimited):
+
+- `MaxNested` — archives extracted from one source folder's extras pass
+- `ExtrasMaxDepth` — how deep that extras walk goes
+
+`AllowSymlinks` is on `Filter`/`Xtract` and `XFile` (default false). When set, the initial search may include
+symlink-named archives. The extras pass never follows archive-member links.
+
+Exceeding `MaxBytes`/`MaxFiles`/`MaxRatio` returns those errors and stops the extract.
+Exceeding `MaxNested` returns `ErrMaxNested` and deletes that folder's extract output.
+Queue jobs inherit `Config` values when the `Xtract` field is `0`.
+
+`MaxFiles` counts claimed-plus-created entries, not just created. An archive whose header claims more entries
+than `MaxFiles` fails fast with `ErrMaxFiles` even when every entry already exists on disk and nothing new would
+be created. This fail-closed default is intentional for a security cap: headers can understate, so the runtime
+write path always re-checks regardless of what the header claimed.

--- a/errors.go
+++ b/errors.go
@@ -36,6 +36,10 @@ var (
 	ErrMaxFiles = errors.New("extracted file count exceeds maximum")
 	// ErrMaxRatio is returned when bytesWritten / archiveFileSize exceeds MaxRatio (0 is unlimited).
 	ErrMaxRatio = errors.New("extracted size exceeds maximum compression ratio")
+	// ErrMaxNested is returned when archives found in extract output exceed MaxNested.
+	ErrMaxNested = errors.New("nested archive count exceeds maximum")
+	// ErrArchiveSymlink is returned when the archive path is a symbolic link.
+	ErrArchiveSymlink = errors.New("refusing to extract a symbolic link as an archive")
 
 	// CUE sheet.
 
@@ -54,7 +58,9 @@ var (
 )
 
 func isLimitError(err error) bool {
-	return errors.Is(err, ErrMaxBytes) || errors.Is(err, ErrMaxFiles) || errors.Is(err, ErrMaxRatio)
+	return errors.Is(err, ErrMaxBytes) || errors.Is(err, ErrMaxFiles) ||
+		errors.Is(err, ErrMaxRatio) || errors.Is(err, ErrMaxNested) ||
+		errors.Is(err, ErrArchiveSymlink)
 }
 
 // ExtractError is a rich error type that can carry multiple errors and warnings

--- a/extras_internal_test.go
+++ b/extras_internal_test.go
@@ -1,0 +1,19 @@
+package xtractr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtrasCap(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, DefaultMaxNested, extrasCap(0, 0))
+	assert.Equal(t, 8, extrasCap(8, 0))
+	assert.Equal(t, 4, extrasCap(0, 4))
+	assert.Equal(t, 8, extrasCap(8, 4))
+	assert.Equal(t, 0, extrasCap(-1, 0))
+	assert.Equal(t, 0, extrasCap(0, -1))
+	assert.Equal(t, 0, extrasCap(-1, 4))
+}

--- a/extras_internal_test.go
+++ b/extras_internal_test.go
@@ -17,3 +17,15 @@ func TestExtrasCap(t *testing.T) {
 	assert.Equal(t, 0, extrasCap(0, -1))
 	assert.Equal(t, 0, extrasCap(-1, 4))
 }
+
+func TestExtrasDepth(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, DefaultExtrasMaxDepth, extrasDepth(0, 0))
+	assert.Equal(t, 4, extrasDepth(4, 0))
+	assert.Equal(t, 3, extrasDepth(0, 3))
+	assert.Equal(t, 4, extrasDepth(4, 3))
+	assert.Equal(t, 0, extrasDepth(-1, 0))
+	assert.Equal(t, 0, extrasDepth(0, -1))
+	assert.Equal(t, 0, extrasDepth(-1, 3))
+}

--- a/extras_internal_test.go
+++ b/extras_internal_test.go
@@ -6,26 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtrasCap(t *testing.T) {
+func TestPick(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, DefaultMaxNested, extrasCap(0, 0))
-	assert.Equal(t, 8, extrasCap(8, 0))
-	assert.Equal(t, 4, extrasCap(0, 4))
-	assert.Equal(t, 8, extrasCap(8, 4))
-	assert.Equal(t, 0, extrasCap(-1, 0))
-	assert.Equal(t, 0, extrasCap(0, -1))
-	assert.Equal(t, 0, extrasCap(-1, 4))
-}
-
-func TestExtrasDepth(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, DefaultExtrasMaxDepth, extrasDepth(0, 0))
-	assert.Equal(t, 4, extrasDepth(4, 0))
-	assert.Equal(t, 3, extrasDepth(0, 3))
-	assert.Equal(t, 4, extrasDepth(4, 3))
-	assert.Equal(t, 0, extrasDepth(-1, 0))
-	assert.Equal(t, 0, extrasDepth(0, -1))
-	assert.Equal(t, 0, extrasDepth(-1, 3))
+	assert.Equal(t, 0, pick(0, 0))
+	assert.Equal(t, 8, pick(8, 0))
+	assert.Equal(t, 4, pick(0, 4))
+	assert.Equal(t, 8, pick(8, 4))
+	assert.Equal(t, -1, pick(-1, 0))
+	assert.Equal(t, -1, pick(0, -1))
+	assert.Equal(t, -1, pick(-1, 4))
+	assert.Equal(t, uint64(3), pick(uint64(0), uint64(3)))
 }

--- a/extras_test.go
+++ b/extras_test.go
@@ -40,6 +40,45 @@ func TestQueueSkipsZipSymlinkExtras(t *testing.T) {
 	require.FileExists(t, filepath.Join(out, "hello.txt"))
 }
 
+func TestQueueAllowSymlinksDoesNotRecurseArchiveMemberLinks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(dir, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	inner := tinyZipBytes(t, "hello.txt", "from-inner")
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{"payload.zip": inner}, map[string]string{
+		"a.zip": "payload.zip",
+		"b.zip": "payload.zip",
+	})
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:        xtractr.NoLogger(),
+		FileMode:      0o600,
+		DirMode:       0o700,
+		MaxNested:     -1,
+		AllowSymlinks: true,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:     xtractr.Filter{Path: dir, AllowSymlinks: true},
+		TempFolder: true,
+		MaxNested:  -1,
+		CBChannel:  make(chan *xtractr.Response, 2),
+	}
+	_, err = queue.Extract(job)
+	require.NoError(t, err)
+	resp := waitExtract(t, job.CBChannel)
+	require.NoError(t, resp.Error)
+	require.Equal(t, 1, resp.Extras.Count(), "archive-member zip symlinks must not be extras")
+}
+
 func TestQueueMaxNestedRejectsTooManyExtras(t *testing.T) {
 	t.Parallel()
 

--- a/extras_test.go
+++ b/extras_test.go
@@ -1,0 +1,187 @@
+package xtractr_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golift.io/xtractr"
+)
+
+func TestQueueSkipsZipSymlinkExtras(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	err := os.Symlink("target", filepath.Join(dir, "symlink-probe"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	inner := tinyZipBytes(t, "hello.txt", "from-inner")
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{"payload.zip": inner}, map[string]string{
+		"a.zip": "payload.zip",
+		"b.zip": "payload.zip",
+		"c.zip": "payload.zip",
+	})
+
+	resp := extractQueueJob(t, dir, 0)
+	require.NoError(t, resp.Error)
+	require.Equal(t, 1, resp.Extras.Count(), "symlink-named extras must not be queued")
+
+	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
+	require.FileExists(t, filepath.Join(out, "payload.zip"))
+	require.FileExists(t, filepath.Join(out, "hello.txt"))
+}
+
+func TestQueueMaxNestedRejectsTooManyExtras(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{
+		"one.zip":   tinyZipBytes(t, "one.txt", "1"),
+		"two.zip":   tinyZipBytes(t, "two.txt", "2"),
+		"three.zip": tinyZipBytes(t, "three.txt", "3"),
+	}, nil)
+
+	resp := extractQueueJob(t, dir, 2)
+	require.ErrorIs(t, resp.Error, xtractr.ErrMaxNested)
+}
+
+func TestQueueMaxNestedAllowsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{
+		"one.zip": tinyZipBytes(t, "one.txt", "1"),
+		"two.zip": tinyZipBytes(t, "two.txt", "2"),
+	}, nil)
+
+	resp := extractQueueJob(t, dir, 2)
+	require.NoError(t, resp.Error)
+	require.Equal(t, 2, resp.Extras.Count())
+
+	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
+	require.FileExists(t, filepath.Join(out, "one.txt"))
+	require.FileExists(t, filepath.Join(out, "two.txt"))
+}
+
+func TestQueueExtrasMaxDepthSkipsDeepArchives(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{
+		"keep.txt":            []byte("surface"),
+		"a/b/c/inner.zip":     tinyZipBytes(t, "deep.txt", "buried"),
+		"shallow/sibling.zip": tinyZipBytes(t, "near.txt", "ok"),
+	}, nil)
+
+	resp := extractQueueJob(t, dir, 64)
+	require.NoError(t, resp.Error)
+
+	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
+	require.FileExists(t, filepath.Join(out, "keep.txt"))
+	require.FileExists(t, filepath.Join(out, "a", "b", "c", "inner.zip"))
+	require.NoFileExists(t, filepath.Join(out, "a", "b", "c", "deep.txt"))
+	require.FileExists(t, filepath.Join(out, "near.txt"))
+}
+
+func extractQueueJob(t *testing.T, dir string, maxNested int) *xtractr.Response {
+	t.Helper()
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:    xtractr.NoLogger(),
+		FileMode:  0o600,
+		DirMode:   0o700,
+		MaxNested: -1,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: true,
+		MaxNested:  maxNested,
+		CBChannel:  make(chan *xtractr.Response, 2),
+	}
+	if maxNested == 0 {
+		job.MaxNested = -1
+	}
+
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+
+	return waitExtract(t, job.CBChannel)
+}
+
+func tinyZipBytes(t *testing.T, name, body string) []byte {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+	writer, err := zipWriter.Create(name)
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+
+	return buf.Bytes()
+}
+
+func writeOuterZip(t *testing.T, dest string, files map[string][]byte, links map[string]string) {
+	t.Helper()
+
+	archiveFile, err := os.Create(dest)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(archiveFile)
+
+	for name, payload := range files {
+		header := &zip.FileHeader{Name: name, Method: zip.Deflate, Modified: time.Now()}
+		writer, createErr := zipWriter.CreateHeader(header)
+		require.NoError(t, createErr)
+
+		_, err = writer.Write(payload)
+		require.NoError(t, err)
+	}
+
+	for name, target := range links {
+		header := &zip.FileHeader{Name: name, Method: zip.Deflate, Modified: time.Now()}
+		header.SetMode(0o755 | fs.ModeSymlink)
+		writer, createErr := zipWriter.CreateHeader(header)
+		require.NoError(t, createErr)
+
+		_, err = writer.Write([]byte(target))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, archiveFile.Close())
+}
+
+func firstExisting(t *testing.T, paths ...string) string {
+	t.Helper()
+
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+
+		_, err := os.Stat(path)
+		if err == nil {
+			return path
+		}
+	}
+
+	t.Fatalf("none of the extract output paths exist: %v", paths)
+
+	return ""
+}

--- a/extras_test.go
+++ b/extras_test.go
@@ -58,18 +58,15 @@ func TestQueueAllowSymlinksDoesNotRecurseArchiveMemberLinks(t *testing.T) {
 	})
 
 	queue := xtractr.NewQueue(&xtractr.Config{
-		Logger:        xtractr.NoLogger(),
-		FileMode:      0o600,
-		DirMode:       0o700,
-		MaxNested:     -1,
-		AllowSymlinks: true,
+		Logger:   xtractr.NoLogger(),
+		FileMode: 0o600,
+		DirMode:  0o700,
 	})
 	defer queue.Stop()
 
 	job := &xtractr.Xtract{
 		Filter:     xtractr.Filter{Path: dir, AllowSymlinks: true},
 		TempFolder: true,
-		MaxNested:  -1,
 		CBChannel:  make(chan *xtractr.Response, 2),
 	}
 	_, err = queue.Extract(job)
@@ -124,7 +121,7 @@ func TestQueueExtrasMaxDepthSkipsDeepArchives(t *testing.T) {
 		"shallow/sibling.zip": tinyZipBytes(t, "near.txt", "ok"),
 	}, nil)
 
-	resp := extractQueueJob(t, dir, 64, 0)
+	resp := extractQueueJob(t, dir, 64, 2)
 	require.NoError(t, resp.Error)
 
 	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
@@ -157,10 +154,9 @@ func extractQueueJob(t *testing.T, dir string, maxNested, extrasMaxDepth int) *x
 	t.Helper()
 
 	queue := xtractr.NewQueue(&xtractr.Config{
-		Logger:    xtractr.NoLogger(),
-		FileMode:  0o600,
-		DirMode:   0o700,
-		MaxNested: -1,
+		Logger:   xtractr.NoLogger(),
+		FileMode: 0o600,
+		DirMode:  0o700,
 	})
 	defer queue.Stop()
 
@@ -170,9 +166,6 @@ func extractQueueJob(t *testing.T, dir string, maxNested, extrasMaxDepth int) *x
 		MaxNested:      maxNested,
 		ExtrasMaxDepth: extrasMaxDepth,
 		CBChannel:      make(chan *xtractr.Response, 2),
-	}
-	if maxNested == 0 {
-		job.MaxNested = -1
 	}
 
 	_, err := queue.Extract(job)

--- a/extras_test.go
+++ b/extras_test.go
@@ -31,7 +31,7 @@ func TestQueueSkipsZipSymlinkExtras(t *testing.T) {
 		"c.zip": "payload.zip",
 	})
 
-	resp := extractQueueJob(t, dir, 0)
+	resp := extractQueueJob(t, dir, 0, 0)
 	require.NoError(t, resp.Error)
 	require.Equal(t, 1, resp.Extras.Count(), "symlink-named extras must not be queued")
 
@@ -51,7 +51,7 @@ func TestQueueMaxNestedRejectsTooManyExtras(t *testing.T) {
 		"three.zip": tinyZipBytes(t, "three.txt", "3"),
 	}, nil)
 
-	resp := extractQueueJob(t, dir, 2)
+	resp := extractQueueJob(t, dir, 2, 0)
 	require.ErrorIs(t, resp.Error, xtractr.ErrMaxNested)
 }
 
@@ -65,7 +65,7 @@ func TestQueueMaxNestedAllowsAtLimit(t *testing.T) {
 		"two.zip": tinyZipBytes(t, "two.txt", "2"),
 	}, nil)
 
-	resp := extractQueueJob(t, dir, 2)
+	resp := extractQueueJob(t, dir, 2, 0)
 	require.NoError(t, resp.Error)
 	require.Equal(t, 2, resp.Extras.Count())
 
@@ -85,7 +85,7 @@ func TestQueueExtrasMaxDepthSkipsDeepArchives(t *testing.T) {
 		"shallow/sibling.zip": tinyZipBytes(t, "near.txt", "ok"),
 	}, nil)
 
-	resp := extractQueueJob(t, dir, 64)
+	resp := extractQueueJob(t, dir, 64, 0)
 	require.NoError(t, resp.Error)
 
 	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
@@ -95,7 +95,26 @@ func TestQueueExtrasMaxDepthSkipsDeepArchives(t *testing.T) {
 	require.FileExists(t, filepath.Join(out, "near.txt"))
 }
 
-func extractQueueJob(t *testing.T, dir string, maxNested int) *xtractr.Response {
+func TestQueueExtrasMaxDepthOverrideExtractsDeep(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{
+		"keep.txt":            []byte("surface"),
+		"a/b/c/inner.zip":     tinyZipBytes(t, "deep.txt", "buried"),
+		"shallow/sibling.zip": tinyZipBytes(t, "near.txt", "ok"),
+	}, nil)
+
+	resp := extractQueueJob(t, dir, 64, 3)
+	require.NoError(t, resp.Error)
+
+	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
+	require.FileExists(t, filepath.Join(out, "deep.txt"))
+	require.FileExists(t, filepath.Join(out, "near.txt"))
+}
+
+func extractQueueJob(t *testing.T, dir string, maxNested, extrasMaxDepth int) *xtractr.Response {
 	t.Helper()
 
 	queue := xtractr.NewQueue(&xtractr.Config{
@@ -107,10 +126,11 @@ func extractQueueJob(t *testing.T, dir string, maxNested int) *xtractr.Response 
 	defer queue.Stop()
 
 	job := &xtractr.Xtract{
-		Filter:     xtractr.Filter{Path: dir},
-		TempFolder: true,
-		MaxNested:  maxNested,
-		CBChannel:  make(chan *xtractr.Response, 2),
+		Filter:         xtractr.Filter{Path: dir},
+		TempFolder:     true,
+		MaxNested:      maxNested,
+		ExtrasMaxDepth: extrasMaxDepth,
+		CBChannel:      make(chan *xtractr.Response, 2),
 	}
 	if maxNested == 0 {
 		job.MaxNested = -1

--- a/files.go
+++ b/files.go
@@ -214,7 +214,8 @@ type Filter struct {
 	// MaxArchives stops the walk after this many archives are found. 0 is unlimited.
 	MaxArchives int
 	// AllowSymlinks includes symlink-named archive files in the listing.
-	// Default false. Symlink directories are never walked.
+	// Default false. Symlink directories found during the walk are never
+	// followed; a symlink passed as Path is (operator-chosen search root).
 	// The extras/recursion pass always ignores this and never lists archive-member links.
 	AllowSymlinks bool
 }
@@ -488,7 +489,7 @@ func (x *XFile) Extract() (size uint64, filesList, archiveList []string, err err
 func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, err error) {
 	err = refuseSymlinkArchiveUnlessAllowed(xFile)
 	if err != nil {
-		return 0, nil, nil, err
+		return 0, nil, nil, wrapSymlinkArchiveError(xFile, err)
 	}
 
 	sName := strings.ToLower(xFile.FilePath)
@@ -1311,6 +1312,14 @@ func skipSymlinkArchivePath(filter *Filter, path string) bool {
 	linkInfo, linkErr := os.Lstat(path)
 
 	return linkErr != nil || linkInfo.Mode()&os.ModeSymlink != 0
+}
+
+func wrapSymlinkArchiveError(xFile *XFile, err error) error {
+	if xFile == nil {
+		return err
+	}
+
+	return NewExtractError(err, xFile.FilePath, xFile.OutputDir, 0, "")
 }
 
 func refuseSymlinkArchiveUnlessAllowed(xFile *XFile) error {

--- a/files.go
+++ b/files.go
@@ -175,6 +175,8 @@ type XFile struct {
 	MaxFiles int
 	// MaxRatio is the maximum bytesWritten / archiveFileSize. 0 means unlimited.
 	MaxRatio float64
+	// AllowSymlinks allows FilePath to be a symbolic link to an archive.
+	AllowSymlinks bool
 	// Progress is called periodically during file extraction.
 	// Contains info about the progress of the extraction.
 	// This is not called if an Updates channel is also provided.
@@ -211,6 +213,9 @@ type Filter struct {
 	MinDepth int
 	// MaxArchives stops the walk after this many archives are found. 0 is unlimited.
 	MaxArchives int
+	// AllowSymlinks includes symlink-named archive files in the listing.
+	// Default false. Symlink directories are never walked.
+	AllowSymlinks bool
 }
 
 // Exclude represents an exclusion list.
@@ -322,10 +327,7 @@ func findCompressedFiles(path string, filter *Filter, depth int) ArchiveList {
 	}
 
 	if !info.IsDir() && IsArchiveFile(path) {
-		// os.Open/Stat follow a final-component symlink; do not treat that path
-		// as an archive or ExtractFile will fail with ErrArchiveSymlink.
-		linkInfo, linkErr := os.Lstat(path)
-		if linkErr != nil || linkInfo.Mode()&os.ModeSymlink != 0 {
+		if skipSymlinkArchivePath(filter, path) {
 			return nil
 		}
 
@@ -402,8 +404,9 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 		}
 
 		switch lowerName := strings.ToLower(file.Name()); {
-		case file.Mode()&os.ModeSymlink != 0:
-			continue // never treat a symlink as an archive, and do not walk symlink dirs.
+		case file.Mode()&os.ModeSymlink != 0 &&
+			(!filter.AllowSymlinks || symlinkTargetsDir(path, file.Name())):
+			continue // skip symlink archives unless allowed; never walk symlink dirs.
 		case !file.IsDir() &&
 			(filter.ExcludeSuffix.Has(lowerName) || depth < filter.MinDepth):
 			continue // file suffix is excluded or we are not deep enough.
@@ -482,7 +485,7 @@ func (x *XFile) Extract() (size uint64, filesList, archiveList []string, err err
 // ExtractFile calls the correct procedure for the type of file being extracted.
 // Returns size of extracted data, list of extracted files, list of archives processed, and/or error.
 func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, err error) {
-	err = refuseSymlinkArchive(xFile.FilePath)
+	err = refuseSymlinkArchiveUnlessAllowed(xFile)
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -1297,6 +1300,30 @@ func (x *XFile) safeFileMode(current os.FileMode) os.FileMode {
 	const minimum = 0o400 // ensure owner has read access to the file.
 
 	return current | minimum
+}
+
+func skipSymlinkArchivePath(filter *Filter, path string) bool {
+	if filter != nil && filter.AllowSymlinks {
+		return false
+	}
+
+	linkInfo, linkErr := os.Lstat(path)
+
+	return linkErr != nil || linkInfo.Mode()&os.ModeSymlink != 0
+}
+
+func refuseSymlinkArchiveUnlessAllowed(xFile *XFile) error {
+	if xFile == nil || xFile.AllowSymlinks {
+		return nil
+	}
+
+	return refuseSymlinkArchive(xFile.FilePath)
+}
+
+func symlinkTargetsDir(dir, name string) bool {
+	info, err := os.Stat(filepath.Join(dir, name))
+
+	return err != nil || info.IsDir()
 }
 
 func refuseSymlinkArchive(path string) error {

--- a/files.go
+++ b/files.go
@@ -209,6 +209,8 @@ type Filter struct {
 	MaxDepth int
 	// Only find archives this many child-folders deep. 0 and 1 are equal.
 	MinDepth int
+	// MaxArchives stops the walk after this many archives are found. 0 is unlimited.
+	MaxArchives int
 }
 
 // Exclude represents an exclusion list.
@@ -320,6 +322,13 @@ func findCompressedFiles(path string, filter *Filter, depth int) ArchiveList {
 	}
 
 	if !info.IsDir() && IsArchiveFile(path) {
+		// os.Open/Stat follow a final-component symlink; do not treat that path
+		// as an archive or ExtractFile will fail with ErrArchiveSymlink.
+		linkInfo, linkErr := os.Lstat(path)
+		if linkErr != nil || linkInfo.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
 		return ArchiveList{path: {path}} // passed in an archive file; send it back out.
 	}
 
@@ -388,7 +397,13 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 	files := ArchiveList{}
 
 	for _, file := range fileList {
+		if archivesAtCap(files, filter) {
+			return files
+		}
+
 		switch lowerName := strings.ToLower(file.Name()); {
+		case file.Mode()&os.ModeSymlink != 0:
+			continue // never treat a symlink as an archive, and do not walk symlink dirs.
 		case !file.IsDir() &&
 			(filter.ExcludeSuffix.Has(lowerName) || depth < filter.MinDepth):
 			continue // file suffix is excluded or we are not deep enough.
@@ -412,6 +427,10 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 	}
 
 	return files
+}
+
+func archivesAtCap(files ArchiveList, filter *Filter) bool {
+	return filter != nil && filter.MaxArchives > 0 && files.Count() >= filter.MaxArchives
 }
 
 // normalizeVolumes maps the volume list reported by an archive decoder into
@@ -463,6 +482,11 @@ func (x *XFile) Extract() (size uint64, filesList, archiveList []string, err err
 // ExtractFile calls the correct procedure for the type of file being extracted.
 // Returns size of extracted data, list of extracted files, list of archives processed, and/or error.
 func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, err error) {
+	err = refuseSymlinkArchive(xFile.FilePath)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
 	sName := strings.ToLower(xFile.FilePath)
 	xFile.bindMoveFiles()
 
@@ -1273,6 +1297,23 @@ func (x *XFile) safeFileMode(current os.FileMode) os.FileMode {
 	const minimum = 0o400 // ensure owner has read access to the file.
 
 	return current | minimum
+}
+
+func refuseSymlinkArchive(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("lstat archive: %w", err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s", ErrArchiveSymlink, path)
+	}
+
+	return nil
 }
 
 func openStatFile(path string) (*os.File, os.FileInfo, error) {

--- a/files.go
+++ b/files.go
@@ -215,6 +215,7 @@ type Filter struct {
 	MaxArchives int
 	// AllowSymlinks includes symlink-named archive files in the listing.
 	// Default false. Symlink directories are never walked.
+	// The extras/recursion pass always ignores this and never lists archive-member links.
 	AllowSymlinks bool
 }
 
@@ -1322,7 +1323,6 @@ func refuseSymlinkArchiveUnlessAllowed(xFile *XFile) error {
 
 func symlinkTargetsDir(dir, name string) bool {
 	info, err := os.Stat(filepath.Join(dir, name))
-
 	return err != nil || info.IsDir()
 }
 

--- a/files_test.go
+++ b/files_test.go
@@ -2,6 +2,7 @@ package xtractr_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,6 +118,84 @@ func TestFindCompressedFiles(t *testing.T) {
 	}
 
 	assert.Equal(t, 8, total, "When skipping the four ISOs, we have 8 archives remaining.")
+}
+
+func TestFindCompressedFilesSkipsSymlinks(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	realZip := filepath.Join(base, "real.zip")
+	require.NoError(t, os.WriteFile(realZip, []byte("pk"), 0o600))
+
+	err := os.Symlink(realZip, filepath.Join(base, "alias.zip"))
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	require.NoError(t, os.Mkdir(filepath.Join(base, "subdir"), 0o700))
+	err = os.Symlink(base, filepath.Join(base, "subdir", "loop.zip"))
+	require.NoError(t, err)
+
+	paths := xtractr.FindCompressedFiles(xtractr.Filter{Path: base})
+	require.Equal(t, 1, paths.Count())
+	require.Equal(t, realZip, paths.List()[0])
+}
+
+func TestFindCompressedFilesMaxArchives(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	for idx := range 5 {
+		require.NoError(t, os.WriteFile(filepath.Join(base, fmt.Sprintf("f%d.zip", idx)), []byte("pk"), 0o600))
+	}
+
+	nested := filepath.Join(base, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "deep.zip"), []byte("pk"), 0o600))
+
+	paths := xtractr.FindCompressedFiles(xtractr.Filter{Path: base, MaxArchives: 3})
+	assert.Equal(t, 3, paths.Count())
+}
+
+func TestFindCompressedFilesSkipsSymlinkPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.zip")
+	require.NoError(t, os.WriteFile(src, []byte("pk"), 0o600))
+
+	link := filepath.Join(dir, "payload-link.zip")
+
+	err := os.Symlink(src, link)
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	paths := xtractr.FindCompressedFiles(xtractr.Filter{Path: link})
+	assert.Empty(t, paths, "a symlink search path must not be returned as an archive")
+}
+
+func TestExtractFileRefusesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload.zip")
+	require.NoError(t, os.WriteFile(src, []byte("pk"), 0o600))
+
+	link := filepath.Join(dir, "payload-link.zip")
+
+	err := os.Symlink(src, link)
+	if err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	_, _, _, err = xtractr.ExtractFile(&xtractr.XFile{ //nolint:dogsled // only the error matters here.
+		FilePath:  link,
+		OutputDir: filepath.Join(dir, "out"),
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	require.ErrorIs(t, err, xtractr.ErrArchiveSymlink)
 }
 
 func TestFindCompressedFilesSkipsDotFiles(t *testing.T) {

--- a/files_test.go
+++ b/files_test.go
@@ -206,6 +206,10 @@ func TestExtractFileRefusesSymlink(t *testing.T) {
 	})
 	require.ErrorIs(t, err, xtractr.ErrArchiveSymlink)
 
+	var extErr *xtractr.ExtractError
+	require.ErrorAs(t, err, &extErr)
+	assert.Equal(t, link, extErr.FilePath)
+
 	_, _, _, err = xtractr.ExtractFile(&xtractr.XFile{ //nolint:dogsled // only the error matters here.
 		FilePath:      link,
 		OutputDir:     filepath.Join(dir, "allowed"),

--- a/files_test.go
+++ b/files_test.go
@@ -139,6 +139,11 @@ func TestFindCompressedFilesSkipsSymlinks(t *testing.T) {
 	paths := xtractr.FindCompressedFiles(xtractr.Filter{Path: base})
 	require.Equal(t, 1, paths.Count())
 	require.Equal(t, realZip, paths.List()[0])
+
+	allowed := xtractr.FindCompressedFiles(xtractr.Filter{Path: base, AllowSymlinks: true})
+	assert.Equal(t, 2, allowed.Count(), "file symlink is included; dir symlink named .zip is not")
+	assert.Contains(t, allowed.List(), realZip)
+	assert.Contains(t, allowed.List(), filepath.Join(base, "alias.zip"))
 }
 
 func TestFindCompressedFilesMaxArchives(t *testing.T) {
@@ -173,6 +178,10 @@ func TestFindCompressedFilesSkipsSymlinkPath(t *testing.T) {
 
 	paths := xtractr.FindCompressedFiles(xtractr.Filter{Path: link})
 	assert.Empty(t, paths, "a symlink search path must not be returned as an archive")
+
+	allowed := xtractr.FindCompressedFiles(xtractr.Filter{Path: link, AllowSymlinks: true})
+	require.Equal(t, 1, allowed.Count())
+	assert.Equal(t, link, allowed.List()[0])
 }
 
 func TestExtractFileRefusesSymlink(t *testing.T) {
@@ -196,6 +205,16 @@ func TestExtractFileRefusesSymlink(t *testing.T) {
 		DirMode:   0o700,
 	})
 	require.ErrorIs(t, err, xtractr.ErrArchiveSymlink)
+
+	_, _, _, err = xtractr.ExtractFile(&xtractr.XFile{ //nolint:dogsled // only the error matters here.
+		FilePath:      link,
+		OutputDir:     filepath.Join(dir, "allowed"),
+		FileMode:      0o600,
+		DirMode:       0o700,
+		AllowSymlinks: true,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, xtractr.ErrArchiveSymlink)
 }
 
 func TestFindCompressedFilesSkipsDotFiles(t *testing.T) {

--- a/queue.go
+++ b/queue.go
@@ -157,6 +157,10 @@ func (x *Xtractr) processQueue() {
 // extract is where the real work begins and files get extracted.
 // This is fired off from processQueue() in a go routine.
 func (x *Xtractr) extract(ext *Xtract) {
+	if x.config.AllowSymlinks {
+		ext.AllowSymlinks = true
+	}
+
 	resp := &Response{
 		X:        ext,
 		Started:  time.Now(),
@@ -380,7 +384,6 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 			MaxRatio:       resp.X.MaxRatio,
 			MaxNested:      resp.X.MaxNested,
 			ExtrasMaxDepth: resp.X.ExtrasMaxDepth,
-			Filter:         Filter{AllowSymlinks: resp.X.AllowSymlinks},
 		},
 		Started:  resp.Started,
 		Output:   resp.Output,
@@ -454,7 +457,7 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		MaxBytes:      pick(resp.X.MaxBytes, x.config.MaxBytes),
 		MaxFiles:      pick(resp.X.MaxFiles, x.config.MaxFiles),
 		MaxRatio:      pick(resp.X.MaxRatio, x.config.MaxRatio),
-		AllowSymlinks: resp.X.AllowSymlinks || x.config.AllowSymlinks,
+		AllowSymlinks: resp.X.AllowSymlinks,
 		log:           x.config.Logger,
 		Updates:       resp.X.Updates,
 		Progress:      resp.X.Progress,
@@ -517,7 +520,6 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
 		MaxDepth:      extrasDepth(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
-		AllowSymlinks: resp.X.AllowSymlinks || x.config.AllowSymlinks,
 	}
 
 	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)

--- a/queue.go
+++ b/queue.go
@@ -65,6 +65,10 @@ type Xtract struct {
 	// (the extras pass). 0 uses Config.MaxNested, then DefaultMaxNested.
 	// Negative means unlimited.
 	MaxNested int
+	// ExtrasMaxDepth is how deep the extras pass walks extract output.
+	// 0 uses Config.ExtrasMaxDepth, then DefaultExtrasMaxDepth.
+	// Negative means unlimited. Distinct from Filter.MaxDepth (initial search).
+	ExtrasMaxDepth int
 }
 
 // Response is sent to the call-back function. The first CBFunction call is just
@@ -230,6 +234,7 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 				MaxFiles:         resp.X.MaxFiles,
 				MaxRatio:         resp.X.MaxRatio,
 				MaxNested:        resp.X.MaxNested,
+				ExtrasMaxDepth:   resp.X.ExtrasMaxDepth,
 			},
 			Started:  resp.Started,
 			Output:   output,
@@ -365,14 +370,15 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 
 	nre := &Response{
 		X: &Xtract{
-			Password:  resp.X.Password,
-			Passwords: resp.X.Passwords,
-			Progress:  resp.X.Progress,
-			Updates:   resp.X.Updates,
-			MaxBytes:  resp.X.MaxBytes,
-			MaxFiles:  resp.X.MaxFiles,
-			MaxRatio:  resp.X.MaxRatio,
-			MaxNested: resp.X.MaxNested,
+			Password:       resp.X.Password,
+			Passwords:      resp.X.Passwords,
+			Progress:       resp.X.Progress,
+			Updates:        resp.X.Updates,
+			MaxBytes:       resp.X.MaxBytes,
+			MaxFiles:       resp.X.MaxFiles,
+			MaxRatio:       resp.X.MaxRatio,
+			MaxNested:      resp.X.MaxNested,
+			ExtrasMaxDepth: resp.X.ExtrasMaxDepth,
 		},
 		Started:  resp.Started,
 		Output:   resp.Output,
@@ -477,9 +483,9 @@ func pick[T uint64 | int | float64](job, cfg T) T { //nolint:ireturn // numeric 
 	return cfg
 }
 
-// extrasCap is the extras-pass archive count limit. 0 from both job and config
-// uses DefaultMaxNested. A negative job or config value means unlimited (return 0).
-func extrasCap(job, cfg int) int {
+// extrasLimit picks a job value, then config, then fallback. 0 from both job
+// and config uses fallback. A negative job or config value means unlimited (0).
+func extrasLimit(job, cfg, fallback int) int {
 	if job < 0 || (job == 0 && cfg < 0) {
 		return 0
 	}
@@ -492,14 +498,22 @@ func extrasCap(job, cfg int) int {
 		return cfg
 	}
 
-	return DefaultMaxNested
+	return fallback
+}
+
+func extrasCap(job, cfg int) int {
+	return extrasLimit(job, cfg, DefaultMaxNested)
+}
+
+func extrasDepth(job, cfg int) int {
+	return extrasLimit(job, cfg, DefaultExtrasMaxDepth)
 }
 
 func (x *Xtractr) extrasFilter(resp *Response) Filter {
 	filter := Filter{
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
-		MaxDepth:      DefaultExtrasMaxDepth,
+		MaxDepth:      extrasDepth(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
 	}
 
 	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)

--- a/queue.go
+++ b/queue.go
@@ -218,6 +218,7 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 				Filter: Filter{
 					Path:          subDir,
 					ExcludeSuffix: resp.X.ExcludeSuffix,
+					AllowSymlinks: resp.X.AllowSymlinks,
 				},
 				Name:             resp.X.Name,
 				Password:         resp.X.Password,
@@ -379,6 +380,7 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 			MaxRatio:       resp.X.MaxRatio,
 			MaxNested:      resp.X.MaxNested,
 			ExtrasMaxDepth: resp.X.ExtrasMaxDepth,
+			Filter:         Filter{AllowSymlinks: resp.X.AllowSymlinks},
 		},
 		Started:  resp.Started,
 		Output:   resp.Output,
@@ -441,20 +443,21 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	x.config.Debugf("Extracting File: %v to %v", filename, resp.Output)
 
 	xFile := &XFile{
-		FilePath:    filename,
-		OutputDir:   resp.Output,
-		FileMode:    x.config.FileMode,
-		DirMode:     x.config.DirMode,
-		Suffix:      x.config.Suffix,
-		Passwords:   resp.X.Passwords,
-		Password:    resp.X.Password,
-		FileWorkers: x.config.FileWorkers,
-		MaxBytes:    pick(resp.X.MaxBytes, x.config.MaxBytes),
-		MaxFiles:    pick(resp.X.MaxFiles, x.config.MaxFiles),
-		MaxRatio:    pick(resp.X.MaxRatio, x.config.MaxRatio),
-		log:         x.config.Logger,
-		Updates:     resp.X.Updates,
-		Progress:    resp.X.Progress,
+		FilePath:      filename,
+		OutputDir:     resp.Output,
+		FileMode:      x.config.FileMode,
+		DirMode:       x.config.DirMode,
+		Suffix:        x.config.Suffix,
+		Passwords:     resp.X.Passwords,
+		Password:      resp.X.Password,
+		FileWorkers:   x.config.FileWorkers,
+		MaxBytes:      pick(resp.X.MaxBytes, x.config.MaxBytes),
+		MaxFiles:      pick(resp.X.MaxFiles, x.config.MaxFiles),
+		MaxRatio:      pick(resp.X.MaxRatio, x.config.MaxRatio),
+		AllowSymlinks: resp.X.AllowSymlinks || x.config.AllowSymlinks,
+		log:           x.config.Logger,
+		Updates:       resp.X.Updates,
+		Progress:      resp.X.Progress,
 	}
 
 	bytes, files, archives, err := ExtractFile(xFile)
@@ -514,6 +517,7 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
 		MaxDepth:      extrasDepth(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
+		AllowSymlinks: resp.X.AllowSymlinks || x.config.AllowSymlinks,
 	}
 
 	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)

--- a/queue.go
+++ b/queue.go
@@ -61,6 +61,10 @@ type Xtract struct {
 	// MaxRatio is the maximum bytesWritten / archiveFileSize per archive.
 	// 0 means unlimited; when 0, Config.MaxRatio is used.
 	MaxRatio float64
+	// MaxNested is the maximum archives extracted from this job's output
+	// (the extras pass). 0 uses Config.MaxNested, then DefaultMaxNested.
+	// Negative means unlimited.
+	MaxNested int
 }
 
 // Response is sent to the call-back function. The first CBFunction call is just
@@ -225,6 +229,7 @@ func (x *Xtractr) decompressFolders(resp *Response) error {
 				MaxBytes:         resp.X.MaxBytes,
 				MaxFiles:         resp.X.MaxFiles,
 				MaxRatio:         resp.X.MaxRatio,
+				MaxNested:        resp.X.MaxNested,
 			},
 			Started:  resp.Started,
 			Output:   output,
@@ -346,14 +351,18 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 	}
 
 	// Now do it again with the output folder.
-	resp.Extras = FindCompressedFiles(Filter{
-		Path:          resp.Output,
-		ExcludeSuffix: resp.X.ExcludeSuffix,
-	})
+	resp.Extras = FindCompressedFiles(x.extrasFilter(resp))
 	// Do not try to extract files that an extractor copied into output (e.g. CUE sheet);
 	// re-extracting the copied CUE would fail and delete the output directory.
 	// Other archives in the output (e.g. CUE+FLAC from a RAR) are still extracted.
 	resp.Extras = excludePathsFromArchiveList(resp.Extras, resp.SkipOnRecursion)
+
+	err = x.checkExtrasLimit(resp)
+	if err != nil {
+		x.DeleteFiles(resp.Output)
+		return err
+	}
+
 	nre := &Response{
 		X: &Xtract{
 			Password:  resp.X.Password,
@@ -363,6 +372,7 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 			MaxBytes:  resp.X.MaxBytes,
 			MaxFiles:  resp.X.MaxFiles,
 			MaxRatio:  resp.X.MaxRatio,
+			MaxNested: resp.X.MaxNested,
 		},
 		Started:  resp.Started,
 		Output:   resp.Output,
@@ -465,6 +475,48 @@ func pick[T uint64 | int | float64](job, cfg T) T { //nolint:ireturn // numeric 
 	}
 
 	return cfg
+}
+
+// extrasCap is the extras-pass archive count limit. 0 from both job and config
+// uses DefaultMaxNested. A negative job or config value means unlimited (return 0).
+func extrasCap(job, cfg int) int {
+	if job < 0 || (job == 0 && cfg < 0) {
+		return 0
+	}
+
+	if job > 0 {
+		return job
+	}
+
+	if cfg > 0 {
+		return cfg
+	}
+
+	return DefaultMaxNested
+}
+
+func (x *Xtractr) extrasFilter(resp *Response) Filter {
+	filter := Filter{
+		Path:          resp.Output,
+		ExcludeSuffix: resp.X.ExcludeSuffix,
+		MaxDepth:      DefaultExtrasMaxDepth,
+	}
+
+	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)
+	if limit > 0 {
+		filter.MaxArchives = limit + 1
+	}
+
+	return filter
+}
+
+func (x *Xtractr) checkExtrasLimit(resp *Response) error {
+	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)
+	if limit <= 0 || resp.Extras.Count() <= limit {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %d archives (max %d)", ErrMaxNested, resp.Extras.Count(), limit)
 }
 
 func (x *Xtractr) cleanupProcessedArchives(resp *Response) error {

--- a/queue.go
+++ b/queue.go
@@ -61,13 +61,14 @@ type Xtract struct {
 	// MaxRatio is the maximum bytesWritten / archiveFileSize per archive.
 	// 0 means unlimited; when 0, Config.MaxRatio is used.
 	MaxRatio float64
-	// MaxNested is the maximum archives extracted from this job's output
-	// (the extras pass). 0 uses Config.MaxNested, then DefaultMaxNested.
-	// Negative means unlimited.
+	// MaxNested is the maximum archives extracted from one source folder's
+	// output (one extras pass). 0 means unlimited; when 0, Config.MaxNested
+	// is used. Negative also means unlimited. Not a job-wide total across
+	// decompressFolders, and not a second-round nesting budget.
 	MaxNested int
 	// ExtrasMaxDepth is how deep the extras pass walks extract output.
-	// 0 uses Config.ExtrasMaxDepth, then DefaultExtrasMaxDepth.
-	// Negative means unlimited. Distinct from Filter.MaxDepth (initial search).
+	// 0 means unlimited; when 0, Config.ExtrasMaxDepth is used. Negative
+	// also means unlimited. Distinct from Filter.MaxDepth (initial search).
 	ExtrasMaxDepth int
 }
 
@@ -157,10 +158,6 @@ func (x *Xtractr) processQueue() {
 // extract is where the real work begins and files get extracted.
 // This is fired off from processQueue() in a go routine.
 func (x *Xtractr) extract(ext *Xtract) {
-	if x.config.AllowSymlinks {
-		ext.AllowSymlinks = true
-	}
-
 	resp := &Response{
 		X:        ext,
 		Started:  time.Now(),
@@ -480,58 +477,37 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	return bytes, files, archives, nil
 }
 
-func pick[T uint64 | int | float64](job, cfg T) T { //nolint:ireturn // numeric union, not an interface.
+func pick[T uint64 | int | float64](vals ...T) T { //nolint:ireturn // numeric union, not an interface.
 	var zero T
-	if job != zero {
-		return job
+
+	for _, val := range vals {
+		if val != zero {
+			return val
+		}
 	}
 
-	return cfg
-}
-
-// extrasLimit picks a job value, then config, then fallback. 0 from both job
-// and config uses fallback. A negative job or config value means unlimited (0).
-func extrasLimit(job, cfg, fallback int) int {
-	if job < 0 || (job == 0 && cfg < 0) {
-		return 0
-	}
-
-	if job > 0 {
-		return job
-	}
-
-	if cfg > 0 {
-		return cfg
-	}
-
-	return fallback
-}
-
-func extrasCap(job, cfg int) int {
-	return extrasLimit(job, cfg, DefaultMaxNested)
-}
-
-func extrasDepth(job, cfg int) int {
-	return extrasLimit(job, cfg, DefaultExtrasMaxDepth)
+	return zero
 }
 
 func (x *Xtractr) extrasFilter(resp *Response) Filter {
 	filter := Filter{
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
-		MaxDepth:      extrasDepth(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
+		MaxDepth:      pick(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
 	}
 
-	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)
-	if limit > 0 {
+	if limit := pick(resp.X.MaxNested, x.config.MaxNested); limit > 0 {
 		filter.MaxArchives = limit + 1
 	}
 
 	return filter
 }
 
+// checkExtrasLimit applies MaxNested to this extras list only (one source
+// folder, one extras pass). Archives left unextracted inside those extras
+// are not counted.
 func (x *Xtractr) checkExtrasLimit(resp *Response) error {
-	limit := extrasCap(resp.X.MaxNested, x.config.MaxNested)
+	limit := pick(resp.X.MaxNested, x.config.MaxNested)
 	if limit <= 0 || resp.Extras.Count() <= limit {
 		return nil
 	}

--- a/start.go
+++ b/start.go
@@ -12,6 +12,12 @@ const (
 	// DefaultBufferSize is the size of the extraction buffer.
 	// ie. How many jobs can be queued before things get slow.
 	DefaultBufferSize = 1000
+	// DefaultMaxNested is the extras-pass archive cap when MaxNested is 0.
+	// A negative MaxNested means unlimited.
+	DefaultMaxNested = 64
+	// DefaultExtrasMaxDepth is how deep FindCompressedFiles walks extract output
+	// looking for nested archives. 0 is the search root; 2 is two subfolders.
+	DefaultExtrasMaxDepth = 2
 )
 
 // Config is the input data to configure the Xtract queue. Fill this out and
@@ -51,6 +57,9 @@ type Config struct {
 	// MaxRatio is the default maximum bytesWritten / archiveFileSize per archive.
 	// 0 means unlimited. Copied onto each XFile when Xtract.MaxRatio is 0.
 	MaxRatio float64
+	// MaxNested is the default maximum archives extracted from an archive's
+	// output (the extras pass). 0 uses DefaultMaxNested. Negative means unlimited.
+	MaxNested int
 }
 
 // Logger allows this library to write logs.

--- a/start.go
+++ b/start.go
@@ -63,7 +63,8 @@ type Config struct {
 	// ExtrasMaxDepth is the default extras-pass walk depth. 0 uses
 	// DefaultExtrasMaxDepth. Negative means unlimited.
 	ExtrasMaxDepth int
-	// AllowSymlinks includes symlink-named archive files when finding extras.
+	// AllowSymlinks allows the initial search to include symlink-named archives.
+	// The extras/recursion pass never follows archive-member symlinks.
 	// Default false.
 	AllowSymlinks bool
 }

--- a/start.go
+++ b/start.go
@@ -60,6 +60,9 @@ type Config struct {
 	// MaxNested is the default maximum archives extracted from an archive's
 	// output (the extras pass). 0 uses DefaultMaxNested. Negative means unlimited.
 	MaxNested int
+	// ExtrasMaxDepth is the default extras-pass walk depth. 0 uses
+	// DefaultExtrasMaxDepth. Negative means unlimited.
+	ExtrasMaxDepth int
 }
 
 // Logger allows this library to write logs.

--- a/start.go
+++ b/start.go
@@ -63,6 +63,9 @@ type Config struct {
 	// ExtrasMaxDepth is the default extras-pass walk depth. 0 uses
 	// DefaultExtrasMaxDepth. Negative means unlimited.
 	ExtrasMaxDepth int
+	// AllowSymlinks includes symlink-named archive files when finding extras.
+	// Default false.
+	AllowSymlinks bool
 }
 
 // Logger allows this library to write logs.

--- a/start.go
+++ b/start.go
@@ -12,12 +12,6 @@ const (
 	// DefaultBufferSize is the size of the extraction buffer.
 	// ie. How many jobs can be queued before things get slow.
 	DefaultBufferSize = 1000
-	// DefaultMaxNested is the extras-pass archive cap when MaxNested is 0.
-	// A negative MaxNested means unlimited.
-	DefaultMaxNested = 64
-	// DefaultExtrasMaxDepth is how deep FindCompressedFiles walks extract output
-	// looking for nested archives. 0 is the search root; 2 is two subfolders.
-	DefaultExtrasMaxDepth = 2
 )
 
 // Config is the input data to configure the Xtract queue. Fill this out and
@@ -57,16 +51,13 @@ type Config struct {
 	// MaxRatio is the default maximum bytesWritten / archiveFileSize per archive.
 	// 0 means unlimited. Copied onto each XFile when Xtract.MaxRatio is 0.
 	MaxRatio float64
-	// MaxNested is the default maximum archives extracted from an archive's
-	// output (the extras pass). 0 uses DefaultMaxNested. Negative means unlimited.
+	// MaxNested is the default maximum archives extracted from one source folder's
+	// extras pass. 0 or negative means unlimited. Used when Xtract.MaxNested is 0.
 	MaxNested int
-	// ExtrasMaxDepth is the default extras-pass walk depth. 0 uses
-	// DefaultExtrasMaxDepth. Negative means unlimited.
+	// ExtrasMaxDepth is the default extras-pass walk depth. 0 means unlimited.
+	// Used when Xtract.ExtrasMaxDepth is 0. Negative also means unlimited.
+	// 0 is the search root; 2 is two subfolders.
 	ExtrasMaxDepth int
-	// AllowSymlinks allows the initial search to include symlink-named archives.
-	// The extras/recursion pass never follows archive-member symlinks.
-	// Default false.
-	AllowSymlinks bool
 }
 
 // Logger allows this library to write logs.


### PR DESCRIPTION
## Summary
- `FindCompressedFiles` does not treat symlink-named archive files as archives unless `AllowSymlinks` is set on `Filter`/`Xtract` or `XFile`. Default is off. A symlink passed as `Filter.Path` is followed (operator-chosen search root); symlink directories found during the walk are never followed.
- `AllowSymlinks` is job-level only (not on `Config`). It applies to the initial search/extract. The extras pass never lists or extracts zip-named symlinks that came out of an archive.
- `ExtractFile` refuses a symlink archive unless `XFile.AllowSymlinks` is set, and wraps that refusal as `*ExtractError`.
- `MaxNested` and `ExtrasMaxDepth` live on `Xtract`/`Config`. `0` inherits `Config`, then unlimited. Negative is also unlimited. There is no baked-in default of 64 or 2.
- `MaxNested` is per source folder / one extras pass (not a job-wide total, not a second recursion). Exceeding it returns `ErrMaxNested` and deletes that folder's extract output. The extras listing also stops after `MaxNested+1` when a cap is set.

Inode/hardlink dedupe of extras is a follow-up stacked on this (#183).

## Test plan
- [ ] `go test` — symlink skip, `AllowSymlinks` on Find/ExtractFile, extras still skip archive-member zip links when the job allows initial links
- [ ] Queue: zip of zip-symlinks extracts the real child once
- [ ] Queue: 3 distinct nested zips with `MaxNested=2` returns `ErrMaxNested`
- [ ] Queue: `ExtrasMaxDepth=2` leaves `a/b/c/inner.zip` unextracted; `ExtrasMaxDepth=3` extracts it
- [ ] `ExtractFile` symlink refuse is `errors.Is(..., ErrArchiveSymlink)` and `errors.As(..., *ExtractError)`