### PR TITLE
Dedupe extras archives by device and inode

### DIFF
--- a/fileid.go
+++ b/fileid.go
@@ -1,0 +1,19 @@
+package xtractr
+
+// rememberFile returns false when path is a later alias of a file already in
+// seen (same device+inode, or resolved path when inode data is unavailable).
+// Paths that cannot be identified are kept (fail open).
+func rememberFile(seen map[string]struct{}, path string) bool {
+	identity, ok := identifyFile(path)
+	if !ok {
+		return true
+	}
+
+	if _, dup := seen[identity]; dup {
+		return false
+	}
+
+	seen[identity] = struct{}{}
+
+	return true
+}

--- a/fileid_internal_test.go
+++ b/fileid_internal_test.go
@@ -1,0 +1,77 @@
+package xtractr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRememberFileHardlinks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "orig.zip")
+	alias := filepath.Join(dir, "alias.zip")
+
+	require.NoError(t, os.WriteFile(orig, []byte("pk"), 0o600))
+
+	err := os.Link(orig, alias)
+	if err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+
+	other := filepath.Join(dir, "other.zip")
+	require.NoError(t, os.WriteFile(other, []byte("pk2"), 0o600))
+
+	seen := make(map[string]struct{})
+	assert.True(t, rememberFile(seen, orig))
+	assert.False(t, rememberFile(seen, alias))
+	assert.True(t, rememberFile(seen, other))
+}
+
+func TestRememberFileSymlinkAliases(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "orig.zip")
+	require.NoError(t, os.WriteFile(orig, []byte("pk"), 0o600))
+
+	link := filepath.Join(dir, "link.zip")
+
+	err := os.Symlink(orig, link)
+	if err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	seen := make(map[string]struct{})
+	assert.True(t, rememberFile(seen, orig))
+	assert.False(t, rememberFile(seen, link))
+}
+
+func TestExtrasAcceptSkipsRecursionAndHardlinks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "orig.zip")
+	alias := filepath.Join(dir, "alias.zip")
+	cue := filepath.Join(dir, "copied.cue.zip")
+	other := filepath.Join(dir, "other.zip")
+
+	require.NoError(t, os.WriteFile(orig, []byte("pk"), 0o600))
+	require.NoError(t, os.WriteFile(cue, []byte("pk"), 0o600))
+	require.NoError(t, os.WriteFile(other, []byte("pk2"), 0o600))
+
+	err := os.Link(orig, alias)
+	if err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+
+	accept := extrasAccept([]string{cue})
+	assert.False(t, accept(ArchiveCandidate{Path: cue}))
+	assert.True(t, accept(ArchiveCandidate{Path: orig}))
+	assert.False(t, accept(ArchiveCandidate{Path: alias}))
+	assert.True(t, accept(ArchiveCandidate{Path: other}))
+}

--- a/fileid_other.go
+++ b/fileid_other.go
@@ -1,0 +1,17 @@
+//go:build !unix && !windows
+
+package xtractr
+
+import (
+	"path/filepath"
+)
+
+// identifyFile falls back to the resolved path when inode data is unavailable.
+func identifyFile(path string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = filepath.Clean(path)
+	}
+
+	return resolved, true
+}

--- a/fileid_other.go
+++ b/fileid_other.go
@@ -13,5 +13,10 @@ func identifyFile(path string) (string, bool) {
 		resolved = filepath.Clean(path)
 	}
 
-	return resolved, true
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", false
+	}
+
+	return abs, true
 }

--- a/fileid_unix.go
+++ b/fileid_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package xtractr
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// identifyFile follows the path (so symlink aliases share an identity) and
+// returns the device and inode of the target.
+func identifyFile(path string) (string, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", false
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", false
+	}
+
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino), true
+}

--- a/fileid_windows.go
+++ b/fileid_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package xtractr
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const fileIndexHighShift = 32
+
+// identifyFile follows the path and returns the volume serial plus file index.
+func identifyFile(path string) (string, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close()
+
+	var info syscall.ByHandleFileInformation
+
+	err = syscall.GetFileInformationByHandle(syscall.Handle(file.Fd()), &info)
+	if err != nil {
+		return "", false
+	}
+
+	ino := uint64(info.FileIndexHigh)<<fileIndexHighShift | uint64(info.FileIndexLow)
+
+	return fmt.Sprintf("%d:%d", info.VolumeSerialNumber, ino), true
+}

--- a/queue.go
+++ b/queue.go
@@ -327,7 +327,8 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 	}
 
 	// Now do it again with the output folder. extrasFilter.Accept skips
-	// extractor-copied paths (e.g. CUE sheets) so they do not consume MaxArchives.
+	// extractor-copied paths and duplicate device+inode aliases so they
+	// do not consume MaxArchives.
 	resp.Extras = FindCompressedFiles(x.extrasFilter(resp))
 
 	err = x.checkExtrasLimit(resp)
@@ -460,7 +461,7 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
 		MaxDepth:      pick(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
-		Accept:        skipRecursionPaths(resp.SkipOnRecursion),
+		Accept:        extrasAccept(resp.SkipOnRecursion),
 	}
 
 	if limit := pick(resp.X.MaxNested, x.config.MaxNested); limit > 0 {
@@ -468,6 +469,21 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 	}
 
 	return filter
+}
+
+// extrasAccept skips extractor-copied paths (e.g. a CUE sheet) and later
+// names that share a device+inode with a path already accepted.
+func extrasAccept(exclude []string) func(ArchiveCandidate) bool {
+	skip := skipRecursionPaths(exclude)
+	seen := make(map[string]struct{})
+
+	return func(candidate ArchiveCandidate) bool {
+		if skip != nil && !skip(candidate) {
+			return false
+		}
+
+		return rememberFile(seen, candidate.Path)
+	}
 }
 
 // skipRecursionPaths returns an Accept func that rejects extractor-copied

--- a/queue.go
+++ b/queue.go
@@ -474,32 +474,16 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 // extrasAccept skips extractor-copied paths (e.g. a CUE sheet) and later
 // names that share a device+inode with a path already accepted.
 func extrasAccept(exclude []string) func(ArchiveCandidate) bool {
-	skip := skipRecursionPaths(exclude)
-	seen := make(map[string]struct{})
-
-	return func(candidate ArchiveCandidate) bool {
-		if skip != nil && !skip(candidate) {
-			return false
-		}
-
-		return rememberFile(seen, candidate.Path)
-	}
-}
-
-// skipRecursionPaths returns an Accept func that rejects extractor-copied
-// paths (e.g. a CUE sheet). Nil when there is nothing to skip.
-func skipRecursionPaths(exclude []string) func(ArchiveCandidate) bool {
-	if len(exclude) == 0 {
-		return nil
-	}
-
 	skip := make(map[string]bool, len(exclude))
 	for _, p := range exclude {
 		skip[filepath.Clean(p)] = true
 	}
 
+	// This lives through the extras pass.
+	seen := make(map[string]struct{})
+
 	return func(candidate ArchiveCandidate) bool {
-		return !skip[filepath.Clean(candidate.Path)]
+		return !skip[filepath.Clean(candidate.Path)] && rememberFile(seen, candidate.Path)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extras `Filter.Accept` now rejects later hardlink and symlink aliases of the same file (device+inode; resolved path where inode data is unavailable). Skipped aliases do not count toward `MaxArchives` / `MaxNested`.
- CUE `SkipOnRecursion` still runs in the same Accept hook (from #184).

Based on `main` (includes #182 and #184).

## Test plan
- [ ] Hardlinks to the same zip: first path accepted, alias rejected
- [ ] Symlink aliases of the same zip collapse to one identity
- [ ] Copied-CUE skip still works with the composed Accept
- [x] Windows golangci-lint (`fileIndexHighShift`)
- [x] `go test ./...`