### PR TITLE
Add Filter.Accept so Find skips without consuming MaxArchives

### DIFF
--- a/extras_internal_test.go
+++ b/extras_internal_test.go
@@ -1,9 +1,12 @@
 package xtractr
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPick(t *testing.T) {
@@ -17,4 +20,31 @@ func TestPick(t *testing.T) {
 	assert.Equal(t, -1, pick(0, -1))
 	assert.Equal(t, -1, pick(-1, 4))
 	assert.Equal(t, uint64(3), pick(uint64(0), uint64(3)))
+}
+
+func TestExtrasFilterAcceptSkipsRecursionPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	keep := filepath.Join(dir, "keep.zip")
+	skip := filepath.Join(dir, "copied-cue.zip")
+	extra := filepath.Join(dir, "extra.zip")
+
+	for _, path := range []string{skip, keep, extra} {
+		require.NoError(t, os.WriteFile(path, []byte("pk"), 0o600))
+	}
+
+	queue := &Xtractr{config: &Config{}}
+	filter := queue.extrasFilter(&Response{
+		X:               &Xtract{MaxNested: 1},
+		Output:          dir,
+		SkipOnRecursion: []string{skip},
+	})
+	require.Equal(t, 2, filter.MaxArchives)
+
+	found := FindCompressedFiles(filter)
+	assert.Equal(t, 2, found.Count(), "skipped CUE copy must not consume MaxArchives")
+	assert.NotContains(t, found.List(), skip)
+	assert.Contains(t, found.List(), keep)
+	assert.Contains(t, found.List(), extra)
 }

--- a/files.go
+++ b/files.go
@@ -218,6 +218,17 @@ type Filter struct {
 	// followed; a symlink passed as Path is (operator-chosen search root).
 	// The extras/recursion pass always ignores this and never lists archive-member links.
 	AllowSymlinks bool
+	// Accept, if set, is called when Find is about to add an archive.
+	// Return false to skip it; skipped paths do not count toward MaxArchives.
+	Accept func(ArchiveCandidate) bool
+}
+
+// ArchiveCandidate is passed to Filter.Accept when Find is about to list a path.
+type ArchiveCandidate struct {
+	// Path is the archive file being considered.
+	Path string
+	// Info is the Lstat of Path. May be nil if the path could not be stated.
+	Info os.FileInfo
 }
 
 // Exclude represents an exclusion list.
@@ -308,7 +319,7 @@ func (e Exclude) Has(test string) bool {
 // so if the rar archive does not have "part" followed by a number in the name, then it will be
 // considered an independent archive. Some packagers seem to use different naming schemes,
 // so this may need to be updated as time progresses. Use the input to Filter to adjust the output.
-func FindCompressedFiles(filter Filter) ArchiveList {
+func FindCompressedFiles(filter Filter) ArchiveList { //nolint:gocritic // public API; Filter is a value.
 	return findCompressedFiles(filter.Path, &filter, 0)
 }
 
@@ -330,6 +341,11 @@ func findCompressedFiles(path string, filter *Filter, depth int) ArchiveList {
 
 	if !info.IsDir() && IsArchiveFile(path) {
 		if skipSymlinkArchivePath(filter, path) {
+			return nil
+		}
+
+		linkInfo, _ := os.Lstat(path)
+		if !acceptArchive(filter, path, linkInfo) {
 			return nil
 		}
 
@@ -421,17 +437,34 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 			partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
 			// Some archives are named poorly. Only return part01 or part001, not all.
 			if !hasParts.MatchString(lowerName) || partOne.MatchString(lowerName) {
-				files[path] = append(files[path], filepath.Join(path, file.Name()))
+				addArchive(files, path, file, filter)
 			}
 		case strings.HasSuffix(lowerName, ".r00") && !CheckR00ForRarFile(fileList, lowerName):
 			// Accept .r00 as the first archive file if no .rar files are present in the path.
-			files[path] = append(files[path], filepath.Join(path, file.Name()))
+			addArchive(files, path, file, filter)
 		case !strings.HasSuffix(lowerName, ".r00") && IsArchiveFile(lowerName):
-			files[path] = append(files[path], filepath.Join(path, file.Name()))
+			addArchive(files, path, file, filter)
 		}
 	}
 
 	return files
+}
+
+func addArchive(files ArchiveList, dir string, file os.FileInfo, filter *Filter) {
+	path := filepath.Join(dir, file.Name())
+	if !acceptArchive(filter, path, file) {
+		return
+	}
+
+	files[dir] = append(files[dir], path)
+}
+
+func acceptArchive(filter *Filter, path string, info os.FileInfo) bool {
+	if filter == nil || filter.Accept == nil {
+		return true
+	}
+
+	return filter.Accept(ArchiveCandidate{Path: path, Info: info})
 }
 
 func archivesAtCap(files ArchiveList, filter *Filter) bool {

--- a/files.go
+++ b/files.go
@@ -344,8 +344,7 @@ func findCompressedFiles(path string, filter *Filter, depth int) ArchiveList {
 			return nil
 		}
 
-		linkInfo, _ := os.Lstat(path)
-		if !acceptArchive(filter, path, linkInfo) {
+		if linkInfo, _ := os.Lstat(path); !acceptArchive(filter, path, linkInfo) {
 			return nil
 		}
 
@@ -417,11 +416,9 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 	files := ArchiveList{}
 
 	for _, file := range fileList {
-		if archivesAtCap(files, filter) {
-			return files
-		}
-
 		switch lowerName := strings.ToLower(file.Name()); {
+		case archivesAtCap(files, filter):
+			return files
 		case file.Mode()&os.ModeSymlink != 0 &&
 			(!filter.AllowSymlinks || symlinkTargetsDir(path, file.Name())):
 			continue // skip symlink archives unless allowed; never walk symlink dirs.
@@ -452,19 +449,13 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 
 func addArchive(files ArchiveList, dir string, file os.FileInfo, filter *Filter) {
 	path := filepath.Join(dir, file.Name())
-	if !acceptArchive(filter, path, file) {
-		return
+	if acceptArchive(filter, path, file) {
+		files[dir] = append(files[dir], path)
 	}
-
-	files[dir] = append(files[dir], path)
 }
 
 func acceptArchive(filter *Filter, path string, info os.FileInfo) bool {
-	if filter == nil || filter.Accept == nil {
-		return true
-	}
-
-	return filter.Accept(ArchiveCandidate{Path: path, Info: info})
+	return filter == nil || filter.Accept == nil || filter.Accept(ArchiveCandidate{Path: path, Info: info})
 }
 
 func archivesAtCap(files ArchiveList, filter *Filter) bool {

--- a/files_test.go
+++ b/files_test.go
@@ -162,6 +162,27 @@ func TestFindCompressedFilesMaxArchives(t *testing.T) {
 	assert.Equal(t, 3, paths.Count())
 }
 
+func TestFindCompressedFilesAcceptSkipsAndDoesNotCount(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	skip := filepath.Join(base, "skip.zip")
+	for _, name := range []string{"skip.zip", "keep1.zip", "keep2.zip", "keep3.zip"} {
+		require.NoError(t, os.WriteFile(filepath.Join(base, name), []byte("pk"), 0o600))
+	}
+
+	paths := xtractr.FindCompressedFiles(xtractr.Filter{
+		Path:        base,
+		MaxArchives: 2,
+		Accept: func(candidate xtractr.ArchiveCandidate) bool {
+			return candidate.Path != skip
+		},
+	})
+	assert.Equal(t, 2, paths.Count())
+	assert.NotContains(t, paths.List(), skip)
+}
+
 func TestFindCompressedFilesSkipsSymlinkPath(t *testing.T) {
 	t.Parallel()
 

--- a/queue.go
+++ b/queue.go
@@ -313,37 +313,6 @@ func weExtractedAnISO(resp *Response) bool {
 	return false
 }
 
-// excludePathsFromArchiveList returns a copy of list with any archive path that
-// appears in exclude (e.g. resp.SkipOnRecursion) removed.
-func excludePathsFromArchiveList(list ArchiveList, exclude []string) ArchiveList {
-	if len(exclude) == 0 {
-		return list
-	}
-
-	skip := make(map[string]bool, len(exclude))
-	out := make(ArchiveList, len(list))
-
-	for _, p := range exclude {
-		skip[filepath.Clean(p)] = true
-	}
-
-	for dir, archives := range list {
-		keep := make([]string, 0, len(archives))
-
-		for _, p := range archives {
-			if !skip[filepath.Clean(p)] {
-				keep = append(keep, p)
-			}
-		}
-
-		if len(keep) > 0 {
-			out[dir] = keep
-		}
-	}
-
-	return out
-}
-
 // decompressFiles runs after we find and verify archives exist.
 // This extracts everything in the search path then (optionally)
 // checks the output path for more archives that were just decompressed.
@@ -357,12 +326,9 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 		return x.cleanupProcessedArchives(resp)
 	}
 
-	// Now do it again with the output folder.
+	// Now do it again with the output folder. extrasFilter.Accept skips
+	// extractor-copied paths (e.g. CUE sheets) so they do not consume MaxArchives.
 	resp.Extras = FindCompressedFiles(x.extrasFilter(resp))
-	// Do not try to extract files that an extractor copied into output (e.g. CUE sheet);
-	// re-extracting the copied CUE would fail and delete the output directory.
-	// Other archives in the output (e.g. CUE+FLAC from a RAR) are still extracted.
-	resp.Extras = excludePathsFromArchiveList(resp.Extras, resp.SkipOnRecursion)
 
 	err = x.checkExtrasLimit(resp)
 	if err != nil {
@@ -494,6 +460,7 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 		Path:          resp.Output,
 		ExcludeSuffix: resp.X.ExcludeSuffix,
 		MaxDepth:      pick(resp.X.ExtrasMaxDepth, x.config.ExtrasMaxDepth),
+		Accept:        skipRecursionPaths(resp.SkipOnRecursion),
 	}
 
 	if limit := pick(resp.X.MaxNested, x.config.MaxNested); limit > 0 {
@@ -501,6 +468,23 @@ func (x *Xtractr) extrasFilter(resp *Response) Filter {
 	}
 
 	return filter
+}
+
+// skipRecursionPaths returns an Accept func that rejects extractor-copied
+// paths (e.g. a CUE sheet). Nil when there is nothing to skip.
+func skipRecursionPaths(exclude []string) func(ArchiveCandidate) bool {
+	if len(exclude) == 0 {
+		return nil
+	}
+
+	skip := make(map[string]bool, len(exclude))
+	for _, p := range exclude {
+		skip[filepath.Clean(p)] = true
+	}
+
+	return func(candidate ArchiveCandidate) bool {
+		return !skip[filepath.Clean(candidate.Path)]
+	}
 }
 
 // checkExtrasLimit applies MaxNested to this extras list only (one source


### PR DESCRIPTION
## Summary
- `Filter.Accept` is called with an `ArchiveCandidate` (`Path`, `Info`) before Find lists a path. Returning false skips it; skipped paths do not count toward `MaxArchives`.
- The extras pass uses that hook for `SkipOnRecursion` (copied CUE sheets) instead of post-filtering the list after the walk.
- `ArchiveCandidate` is a struct so later work (inode/hardlink dedupe on #183) can compose in the same closure.

## Test plan
- [ ] `FindCompressedFiles` with `Accept` skipping one zip and `MaxArchives: 2` returns two keepers, not the skip
- [ ] extras filter: copied-CUE path + `MaxNested: 1` still finds the two real extras
- [ ] `go test ./...`


Made with [Cursor](https://cursor.com)