### PR TITLE
Share extract caps with extras via the tighter leftover

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,13 @@ type XFile struct {
 
 ### Input Safety
 
-Per-archive caps on `XFile`, `Xtract`, and `Config` (`0` means unlimited):
+Extraction caps (`0` means unlimited):
 
-- `MaxBytes` — uncompressed bytes written for one archive
-- `MaxFiles` — files, directories, and symlinks created for one archive
+- `MaxBytes` — uncompressed bytes written
+- `MaxFiles` — files, directories, and symlinks created
 - `MaxRatio` — `bytesWritten / archiveFileSize`
+
+On a queue job (`Xtract`/`Config`) these apply **per top-level archive**. Two sibling rips in one folder each get a full cap. Extras from that folder share the **tighter leftover** (smallest remaining byte/ratio room, then files). `MaxRatio` keeps the parent archive size, not child compressed sizes. Standalone `XFile` stays per-archive.
 
 Queue extras caps on `Xtract` and `Config` (`0` inherits `Config`, then unlimited):
 
@@ -225,7 +227,7 @@ Queue extras caps on `Xtract` and `Config` (`0` inherits `Config`, then unlimite
 `AllowSymlinks` is on `Filter`/`Xtract` and `XFile` (default false). When set, the initial search may include
 symlink-named archives. The extras pass never follows archive-member links.
 
-Exceeding `MaxBytes`/`MaxFiles`/`MaxRatio` returns those errors and stops the extract.
+Exceeding `MaxBytes`/`MaxFiles`/`MaxRatio` returns those errors and stops the extract (and extras if the tighter leftover is already used).
 Exceeding `MaxNested` returns `ErrMaxNested` and deletes that folder's extract output.
 Queue jobs inherit `Config` values when the `Xtract` field is `0`.
 

--- a/extras_test.go
+++ b/extras_test.go
@@ -131,6 +131,91 @@ func TestQueueExtrasMaxDepthSkipsDeepArchives(t *testing.T) {
 	require.FileExists(t, filepath.Join(out, "near.txt"))
 }
 
+func TestQueueSiblingArchivesGetOwnMaxFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeOuterZip(t, filepath.Join(dir, "one.zip"), map[string][]byte{"one.txt": []byte("1")}, nil)
+	writeOuterZip(t, filepath.Join(dir, "two.zip"), map[string][]byte{"two.txt": []byte("2")}, nil)
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:   xtractr.NoLogger(),
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:           xtractr.Filter{Path: dir},
+		TempFolder:       true,
+		DisableRecursion: true,
+		MaxFiles:         1,
+		CBChannel:        make(chan *xtractr.Response, 2),
+	}
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+
+	resp := waitExtract(t, job.CBChannel)
+	require.NoError(t, resp.Error)
+
+	out := firstExisting(t, resp.Output, dir+xtractr.DefaultSuffix)
+	require.FileExists(t, filepath.Join(out, "one.txt"))
+	require.FileExists(t, filepath.Join(out, "two.txt"))
+}
+
+func TestQueueArchiveBudgetSharesFilesWithExtras(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	writeOuterZip(t, src, map[string][]byte{
+		"inner.zip": tinyZipBytes(t, "hello.txt", "from-inner"),
+	}, nil)
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:   xtractr.NoLogger(),
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: true,
+		MaxFiles:   1,
+		CBChannel:  make(chan *xtractr.Response, 2),
+	}
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+	require.ErrorIs(t, waitExtract(t, job.CBChannel).Error, xtractr.ErrMaxFiles)
+}
+
+func TestQueueArchiveBudgetSharesBytesWithExtras(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "outer.zip")
+	inner := tinyZipBytes(t, "big.txt", string(make([]byte, 4096)))
+	writeOuterZip(t, src, map[string][]byte{"inner.zip": inner}, nil)
+
+	queue := xtractr.NewQueue(&xtractr.Config{
+		Logger:   xtractr.NoLogger(),
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+	defer queue.Stop()
+
+	job := &xtractr.Xtract{
+		Filter:     xtractr.Filter{Path: dir},
+		TempFolder: true,
+		MaxBytes:   uint64(len(inner) + 64),
+		CBChannel:  make(chan *xtractr.Response, 2),
+	}
+	_, err := queue.Extract(job)
+	require.NoError(t, err)
+	require.ErrorIs(t, waitExtract(t, job.CBChannel).Error, xtractr.ErrMaxBytes)
+}
+
 func TestQueueExtrasMaxDepthOverrideExtractsDeep(t *testing.T) {
 	t.Parallel()
 

--- a/progress.go
+++ b/progress.go
@@ -43,6 +43,13 @@ type progressTracker struct {
 	// shared is set so a top-level archive and that folder's extras reuse
 	// Wrote/Files and the parent Compressed size used for MaxRatio.
 	shared bool
+	// snap* are this archive's progress baseline. Limits still use the
+	// cumulative Wrote/Files/Compressed on Progress; snapshot() subtracts
+	// these so callbacks stay per-archive (extras Percent must not be
+	// parent Wrote / child Total).
+	snapWrote      uint64
+	snapFiles      int
+	snapCompressed uint64
 }
 
 // Percent returns the percent of bytes read or written.
@@ -125,8 +132,9 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 }
 
 // bindSharedProgress rebinds a shared tracker to this XFile. Wrote, Files,
-// and Compressed stay (Compressed is filled once from the first archive);
-// Read/Done/headerErr reset.
+// and Compressed stay for the cap (Compressed is filled once from the first
+// archive). Read/Done/headerErr reset. snap* mark this archive so snapshot()
+// reports only its progress.
 func (x *XFile) bindSharedProgress(total, compressed uint64, count int) {
 	x.prog.mu.Lock()
 	x.prog.Total = total
@@ -135,6 +143,9 @@ func (x *XFile) bindSharedProgress(total, compressed uint64, count int) {
 	x.prog.Read = 0
 	x.prog.Done = false
 	x.prog.headerErr = nil
+	x.prog.snapWrote = x.prog.Wrote
+	x.prog.snapFiles = x.prog.Files
+	x.prog.snapCompressed = compressed
 
 	if x.prog.Compressed == 0 {
 		x.prog.Compressed = compressed
@@ -219,11 +230,33 @@ func (x *XFile) continueArchiveProgress(total, compressed uint64, count int) *pr
 }
 
 // snapshot returns a copy of the Progress data, safe to send to callbacks/channels.
+// Shared trackers report this archive only; cap counters stay cumulative.
 func (p *progressTracker) snapshot() Progress {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.Progress
+	out := p.Progress
+	if !p.shared {
+		return out
+	}
+
+	if out.Wrote >= p.snapWrote {
+		out.Wrote -= p.snapWrote
+	} else {
+		out.Wrote = 0
+	}
+
+	if out.Files >= p.snapFiles {
+		out.Files -= p.snapFiles
+	} else {
+		out.Files = 0
+	}
+
+	if p.snapCompressed > 0 {
+		out.Compressed = p.snapCompressed
+	}
+
+	return out
 }
 
 // safeSend attempts to send a progress update without blocking.

--- a/progress.go
+++ b/progress.go
@@ -40,6 +40,9 @@ type progressTracker struct {
 
 	mu        sync.Mutex
 	headerErr error // optional fast-fail from claimed archive headers
+	// shared is set so a top-level archive and that folder's extras reuse
+	// Wrote/Files and the parent Compressed size used for MaxRatio.
+	shared bool
 }
 
 // Percent returns the percent of bytes read or written.
@@ -105,13 +108,44 @@ func ArchiveProgress(every float64, progress chan Progress, reset, exit bool) { 
 }
 
 func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracker {
+	if x.prog != nil && x.prog.shared {
+		x.bindSharedProgress(total, compressed, count)
+		return x.prog
+	}
+
 	tracker := &progressTracker{}
 	tracker.Total = total
 	tracker.Compressed = compressed
 	tracker.Count = count
 	tracker.XFile = x
-	tracker.send = func() {}
 	x.prog = tracker
+	x.bindProgressSend(tracker)
+
+	return tracker
+}
+
+// bindSharedProgress rebinds a shared tracker to this XFile. Wrote, Files,
+// and Compressed stay (Compressed is filled once from the first archive);
+// Read/Done/headerErr reset.
+func (x *XFile) bindSharedProgress(total, compressed uint64, count int) {
+	x.prog.mu.Lock()
+	x.prog.Total = total
+	x.prog.Count = count
+	x.prog.XFile = x
+	x.prog.Read = 0
+	x.prog.Done = false
+	x.prog.headerErr = nil
+
+	if x.prog.Compressed == 0 {
+		x.prog.Compressed = compressed
+	}
+
+	x.prog.mu.Unlock()
+	x.bindProgressSend(x.prog)
+}
+
+func (x *XFile) bindProgressSend(tracker *progressTracker) {
+	tracker.send = func() {}
 
 	if x.Progress != nil {
 		tracker.send = func() {
@@ -124,8 +158,6 @@ func (x *XFile) newProgress(total, compressed uint64, count int) *progressTracke
 			x.Updates <- tracker.snapshot()
 		}
 	}
-
-	return tracker
 }
 
 // newArchiveProgress is newProgress with Compressed set to the archive file
@@ -140,11 +172,11 @@ func (x *XFile) newArchiveProgress(total, compressed uint64, count int) *progres
 	}
 
 	tracker := x.newProgress(total, compressed, count)
-	tracker.headerErr = x.checkClaimedLimits(total, count, compressed)
+	tracker.headerErr = x.checkClaimedLimits(total, count, tracker.Compressed)
 
 	// Fail closed: MaxRatio with no denominator would otherwise be treated as
 	// unlimited (exceedsRatio used to return false when compressed == 0).
-	if tracker.headerErr == nil && x.MaxRatio > 0 && compressed == 0 {
+	if tracker.headerErr == nil && x.MaxRatio > 0 && tracker.Compressed == 0 {
 		tracker.headerErr = fmt.Errorf("%w: compressed size unavailable", ErrMaxRatio)
 	}
 
@@ -164,6 +196,10 @@ func (x *XFile) archiveProgress(total, compressed uint64, count int) (*progressT
 // current tracker. Used when ISO9660 follows a partial UDF attempt so the same
 // MaxBytes/MaxFiles budget is not reset.
 func (x *XFile) continueArchiveProgress(total, compressed uint64, count int) *progressTracker {
+	if x.prog != nil && x.prog.shared {
+		return x.newArchiveProgress(total, compressed, count)
+	}
+
 	var wrote uint64
 
 	var files int
@@ -343,6 +379,101 @@ func archiveFileSize(path string) uint64 {
 	return uint64(info.Size())
 }
 
+func (p *progressTracker) wrote() uint64 {
+	if p == nil {
+		return 0
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.Wrote
+}
+
+func newSharedBudget() *progressTracker {
+	return &progressTracker{shared: true}
+}
+
+const (
+	unlimitedBytes = ^uint64(0)
+	unlimitedFiles = int(^uint(0) >> 1)
+)
+
+func remainingBytes(wrote, compressed, maxBytes uint64, maxRatio float64) uint64 {
+	room := unlimitedBytes
+
+	if maxBytes > 0 {
+		if wrote >= maxBytes {
+			return 0
+		}
+
+		room = maxBytes - wrote
+	}
+
+	if maxRatio > 0 {
+		if compressed == 0 {
+			if wrote > 0 {
+				return 0
+			}
+
+			return room
+		}
+
+		allowed := uint64(float64(compressed) * maxRatio)
+		if wrote >= allowed {
+			return 0
+		}
+
+		if left := allowed - wrote; left < room {
+			room = left
+		}
+	}
+
+	return room
+}
+
+func remainingFiles(files, maxFiles int) int {
+	if maxFiles <= 0 {
+		return unlimitedFiles
+	}
+
+	if files >= maxFiles {
+		return 0
+	}
+
+	return maxFiles - files
+}
+
+// tighterBudget returns the tracker with the least leftover room. Byte/ratio
+// leftovers decide first; file leftovers break ties. Nil entries are skipped.
+func tighterBudget(trackers []*progressTracker, maxBytes uint64, maxFiles int, maxRatio float64) *progressTracker {
+	var best *progressTracker
+
+	bestBytes := unlimitedBytes
+	bestFiles := unlimitedFiles
+
+	for _, tracker := range trackers {
+		if tracker == nil {
+			continue
+		}
+
+		tracker.mu.Lock()
+		wrote, files, compressed := tracker.Wrote, tracker.Files, tracker.Compressed
+		tracker.mu.Unlock()
+
+		bytesLeft := remainingBytes(wrote, compressed, maxBytes, maxRatio)
+		filesLeft := remainingFiles(files, maxFiles)
+
+		if best == nil || bytesLeft < bestBytes || (bytesLeft == bestBytes && filesLeft < bestFiles) {
+			best = tracker
+			bestBytes = bytesLeft
+			bestFiles = filesLeft
+		}
+	}
+
+	return best
+}
+
 func archiveFileSizes(paths ...string) uint64 {
 	var total uint64
 
@@ -357,15 +488,26 @@ func archiveFileSizes(paths ...string) uint64 {
 // configured caps. Headers can understate, so this never replaces runtime
 // checks in Write / addFileLocked.
 func (x *XFile) checkClaimedLimits(claimedBytes uint64, claimedFiles int, compressed uint64) error {
-	if x.MaxBytes > 0 && claimedBytes > x.MaxBytes {
+	var (
+		wrote uint64
+		files int
+	)
+
+	if x.prog != nil {
+		x.prog.mu.Lock()
+		wrote, files = x.prog.Wrote, x.prog.Files
+		x.prog.mu.Unlock()
+	}
+
+	if x.MaxBytes > 0 && wrote+claimedBytes > x.MaxBytes {
 		return ErrMaxBytes
 	}
 
-	if x.MaxFiles > 0 && claimedFiles > x.MaxFiles {
+	if x.MaxFiles > 0 && files+claimedFiles > x.MaxFiles {
 		return ErrMaxFiles
 	}
 
-	if claimedBytes > 0 && exceedsRatio(claimedBytes, compressed, x.MaxRatio) {
+	if claimedBytes > 0 && exceedsRatio(wrote+claimedBytes, compressed, x.MaxRatio) {
 		return ErrMaxRatio
 	}
 

--- a/progress.go
+++ b/progress.go
@@ -410,26 +410,32 @@ func remainingBytes(wrote, compressed, maxBytes uint64, maxRatio float64) uint64
 		room = maxBytes - wrote
 	}
 
-	if maxRatio > 0 {
-		if compressed == 0 {
-			if wrote > 0 {
-				return 0
-			}
-
-			return room
-		}
-
-		allowed := uint64(float64(compressed) * maxRatio)
-		if wrote >= allowed {
-			return 0
-		}
-
-		if left := allowed - wrote; left < room {
-			room = left
-		}
+	if left := remainingRatio(wrote, compressed, maxRatio); left < room {
+		return left
 	}
 
 	return room
+}
+
+func remainingRatio(wrote, compressed uint64, maxRatio float64) uint64 {
+	if maxRatio <= 0 {
+		return unlimitedBytes
+	}
+
+	if compressed == 0 {
+		if wrote > 0 {
+			return 0
+		}
+
+		return unlimitedBytes
+	}
+
+	allowed := uint64(float64(compressed) * maxRatio)
+	if wrote >= allowed {
+		return 0
+	}
+
+	return allowed - wrote
 }
 
 func remainingFiles(files, maxFiles int) int {
@@ -446,6 +452,7 @@ func remainingFiles(files, maxFiles int) int {
 
 // tighterBudget returns the tracker with the least leftover room. Byte/ratio
 // leftovers decide first; file leftovers break ties. Nil entries are skipped.
+// We get here when one folder has two or more archives with "extras" (child archives) in either or both of them.
 func tighterBudget(trackers []*progressTracker, maxBytes uint64, maxFiles int, maxRatio float64) *progressTracker {
 	var best *progressTracker
 

--- a/progress_internal_test.go
+++ b/progress_internal_test.go
@@ -102,6 +102,79 @@ func TestExceedsRatioFailsClosedWithoutCompressedSize(t *testing.T) {
 	require.True(t, exceedsRatio(1, 0, 2), "any write without a denominator exceeds")
 }
 
+func TestNewProgressSharedKeepsCompressedAndCounts(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{FilePath: "child.zip"}
+	xFile.prog = newSharedBudget()
+	xFile.prog.Compressed = 99
+	xFile.prog.Wrote = 7
+	xFile.prog.Files = 2
+
+	xFile.newProgress(50, 12345, 3)
+	require.Equal(t, uint64(99), xFile.prog.Compressed)
+	require.Equal(t, uint64(7), xFile.prog.Wrote)
+	require.Equal(t, 2, xFile.prog.Files)
+	require.Equal(t, uint64(50), xFile.prog.Total)
+	require.Equal(t, 3, xFile.prog.Count)
+}
+
+func TestCheckClaimedLimitsAddsExistingSharedCounts(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{MaxFiles: 5, MaxBytes: 100, MaxRatio: 2}
+	xFile.prog = newSharedBudget()
+	xFile.prog.Files = 4
+	xFile.prog.Wrote = 90
+
+	require.ErrorIs(t, xFile.checkClaimedLimits(0, 2, 10), ErrMaxFiles)
+	require.ErrorIs(t, xFile.checkClaimedLimits(20, 0, 10), ErrMaxBytes)
+	require.ErrorIs(t, xFile.checkClaimedLimits(1, 0, 10), ErrMaxRatio)
+}
+
+func TestTighterBudgetPicksSmallerRemainingBytes(t *testing.T) {
+	t.Parallel()
+
+	loose := &progressTracker{Progress: Progress{Wrote: 10, Compressed: 100}}
+	tight := &progressTracker{Progress: Progress{Wrote: 80, Compressed: 100}}
+
+	got := tighterBudget([]*progressTracker{loose, tight}, 100, 0, 0)
+	require.Equal(t, tight, got)
+}
+
+func TestTighterBudgetPicksSmallerRemainingFilesWhenBytesTie(t *testing.T) {
+	t.Parallel()
+
+	loose := &progressTracker{Progress: Progress{Wrote: 10, Files: 1}}
+	tight := &progressTracker{Progress: Progress{Wrote: 10, Files: 8}}
+
+	got := tighterBudget([]*progressTracker{loose, tight}, 100, 10, 0)
+	require.Equal(t, tight, got)
+}
+
+func TestTighterBudgetPicksSmallerRatioRoom(t *testing.T) {
+	t.Parallel()
+
+	// Same wrote; smaller Compressed leaves less MaxRatio room.
+	loose := &progressTracker{Progress: Progress{Wrote: 10, Compressed: 100}}
+	tight := &progressTracker{Progress: Progress{Wrote: 10, Compressed: 20}}
+
+	got := tighterBudget([]*progressTracker{loose, tight}, 0, 0, 2)
+	require.Equal(t, tight, got)
+}
+
+func TestNewProgressSharedFillsCompressedOnce(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{FilePath: "parent.zip"}
+	xFile.prog = newSharedBudget()
+	xFile.newProgress(50, 40, 1)
+	require.Equal(t, uint64(40), xFile.prog.Compressed)
+
+	xFile.newProgress(10, 999, 1)
+	require.Equal(t, uint64(40), xFile.prog.Compressed)
+}
+
 func TestArchiveProgressFailsClosedWithoutCompressedSize(t *testing.T) {
 	t.Parallel()
 

--- a/progress_internal_test.go
+++ b/progress_internal_test.go
@@ -163,6 +163,32 @@ func TestTighterBudgetPicksSmallerRatioRoom(t *testing.T) {
 	require.Equal(t, tight, got)
 }
 
+func TestSharedSnapshotIsPerArchive(t *testing.T) {
+	t.Parallel()
+
+	xFile := &XFile{FilePath: "child.zip"}
+	xFile.prog = newSharedBudget()
+	xFile.prog.Compressed = 99
+	xFile.prog.Wrote = 700
+	xFile.prog.Files = 5
+
+	xFile.newProgress(50, 20, 3)
+	xFile.prog.Wrote += 10
+	xFile.prog.Files++
+	xFile.prog.Read = 4
+
+	snap := xFile.prog.snapshot()
+	require.Equal(t, uint64(10), snap.Wrote)
+	require.Equal(t, 1, snap.Files)
+	require.Equal(t, uint64(20), snap.Compressed)
+	require.Equal(t, uint64(50), snap.Total)
+	require.InDelta(t, 20, snap.Percent(), 0.01)
+
+	require.Equal(t, uint64(710), xFile.prog.Wrote, "cap Wrote stays cumulative")
+	require.Equal(t, 6, xFile.prog.Files)
+	require.Equal(t, uint64(99), xFile.prog.Compressed, "MaxRatio keeps parent size")
+}
+
 func TestNewProgressSharedFillsCompressedOnce(t *testing.T) {
 	t.Parallel()
 

--- a/queue.go
+++ b/queue.go
@@ -52,14 +52,20 @@ type Xtract struct {
 	// Contains info about the progress of the extraction.
 	// Shared by all archive file extractions that occur with this Xtract.
 	Updates chan Progress
-	// MaxBytes is the maximum uncompressed bytes written per archive.
-	// 0 means unlimited; when 0, Config.MaxBytes is used.
+	// MaxBytes is the maximum uncompressed bytes written for one top-level
+	// archive. Extras in that folder share the tighter leftover among those
+	// archives. 0 means unlimited; when 0, Config.MaxBytes is used.
+	// Standalone XFile remains per-archive.
 	MaxBytes uint64
-	// MaxFiles is the maximum files, directories, and symlinks created per archive.
-	// 0 means unlimited; when 0, Config.MaxFiles is used.
+	// MaxFiles is the maximum files, directories, and symlinks created for
+	// one top-level archive (extras share the tighter leftover). 0 means
+	// unlimited; when 0, Config.MaxFiles is used. Standalone XFile remains
+	// per-archive.
 	MaxFiles int
-	// MaxRatio is the maximum bytesWritten / archiveFileSize per archive.
-	// 0 means unlimited; when 0, Config.MaxRatio is used.
+	// MaxRatio is totalWritten / that archive's compressed size. Extras keep
+	// the parent size (child sizes are not added) and share the tighter
+	// leftover. 0 means unlimited; when 0, Config.MaxRatio is used.
+	// Standalone XFile remains per-archive.
 	MaxRatio float64
 	// MaxNested is the maximum archives extracted from one source folder's
 	// output (one extras pass). 0 means unlimited; when 0, Config.MaxNested
@@ -127,6 +133,10 @@ type Response struct {
 	Error error
 	// Copied from input data.
 	X *Xtract
+	// budgets are per top-level archive trackers in this folder.
+	budgets []*progressTracker
+	// budget is the extras tracker: the tighter leftover among budgets.
+	budget *progressTracker
 }
 
 // Extract is how external code begins an extraction process against a path.
@@ -352,6 +362,7 @@ func (x *Xtractr) decompressFiles(resp *Response) error {
 		Started:  resp.Started,
 		Output:   resp.Output,
 		Archives: resp.Extras,
+		budget:   x.extrasBudget(resp),
 	}
 	err = x.decompressArchives(nre)
 	// Combine the new Response with the existing response.
@@ -425,9 +436,17 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 		log:           x.config.Logger,
 		Updates:       resp.X.Updates,
 		Progress:      resp.X.Progress,
+		prog:          resp.budget,
 	}
 
+	if xFile.prog == nil {
+		xFile.prog = newSharedBudget()
+		resp.budgets = append(resp.budgets, xFile.prog)
+	}
+
+	wroteBefore := xFile.prog.wrote()
 	bytes, files, archives, err := ExtractFile(xFile)
+	bytes = xFile.prog.wrote() - wroteBefore
 
 	if len(xFile.SkipOnRecursion) > 0 {
 		resp.SkipOnRecursion = append(resp.SkipOnRecursion, xFile.SkipOnRecursion...)
@@ -454,6 +473,15 @@ func pick[T uint64 | int | float64](vals ...T) T { //nolint:ireturn // numeric u
 	}
 
 	return zero
+}
+
+func (x *Xtractr) extrasBudget(resp *Response) *progressTracker {
+	return tighterBudget(
+		resp.budgets,
+		pick(resp.X.MaxBytes, x.config.MaxBytes),
+		pick(resp.X.MaxFiles, x.config.MaxFiles),
+		pick(resp.X.MaxRatio, x.config.MaxRatio),
+	)
 }
 
 func (x *Xtractr) extrasFilter(resp *Response) Filter {

--- a/queue.go
+++ b/queue.go
@@ -445,8 +445,8 @@ func (x *Xtractr) processArchive(filename string, resp *Response) (uint64, []str
 	}
 
 	wroteBefore := xFile.prog.wrote()
-	bytes, files, archives, err := ExtractFile(xFile)
-	bytes = xFile.prog.wrote() - wroteBefore
+	_, files, archives, err := ExtractFile(xFile)
+	bytes := xFile.prog.wrote() - wroteBefore
 
 	if len(xFile.SkipOnRecursion) > 0 {
 		resp.SkipOnRecursion = append(resp.SkipOnRecursion, xFile.SkipOnRecursion...)

--- a/start.go
+++ b/start.go
@@ -42,14 +42,16 @@ type Config struct {
 	// siblings as a known extra extension (e.g. movie.mkv.xtractr_partial).
 	// Empty uses DefaultSuffix.
 	Suffix string
-	// MaxBytes is the default maximum uncompressed bytes written per archive.
-	// 0 means unlimited. Copied onto each XFile when Xtract.MaxBytes is 0.
+	// MaxBytes is the default per top-level-archive uncompressed-byte cap.
+	// Extras share the tighter leftover in that folder. 0 means unlimited.
+	// Used when Xtract.MaxBytes is 0.
 	MaxBytes uint64
-	// MaxFiles is the default maximum files, directories, and symlinks created
-	// per archive. 0 means unlimited. Copied onto each XFile when Xtract.MaxFiles is 0.
+	// MaxFiles is the default per top-level-archive file/dir/symlink cap.
+	// Extras share the tighter leftover in that folder. 0 means unlimited.
+	// Used when Xtract.MaxFiles is 0.
 	MaxFiles int
-	// MaxRatio is the default maximum bytesWritten / archiveFileSize per archive.
-	// 0 means unlimited. Copied onto each XFile when Xtract.MaxRatio is 0.
+	// MaxRatio is the default per-archive totalWritten / archive compressed size.
+	// Extras keep the parent size. 0 means unlimited. Used when Xtract.MaxRatio is 0.
 	MaxRatio float64
 	// MaxNested is the default maximum archives extracted from one source folder's
 	// extras pass. 0 or negative means unlimited. Used when Xtract.MaxNested is 0.


### PR DESCRIPTION
If an archive has an archive in it, they both get their own "maximums". This contribution locks them to one maximum. If one job extracts two archives in the same folder, and one or both have nested archives, the maximums for the nested archives is set to the lowest remainder (budget) among the parent archives.

## Summary
- Queue jobs apply `MaxBytes` / `MaxFiles` / `MaxRatio` per top-level archive so sibling rips each get a full cap.
- The extras pass continues the tighter leftover (smallest remaining byte/ratio room, then files) so nested archives cannot reset those limits.
- Standalone `ExtractFile` stays per-archive.

## Test plan
- [ ] `go test ./...`
- [ ] Two archives in one folder with `MaxFiles: 1` both extract
- [ ] Outer+inner zip hits `ErrMaxFiles` / `ErrMaxBytes` on extras when the parent leftover is spent


Made with [Cursor](https://cursor.com)