### PR TITLE
Fix Copilot findings from the files.go split

### DIFF
--- a/files.go
+++ b/files.go
@@ -291,7 +291,7 @@ func Difference(slice1, slice2 []string) []string {
 		seen[item] = struct{}{}
 	}
 
-	diff := []string{}
+	diff := make([]string, 0, len(slice2))
 
 	for _, item := range slice2 {
 		if _, found := seen[item]; !found {
@@ -409,12 +409,17 @@ func CheckR00ForRarFile(fileList []os.FileInfo, r00file string) bool {
 	return false
 }
 
+// RAR multipart name matchers. Compiled once; reused for every directory in a Find walk.
+// `$` already anchors the end, so a leading `.*` is unnecessary.
+var (
+	rarHasParts = regexp.MustCompile(`\.part\d+\.rar$`)
+	rarPartOne  = regexp.MustCompile(`\.part0*1\.rar$`)
+)
+
 // getCompressedFiles checks file suffixes to find archives to decompress.
 // This pays special attention to the widely accepted variance of rar formats.
 func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, depth int) ArchiveList { //nolint:cyclop
 	files := ArchiveList{}
-	hasParts := regexp.MustCompile(`.*\.part\d+\.rar$`)
-	partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
 
 	for _, file := range fileList {
 		switch lowerName := strings.ToLower(file.Name()); {
@@ -432,7 +437,7 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 			maps.Copy(files, findCompressedFiles(filepath.Join(path, file.Name()), filter, depth+1))
 		case strings.HasSuffix(lowerName, ".rar"):
 			// Some archives are named poorly. Only return part01 or part001, not all.
-			if !hasParts.MatchString(lowerName) || partOne.MatchString(lowerName) {
+			if !rarHasParts.MatchString(lowerName) || rarPartOne.MatchString(lowerName) {
 				addArchive(files, path, file, filter)
 			}
 		case strings.HasSuffix(lowerName, ".r00") && !CheckR00ForRarFile(fileList, lowerName):

--- a/files.go
+++ b/files.go
@@ -286,17 +286,16 @@ func listFiles(paths ...string) ([]string, error) {
 // Used to find new files in a file list from a path. ie. those we extracted.
 // This is a helper method and only exposed for convenience. You do not have to call this.
 func Difference(slice1, slice2 []string) []string {
+	seen := make(map[string]struct{}, len(slice1))
+	for _, item := range slice1 {
+		seen[item] = struct{}{}
+	}
+
 	diff := []string{}
 
-	for _, s2p := range slice2 {
-		var found bool
-
-		if slices.Contains(slice1, s2p) {
-			found = true
-		}
-
-		if !found { // String not found, so it's a new string, add it to the diff.
-			diff = append(diff, s2p)
+	for _, item := range slice2 {
+		if _, found := seen[item]; !found {
+			diff = append(diff, item)
 		}
 	}
 
@@ -414,6 +413,8 @@ func CheckR00ForRarFile(fileList []os.FileInfo, r00file string) bool {
 // This pays special attention to the widely accepted variance of rar formats.
 func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, depth int) ArchiveList { //nolint:cyclop
 	files := ArchiveList{}
+	hasParts := regexp.MustCompile(`.*\.part\d+\.rar$`)
+	partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
 
 	for _, file := range fileList {
 		switch lowerName := strings.ToLower(file.Name()); {
@@ -430,8 +431,6 @@ func getCompressedFiles(path string, filter *Filter, fileList []os.FileInfo, dep
 		case file.IsDir(): // Recurse.
 			maps.Copy(files, findCompressedFiles(filepath.Join(path, file.Name()), filter, depth+1))
 		case strings.HasSuffix(lowerName, ".rar"):
-			hasParts := regexp.MustCompile(`.*\.part\d+\.rar$`)
-			partOne := regexp.MustCompile(`.*\.part0*1\.rar$`)
 			// Some archives are named poorly. Only return part01 or part001, not all.
 			if !hasParts.MatchString(lowerName) || partOne.MatchString(lowerName) {
 				addArchive(files, path, file, filter)
@@ -1261,7 +1260,7 @@ func (x *XFile) SetLogger(logger Logger) {
 }
 
 // cleanup runs after a successful extract.
-// The intent it to move files into their final location.
+// The intent is to move files into their final location.
 func (x *XFile) cleanup(files []string) ([]string, error) {
 	files, err := x.squashRoot(files)
 	if err != nil {

--- a/files_test.go
+++ b/files_test.go
@@ -264,6 +264,15 @@ func TestFindCompressedFilesSkipsDotFiles(t *testing.T) {
 	}
 }
 
+func TestDifference(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"b", "c"}, xtractr.Difference([]string{"a", "d"}, []string{"a", "b", "c"}))
+	assert.Empty(t, xtractr.Difference([]string{"a", "b"}, []string{"a", "b"}))
+	assert.Equal(t, []string{"a", "a"}, xtractr.Difference(nil, []string{"a", "a"}))
+	assert.Empty(t, xtractr.Difference([]string{"a"}, nil))
+}
+
 func TestAllExcept(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fixes the three Copilot comments on #186 in `files.go` on `main`, so that split can rebase after this merges.
- `Difference` uses a set so membership is O(1) per item instead of `slices.Contains` in a loop.
- RAR `part` regexes in `getCompressedFiles` compile once per directory walk, not per file.
- `cleanup` comment: "intent it to" → "intent is to".

## Test plan
- [x] `go test -run 'TestDifference|TestFindCompressedFiles' .`
- [x] `golangci-lint run ./...`
- [ ] CI gotest matrix (macos / windows / ubuntu)


Made with [Cursor](https://cursor.com)