### PR TITLE
Export IsLimitError for extract cap failures

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -35,7 +35,7 @@ func Extract7z(xFile *XFile) (size uint64, filesList, archiveList []string, err 
 		switch {
 		case err == nil:
 			return size, files, archives, nil
-		case isLimitError(err):
+		case IsLimitError(err):
 			return size, files, archives, err
 		case idx == len(passwords)-1:
 			return size, files, archives, fmt.Errorf("used password %d of %d: %w", idx+1, len(passwords), err)

--- a/cue.go
+++ b/cue.go
@@ -130,7 +130,7 @@ func ExtractCUE(xFile *XFile) (size uint64, files, archives []string, err error)
 // errors abort the extract; other copy failures are logged and ignored.
 func copyCueSheetToOutput(xFile *XFile, cueDest string, files []string) ([]string, error) {
 	writeErr := copyCueToOutput(xFile, xFile.FilePath, cueDest, xFile.FileMode)
-	if isLimitError(writeErr) {
+	if IsLimitError(writeErr) {
 		return files, writeErr
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -57,7 +57,9 @@ var (
 	ErrUnsupportedRPMArchiveFmt  = errors.New("unsupported rpm archive format")
 )
 
-func isLimitError(err error) bool {
+// IsLimitError reports whether err is a configured extract cap: MaxBytes,
+// MaxFiles, MaxRatio, MaxNested, or a symlink used as an archive.
+func IsLimitError(err error) bool {
 	return errors.Is(err, ErrMaxBytes) || errors.Is(err, ErrMaxFiles) ||
 		errors.Is(err, ErrMaxRatio) || errors.Is(err, ErrMaxNested) ||
 		errors.Is(err, ErrArchiveSymlink)

--- a/files.go
+++ b/files.go
@@ -291,7 +291,7 @@ func ExtractFile(xFile *XFile) (size uint64, filesList, archiveList []string, er
 
 		// A resource cap aborts the extraction; do not re-extract via signature
 		// detection, which would reset the counters and could even report success.
-		if isLimitError(err) {
+		if IsLimitError(err) {
 			return size, filesList, archiveList, err
 		}
 

--- a/files_test.go
+++ b/files_test.go
@@ -288,6 +288,19 @@ func TestAllExcept(t *testing.T) {
 	assert.NotContains(t, exceptCue, ".cue.txt")
 }
 
+func TestIsLimitError(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, xtractr.IsLimitError(nil))
+	assert.False(t, xtractr.IsLimitError(errors.New("other error")))
+	assert.True(t, xtractr.IsLimitError(xtractr.ErrMaxBytes))
+	assert.True(t, xtractr.IsLimitError(xtractr.ErrMaxFiles))
+	assert.True(t, xtractr.IsLimitError(xtractr.ErrMaxRatio))
+	assert.True(t, xtractr.IsLimitError(xtractr.ErrMaxNested))
+	assert.True(t, xtractr.IsLimitError(xtractr.ErrArchiveSymlink))
+	assert.True(t, xtractr.IsLimitError(fmt.Errorf("wrap: %w", xtractr.ErrMaxBytes)))
+}
+
 func TestIsErrNameTooLong(t *testing.T) {
 	t.Parallel()
 

--- a/flac.go
+++ b/flac.go
@@ -62,7 +62,7 @@ func splitFLAC(xFile *XFile, audioPath string, cue *CueSheet, timestamps []cueTi
 	if len(pictures) > 0 {
 		picturePaths, pictureBytes, err = writePicturesToFiles(xFile, xFile.OutputDir, pictures, xFile.FileMode)
 		switch {
-		case isLimitError(err):
+		case IsLimitError(err):
 			return 0, nil, err
 		case err != nil:
 			xFile.Debugf("Error writing album art files: %s", err)

--- a/iso.go
+++ b/iso.go
@@ -25,7 +25,7 @@ func ExtractISO(xFile *XFile) (size uint64, filesList []string, err error) {
 		return size, filesList, nil
 	}
 
-	if isLimitError(udfErr) {
+	if IsLimitError(udfErr) {
 		if xFile.prog != nil {
 			xFile.prog.done()
 		}

--- a/rar.go
+++ b/rar.go
@@ -31,7 +31,7 @@ func ExtractRAR(xFile *XFile) (size uint64, filesList, archiveList []string, err
 		switch {
 		case err == nil:
 			return size, files, archives, nil
-		case isLimitError(err):
+		case IsLimitError(err):
 			return size, files, archives, err
 		case strings.Contains(err.Error(), "incorrect password"):
 			// https://github.com/nwaples/rardecode/issues/28


### PR DESCRIPTION
## Summary
- Export `IsLimitError` so apps can tell a configured extract cap from a transient failure.
- Same sentinels as before: MaxBytes, MaxFiles, MaxRatio, MaxNested, and a symlink used as an archive.

## Test plan
- [x] `go test ./...`
- [x] Unpackerr uses this to mark Starr limit failures as no-retry

Made with [Cursor](https://cursor.com)